### PR TITLE
feat(docs): deploy to docs.llamafarm.dev

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -49,6 +49,7 @@ jobs:
         with:
           node-version: 22
           cache: npm
+          cache-dependency-path: docs/website/package-lock.json
       - uses: webfactory/ssh-agent@v0.5.0
         with:
           ssh-private-key: ${{ secrets.GH_PAGES_DEPLOY }}

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - feat-docs-deploy
   pull_request:
     branches:
       - main
@@ -38,22 +39,24 @@ jobs:
           path: docs/website/build
 
   deploy:
-    name: Deploy to GitHub Pages
-    needs: build
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-
-    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
-    permissions:
-      pages: write # to deploy to Pages
-      id-token: write # to verify the deployment originates from an appropriate source
-
-    # Deploy to the github-pages environment
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
+    # if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: yarn
+      - uses: webfactory/ssh-agent@v0.5.0
+        with:
+          ssh-private-key: ${{ secrets.GH_PAGES_DEPLOY }}
       - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+        env:
+          USE_SSH: true
+        run: |
+          git config --global user.email "ops@llamafarm.dev"
+          git config --global user.name "llama-farm-bot"
+          yarn install --frozen-lockfile
+          yarn deploy

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: yarn
+          cache: npm
       - uses: webfactory/ssh-agent@v0.5.0
         with:
           ssh-private-key: ${{ secrets.GH_PAGES_DEPLOY }}

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - feat-docs-deploy
   pull_request:
     branches:
       - main

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -41,6 +41,9 @@ jobs:
   deploy:
     # if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./docs/website
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -58,5 +58,5 @@ jobs:
         run: |
           git config --global user.email "ops@llamafarm.dev"
           git config --global user.name "llama-farm-bot"
-          yarn install --frozen-lockfile
-          yarn deploy
+          npm i
+          npm run deploy

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -39,7 +39,7 @@ jobs:
           path: docs/website/build
 
   deploy:
-    # if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/docs/website/docusaurus.config.ts
+++ b/docs/website/docusaurus.config.ts
@@ -15,7 +15,7 @@ const config: Config = {
   },
 
   // Set the production url of your site here
-  url: 'https://llama-farm.github.io',
+  url: 'https://docs.llamafarm.dev',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: '/',
@@ -23,7 +23,7 @@ const config: Config = {
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
   organizationName: 'llama-farm', // Usually your GitHub org/user name.
-  projectName: 'llamafarm', // Usually your repo name.
+  projectName: 'docs.llamafarm.dev', // Usually your repo name.
 
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',

--- a/docs/website/docusaurus.config.ts
+++ b/docs/website/docusaurus.config.ts
@@ -25,6 +25,7 @@ const config: Config = {
   // If you aren't using GitHub pages, you don't need these.
   organizationName: 'llama-farm', // Usually your GitHub org/user name.
   projectName: 'llama-farm.github.io', // Usually your repo name.
+  deploymentBranch: 'main',
 
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',

--- a/docs/website/docusaurus.config.ts
+++ b/docs/website/docusaurus.config.ts
@@ -19,11 +19,12 @@ const config: Config = {
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: '/',
+  trailingSlash: false,
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
   organizationName: 'llama-farm', // Usually your GitHub org/user name.
-  projectName: 'docs.llamafarm.dev', // Usually your repo name.
+  projectName: 'llama-farm.github.io', // Usually your repo name.
 
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',


### PR DESCRIPTION
## Summary by Sourcery

Implement SSH-based deployment of documentation to docs.llamafarm.dev by updating the GitHub Actions workflow and Docusaurus configuration.

New Features:
- Enable docs-deploy workflow to trigger on both main and feat-docs-deploy branches

CI:
- Replace GitHub Pages environment deployment with SSH-based publishing using GH_PAGES_DEPLOY secret
- Add checkout of full git history, Node.js 22 setup with Yarn caching, and SSH agent initialization in the deploy job

Documentation:
- Update Docusaurus site URL to https://docs.llamafarm.dev and set projectName to docs.llamafarm.dev

<!-- CLI_COVERAGE_START -->

### CLI Coverage

| File | Lines (cov/total) | Functions (cov/total) | Statements (cov/total) |
|---|---:|---:|---:|
| llamafarm-cli/cmd/config/schema.go | 0/62 (0.0%) | 0/2 (0.0%) | 0/76 (0.0%) |
| llamafarm-cli/cmd/config/types.go | 89/148 (60.1%) | 0/8 (0.0%) | 53/180 (29.4%) |
| llamafarm-cli/cmd/datasets.go | 16/171 (9.4%) | 0/1 (0.0%) | 7/228 (3.1%) |
| llamafarm-cli/cmd/designer.go | 7/55 (12.7%) | 0/2 (0.0%) | 2/62 (3.2%) |
| llamafarm-cli/cmd/init.go | 3/33 (9.1%) | 0/1 (0.0%) | 1/42 (2.4%) |
| llamafarm-cli/cmd/projects.go | 103/328 (31.4%) | 0/10 (0.0%) | 62/406 (15.3%) |
| llamafarm-cli/cmd/root.go | 11/21 (52.4%) | 0/2 (0.0%) | 0/10 (0.0%) |
| llamafarm-cli/cmd/run.go | 4/49 (8.2%) | 0/1 (0.0%) | 2/66 (3.0%) |
| llamafarm-cli/cmd/version.go | 3/6 (50.0%) | 0/1 (0.0%) | 1/4 (25.0%) |
| llamafarm-cli/main.go | 0/3 (0.0%) | 0/1 (0.0%) | 0/3 (0.0%) |
| llamafarm-cli/tools/copy/main.go | 0/22 (0.0%) | 0/1 (0.0%) | 0/42 (0.0%) |
| llamafarm-cli/tools/cover2lcov/main.go | 0/86 (0.0%) | 0/1 (0.0%) | 0/204 (0.0%) |
| llamafarm-cli/tools/coverreport/main.go | 0/177 (0.0%) | 0/2 (0.0%) | 0/381 (0.0%) |
| total | 236/1161 (20.3%) | 0/33 (0.0%) | 128/1704 (7.5%) |

<!-- CLI_COVERAGE_END -->