### PR TITLE
chore(server): add test for data service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
         working-directory: ${{ matrix.component }}
         run: |
           # Install pytest if not already in dependencies
-          uv add --dev pytest pytest-cov || true
+          uv add --dev pytest pytest-cov pytest-asyncio || true
 
       - name: Run linting
         working-directory: ${{ matrix.component }}

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -41,6 +41,7 @@ test = [
 [dependency-groups]
 test = [
     "pytest>=8.4.1",
+    "pytest-asyncio>=1.1.0",
     "pytest-mock>=3.14.1",
 ]
 

--- a/server/services/data_service.py
+++ b/server/services/data_service.py
@@ -152,7 +152,7 @@ class DataService:
         # Make sure the file is not in use by another dataset
         project = ProjectService.get_project(namespace, project_id)
         other_dataset = next(
-            (ds for ds in project.config.get("datasets") if ds["name"] != dataset),
+            (ds for ds in project.config.get("datasets") if ds["name"] != dataset and file.hash in ds["files"]),
             None,
         )
         if other_dataset:

--- a/server/services/data_service.py
+++ b/server/services/data_service.py
@@ -4,9 +4,9 @@ from datetime import datetime
 
 from fastapi import UploadFile
 from pydantic import BaseModel
-from server.services.project_service import ProjectService
 
 from core.logging import FastAPIStructLogger
+from services.project_service import ProjectService
 
 logger = FastAPIStructLogger()
 

--- a/server/services/data_service.py
+++ b/server/services/data_service.py
@@ -38,19 +38,20 @@ class DataService:
         <file_content_hash> # File content
       index/
         by_name/
-          <original_file_name> -> ../raw/<file_content_hash> # symlink to the file content
+          <original_file_name> -> ../raw/<file_content_hash> # symlink to file content
 
     The metadata file is a json file that contains the following information:
     {
       "original_file_name": "example.pdf",
-      "resolved_file_name": "example_1719852800.pdf", # resolved file name with timestamp to avoid collisions
+      "resolved_file_name": "example_1719852800.pdf", # resolved with timestamp
       "timestamp": "1753978291",
       "size": 1000, # in bytes
       "mime_type": "application/pdf", # mime type of the original file
-      "hash": "2b3e321d021e5c625a4a003f0624801fa46faab59b530caddcd65a5c106b8a17" # hash of the file content
+      "hash": "2b3e321d021e5c625a4a003f0624801fa46faab59b530caddcd65a5c106b8a17"
     }
 
-    File name collisions are resolved by adding an epoch timestamp to the file name. E.g. "example.pdf" -> "example_1719852800.pdf"
+    File name collisions are resolved by adding an epoch timestamp to the file name.
+    E.g. "example.pdf" -> "example_1719852800.pdf"
     """
 
     @classmethod
@@ -156,7 +157,7 @@ class DataService:
         )
         if other_dataset:
             raise FileExistsInAnotherDatasetError(
-                f"File '{file.hash}' is in use by dataset '{other_dataset.name}'"
+                f"File '{file.hash}' is in use by dataset '{other_dataset['name']}'"
             )
 
         metadata_path = os.path.join(data_dir, "meta", f"{file.hash}.json")

--- a/server/tests/test_data_service.py
+++ b/server/tests/test_data_service.py
@@ -1,0 +1,387 @@
+"""
+Tests for DataService.
+
+This module contains comprehensive tests for the DataService class,
+including unit tests for all public methods and edge cases.
+"""
+
+import os
+import tempfile
+import pytest
+from unittest.mock import Mock, patch, mock_open, AsyncMock
+from datetime import datetime
+from fastapi import UploadFile
+from io import BytesIO
+
+from services.data_service import DataService, MetadataFileContent, FileExistsInAnotherDatasetError
+from services.project_service import ProjectService
+
+# Configure pytest for async tests
+pytest_plugins = ('pytest_asyncio',)
+
+
+class TestDataService:
+    """Test cases for DataService class."""
+
+    def setup_method(self):
+        """Set up test fixtures before each test method."""
+        self.test_namespace = "test_namespace"
+        self.test_project = "test_project"
+        self.test_data_dir = "/test/data/dir"
+        
+        # Mock file data
+        self.test_file_content = b"test file content"
+        self.test_file_hash = "a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3"
+        
+        # Mock metadata
+        self.mock_metadata = MetadataFileContent(
+            original_file_name="test.pdf",
+            resolved_file_name="test_1640995200.0.pdf",
+            size=len(self.test_file_content),
+            mime_type="application/pdf",
+            hash=self.test_file_hash
+        )
+        
+        # Mock project with datasets
+        self.mock_project = Mock()
+        self.mock_project.config = {
+            "datasets": [
+                {"name": "dataset1", "files": [self.test_file_hash]},
+                {"name": "dataset2", "files": ["other_hash"]}
+            ]
+        }
+
+    @patch('services.data_service.os.makedirs')
+    @patch('services.data_service.ProjectService.get_project_dir')
+    def test_get_data_dir_creates_directories(self, mock_get_project_dir, mock_makedirs):
+        """Test that get_data_dir creates all necessary directories."""
+        mock_get_project_dir.return_value = "/project/dir"
+        
+        result = DataService.get_data_dir(self.test_namespace, self.test_project)
+        
+        expected_data_dir = "/project/dir/lf_data"
+        assert result == expected_data_dir
+        mock_get_project_dir.assert_called_once_with(self.test_namespace, self.test_project)
+        
+        # Verify all directories are created
+        expected_calls = [
+            (("/project/dir/lf_data",), {"exist_ok": True}),
+            (("/project/dir/lf_data/meta",), {"exist_ok": True}),
+            (("/project/dir/lf_data/raw",), {"exist_ok": True}),
+            (("/project/dir/lf_data/index/by_name",), {"exist_ok": True})
+        ]
+        assert mock_makedirs.call_count == 4
+        for call in expected_calls:
+            assert call in [(args, kwargs) for args, kwargs in mock_makedirs.call_args_list]
+
+    def test_hash_data(self):
+        """Test data hashing functionality."""
+        test_data = b"hello world"
+        expected_hash = "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+        
+        result = DataService.hash_data(test_data)
+        
+        assert result == expected_hash
+
+    @patch('services.data_service.datetime')
+    def test_append_collision_timestamp(self, mock_datetime):
+        """Test timestamp appending for collision resolution."""
+        mock_datetime.now.return_value.timestamp.return_value = 1640995200.0
+        
+        # Test with extension
+        result = DataService.append_collision_timestamp("test.pdf")
+        assert result == "test_1640995200.0.pdf"
+        
+        # Test without extension
+        result = DataService.append_collision_timestamp("test")
+        assert result == "test_1640995200.0"
+
+    @patch.object(DataService, 'get_data_dir')
+    @patch.object(DataService, 'hash_data')
+    @patch.object(DataService, 'append_collision_timestamp')
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('os.symlink')
+    @patch('services.data_service.logger')
+    @pytest.mark.asyncio
+    async def test_add_data_file_success(
+        self, 
+        mock_logger, 
+        mock_symlink, 
+        mock_file_open, 
+        mock_append_timestamp, 
+        mock_hash_data, 
+        mock_get_data_dir
+    ):
+        """Test successfully adding a data file."""
+        # Setup mocks
+        mock_get_data_dir.return_value = self.test_data_dir
+        mock_hash_data.return_value = self.test_file_hash
+        mock_append_timestamp.return_value = "test_1640995200.0.pdf"
+        
+        # Create mock upload file
+        mock_upload_file = Mock(spec=UploadFile)
+        mock_upload_file.filename = "test.pdf"
+        mock_upload_file.content_type = "application/pdf"
+        mock_upload_file.read = AsyncMock(return_value=self.test_file_content)
+        
+        # Execute
+        result = await DataService.add_data_file(
+            self.test_namespace, 
+            self.test_project, 
+            mock_upload_file
+        )
+        
+        # Verify result
+        assert isinstance(result, MetadataFileContent)
+        assert result.original_file_name == "test.pdf"
+        assert result.resolved_file_name == "test_1640995200.0.pdf"
+        assert result.size == len(self.test_file_content)
+        assert result.mime_type == "application/pdf"
+        assert result.hash == self.test_file_hash
+        
+        # Verify file operations
+        mock_upload_file.read.assert_called_once()
+        mock_hash_data.assert_called_once_with(self.test_file_content)
+        mock_append_timestamp.assert_called_once_with("test.pdf")
+        
+        # Verify file writes
+        assert mock_file_open.call_count == 2  # metadata and raw file
+        mock_symlink.assert_called_once()
+        mock_logger.info.assert_called_once()
+
+    @patch.object(DataService, 'get_data_dir')
+    @patch('builtins.open', new_callable=mock_open, read_data=b"test file content")
+    def test_read_data_file_success(self, mock_file_open, mock_get_data_dir):
+        """Test successfully reading a data file."""
+        mock_get_data_dir.return_value = self.test_data_dir
+        
+        result = DataService.read_data_file(
+            self.test_namespace, 
+            self.test_project, 
+            self.test_file_hash
+        )
+        
+        assert result == b"test file content"
+        mock_get_data_dir.assert_called_once_with(self.test_namespace, self.test_project)
+        mock_file_open.assert_called_once_with(
+            f"{self.test_data_dir}/raw/{self.test_file_hash}", "rb"
+        )
+
+    @patch.object(DataService, 'get_data_dir')
+    @patch('builtins.open', new_callable=mock_open)
+    def test_read_data_file_not_found(self, mock_file_open, mock_get_data_dir):
+        """Test reading a non-existent data file."""
+        mock_get_data_dir.return_value = self.test_data_dir
+        mock_file_open.side_effect = FileNotFoundError("File not found")
+        
+        with pytest.raises(FileNotFoundError):
+            DataService.read_data_file(
+                self.test_namespace, 
+                self.test_project, 
+                "nonexistent_hash"
+            )
+
+    @patch.object(DataService, 'get_data_dir')
+    @patch('builtins.open', new_callable=mock_open)
+    def test_get_data_file_metadata_by_hash_success(self, mock_file_open, mock_get_data_dir):
+        """Test successfully getting metadata by hash."""
+        mock_get_data_dir.return_value = self.test_data_dir
+        mock_file_open.return_value.read.return_value = self.mock_metadata.model_dump_json()
+        
+        result = DataService.get_data_file_metadata_by_hash(
+            self.test_namespace, 
+            self.test_project, 
+            self.test_file_hash
+        )
+        
+        assert isinstance(result, MetadataFileContent)
+        assert result.original_file_name == self.mock_metadata.original_file_name
+        assert result.hash == self.mock_metadata.hash
+        
+        mock_get_data_dir.assert_called_once_with(self.test_namespace, self.test_project)
+        mock_file_open.assert_called_once_with(
+            f"{self.test_data_dir}/meta/{self.test_file_hash}.json"
+        )
+
+    @patch.object(DataService, 'get_data_dir')
+    @patch('builtins.open', new_callable=mock_open)
+    def test_get_data_file_metadata_by_hash_not_found(self, mock_file_open, mock_get_data_dir):
+        """Test getting metadata for non-existent file."""
+        mock_get_data_dir.return_value = self.test_data_dir
+        mock_file_open.side_effect = FileNotFoundError("Metadata not found")
+        
+        with pytest.raises(FileNotFoundError):
+            DataService.get_data_file_metadata_by_hash(
+                self.test_namespace, 
+                self.test_project, 
+                "nonexistent_hash"
+            )
+
+    @patch('services.data_service.os.remove')
+    @patch('services.data_service.logger')
+    @patch.object(DataService, 'get_data_dir')
+    @patch('services.data_service.ProjectService.get_project')
+    def test_delete_data_file_success(
+        self, 
+        mock_get_project,
+        mock_get_data_dir, 
+        mock_logger, 
+        mock_remove
+    ):
+        """Test successfully deleting a data file."""
+        mock_get_data_dir.return_value = self.test_data_dir
+        
+        # Mock project with datasets where no other dataset exists
+        mock_project = Mock()
+        mock_project.config = {
+            "datasets": [
+                {"name": "target_dataset", "files": [self.test_file_hash]}
+            ]
+        }
+        mock_get_project.return_value = mock_project
+        
+        # Execute
+        DataService.delete_data_file(
+            self.test_namespace, 
+            self.test_project, 
+            "target_dataset", 
+            self.mock_metadata
+        )
+        
+        # Verify file removals
+        expected_calls = [
+            f"{self.test_data_dir}/meta/{self.test_file_hash}.json",
+            f"{self.test_data_dir}/raw/{self.test_file_hash}",
+            f"{self.test_data_dir}/index/by_name/{self.mock_metadata.resolved_file_name}"
+        ]
+        assert mock_remove.call_count == 3
+        for expected_path in expected_calls:
+            mock_remove.assert_any_call(expected_path)
+        
+        mock_logger.info.assert_called_once()
+
+    @patch.object(DataService, 'get_data_dir')
+    @patch('services.data_service.ProjectService.get_project')
+    def test_delete_data_file_in_use_by_another_dataset(
+        self, 
+        mock_get_project, 
+        mock_get_data_dir
+    ):
+        """Test deleting a file that's in use by another dataset."""
+        mock_get_data_dir.return_value = self.test_data_dir
+        
+        # Mock project with datasets where another dataset exists
+        # Note: Current logic just checks if ANY other dataset exists, not if file is in use
+        mock_project = Mock()
+        mock_project.config = {
+            "datasets": [
+                {"name": "target_dataset", "files": [self.test_file_hash]},
+                {"name": "other_dataset", "files": ["other_hash"]}
+            ]
+        }
+        mock_get_project.return_value = mock_project
+        
+        # Execute and verify exception
+        with pytest.raises(FileExistsInAnotherDatasetError) as exc_info:
+            DataService.delete_data_file(
+                self.test_namespace, 
+                self.test_project, 
+                "target_dataset", 
+                self.mock_metadata
+            )
+        
+        assert "is in use by dataset 'other_dataset'" in str(exc_info.value)
+
+    @patch.object(DataService, 'get_data_dir')
+    @patch('services.data_service.ProjectService.get_project')
+    def test_delete_data_file_no_other_datasets(
+        self, 
+        mock_get_project, 
+        mock_get_data_dir
+    ):
+        """Test deleting a file when no other datasets exist."""
+        mock_get_data_dir.return_value = self.test_data_dir
+        
+        # Mock project with only the target dataset
+        mock_project = Mock()
+        mock_project.config = {
+            "datasets": [
+                {"name": "target_dataset", "files": [self.test_file_hash]}
+            ]
+        }
+        mock_get_project.return_value = mock_project
+        
+        with patch('services.data_service.os.remove') as mock_remove, \
+             patch('services.data_service.logger') as mock_logger:
+            
+            # Should not raise an exception
+            DataService.delete_data_file(
+                self.test_namespace, 
+                self.test_project, 
+                "target_dataset", 
+                self.mock_metadata
+            )
+            
+            # Verify files were removed
+            assert mock_remove.call_count == 3
+            mock_logger.info.assert_called_once()
+
+
+# Integration tests
+class TestDataServiceIntegration:
+    """Integration tests for DataService workflows."""
+
+    @patch.object(DataService, 'get_data_dir')
+    def test_file_hash_consistency(self, mock_get_data_dir):
+        """Test that the same data always produces the same hash."""
+        test_data1 = b"consistent test data"
+        test_data2 = b"consistent test data"
+        test_data3 = b"different test data"
+        
+        hash1 = DataService.hash_data(test_data1)
+        hash2 = DataService.hash_data(test_data2)
+        hash3 = DataService.hash_data(test_data3)
+        
+        assert hash1 == hash2  # Same data, same hash
+        assert hash1 != hash3  # Different data, different hash
+        assert len(hash1) == 64  # SHA256 hex length
+
+    def test_collision_timestamp_format(self):
+        """Test that collision timestamp produces valid file names."""
+        with patch('services.data_service.datetime') as mock_datetime:
+            mock_datetime.now.return_value.timestamp.return_value = 1640995200.5
+            
+            # Test various file name formats
+            test_cases = [
+                ("file.pdf", "file_1640995200.5.pdf"),
+                ("file.tar.gz", "file.tar_1640995200.5.gz"),
+                ("no_extension", "no_extension_1640995200.5"),
+                ("multiple.dots.in.name.txt", "multiple.dots.in.name_1640995200.5.txt")
+            ]
+            
+            for input_name, expected_output in test_cases:
+                result = DataService.append_collision_timestamp(input_name)
+                assert result == expected_output
+
+    def test_metadata_serialization_roundtrip(self):
+        """Test that metadata can be serialized and deserialized correctly."""
+        original_metadata = MetadataFileContent(
+            original_file_name="test.pdf",
+            resolved_file_name="test_1640995200.0.pdf",
+            size=1024,
+            mime_type="application/pdf",
+            hash="abcd1234"
+        )
+        
+        # Serialize to JSON
+        json_data = original_metadata.model_dump_json()
+        
+        # Deserialize back
+        restored_metadata = MetadataFileContent.model_validate_json(json_data)
+        
+        # Verify all fields match
+        assert restored_metadata.original_file_name == original_metadata.original_file_name
+        assert restored_metadata.resolved_file_name == original_metadata.resolved_file_name
+        assert restored_metadata.size == original_metadata.size
+        assert restored_metadata.mime_type == original_metadata.mime_type
+        assert restored_metadata.hash == original_metadata.hash

--- a/server/tests/test_data_service.py
+++ b/server/tests/test_data_service.py
@@ -5,16 +5,16 @@ This module contains comprehensive tests for the DataService class,
 including unit tests for all public methods and edge cases.
 """
 
-import os
-import tempfile
-import pytest
-from unittest.mock import Mock, patch, mock_open, AsyncMock
-from datetime import datetime
-from fastapi import UploadFile
-from io import BytesIO
+from unittest.mock import AsyncMock, Mock, mock_open, patch
 
-from services.data_service import DataService, MetadataFileContent, FileExistsInAnotherDatasetError
-from services.project_service import ProjectService
+import pytest
+from fastapi import UploadFile
+
+from services.data_service import (
+    DataService,
+    FileExistsInAnotherDatasetError,
+    MetadataFileContent,
+)
 
 # Configure pytest for async tests
 pytest_plugins = ('pytest_asyncio',)
@@ -276,7 +276,7 @@ class TestDataService:
         mock_project.config = {
             "datasets": [
                 {"name": "target_dataset", "files": [self.test_file_hash]},
-                {"name": "other_dataset", "files": ["other_hash"]}
+                {"name": "other_dataset", "files": ["other_hash", self.test_file_hash]}
             ]
         }
         mock_get_project.return_value = mock_project

--- a/server/tests/test_dataset_service.py
+++ b/server/tests/test_dataset_service.py
@@ -5,9 +5,11 @@ This module contains comprehensive tests for the DatasetService class,
 including unit tests for all public methods and edge cases.
 """
 
+from unittest.mock import patch
+
 import pytest
-from unittest.mock import Mock, patch
-from services.dataset_service import DEFAULT_PARSERS, DatasetService, Dataset
+
+from services.dataset_service import DEFAULT_PARSERS, DatasetService
 from services.project_service import ProjectService
 
 

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -976,6 +976,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-asyncio"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4e/51/f8794af39eeb870e87a8c8068642fc07bce0c854d6865d7dd0f2a9d338c2/pytest_asyncio-1.1.0.tar.gz", hash = "sha256:796aa822981e01b68c12e4827b8697108f7205020f24b5793b3c41555dab68ea", size = 46652, upload-time = "2025-07-16T04:29:26.393Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/9d/bf86eddabf8c6c9cb1ea9a869d6873b46f105a5d292d3a6f7071f5b07935/pytest_asyncio-1.1.0-py3-none-any.whl", hash = "sha256:5fe2d69607b0bd75c656d1211f969cadba035030156745ee09e7d71740e58ecf", size = 15157, upload-time = "2025-07-16T04:29:24.929Z" },
+]
+
+[[package]]
 name = "pytest-mock"
 version = "3.14.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1221,6 +1233,7 @@ test = [
 [package.dev-dependencies]
 test = [
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-mock" },
 ]
 
@@ -1249,6 +1262,7 @@ provides-extras = ["test"]
 [package.metadata.requires-dev]
 test = [
     { name = "pytest", specifier = ">=8.4.1" },
+    { name = "pytest-asyncio", specifier = ">=1.1.0" },
     { name = "pytest-mock", specifier = ">=3.14.1" },
 ]
 


### PR DESCRIPTION
## Summary by Sourcery

Add comprehensive unit and integration tests for DataService covering file operations, hashing, timestamp collisions, metadata handling, and deletion workflows; add pytest-asyncio to test dependencies; refine error messaging and documentation formatting.

Bug Fixes:
- Correct error message to reference dataset name from dict when deleting data file in use by another dataset

Enhancements:
- Clean up docstring formatting in DataService

Build:
- Add pytest-asyncio to test dependencies

Tests:
- Add extensive unit tests for DataService methods (get_data_dir, hash_data, append_collision_timestamp, add, read, metadata retrieval, and deletion)
- Add integration tests for hash consistency, collision timestamp formatting, and metadata serialization round-trip