### PR TITLE
fix(ci): trivy scan and upload

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -132,15 +132,18 @@ jobs:
     name: Security Scan
     runs-on: ubuntu-latest
     needs: build-and-push
-    if: github.event_name != 'pull_request'
+    # if: github.event_name != 'pull_request'
 
     permissions:
       contents: read
       packages: read
+      security-events: write
     strategy:
       matrix:
         service: [designer, server, runtime]
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -132,7 +132,7 @@ jobs:
     name: Security Scan
     runs-on: ubuntu-latest
     needs: build-and-push
-    # if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request'
 
     permissions:
       contents: read


### PR DESCRIPTION
## Summary by Sourcery

Enable Trivy vulnerability scanning to run on pull requests and properly upload findings

CI:
- Allow Trivy scan on pull requests by removing the event filter
- Add checkout step before running Trivy scanner
- Grant security-events write permission for reporting scan results

<!-- CLI_COVERAGE_START -->

### CLI Coverage

| File | Lines (cov/total) | Functions (cov/total) | Statements (cov/total) |
|---|---:|---:|---:|
| llamafarm-cli/cmd/config/schema.go | 0/62 (0.0%) | 0/2 (0.0%) | 0/76 (0.0%) |
| llamafarm-cli/cmd/config/types.go | 89/148 (60.1%) | 0/8 (0.0%) | 53/180 (29.4%) |
| llamafarm-cli/cmd/datasets.go | 16/171 (9.4%) | 0/1 (0.0%) | 7/228 (3.1%) |
| llamafarm-cli/cmd/designer.go | 7/55 (12.7%) | 0/2 (0.0%) | 2/62 (3.2%) |
| llamafarm-cli/cmd/init.go | 3/33 (9.1%) | 0/1 (0.0%) | 1/42 (2.4%) |
| llamafarm-cli/cmd/projects.go | 103/328 (31.4%) | 0/10 (0.0%) | 62/406 (15.3%) |
| llamafarm-cli/cmd/root.go | 11/21 (52.4%) | 0/2 (0.0%) | 0/10 (0.0%) |
| llamafarm-cli/cmd/run.go | 4/49 (8.2%) | 0/1 (0.0%) | 2/66 (3.0%) |
| llamafarm-cli/cmd/version.go | 3/6 (50.0%) | 0/1 (0.0%) | 1/4 (25.0%) |
| llamafarm-cli/main.go | 0/3 (0.0%) | 0/1 (0.0%) | 0/3 (0.0%) |
| llamafarm-cli/tools/copy/main.go | 0/22 (0.0%) | 0/1 (0.0%) | 0/42 (0.0%) |
| llamafarm-cli/tools/cover2lcov/main.go | 0/86 (0.0%) | 0/1 (0.0%) | 0/204 (0.0%) |
| llamafarm-cli/tools/coverreport/main.go | 0/177 (0.0%) | 0/2 (0.0%) | 0/381 (0.0%) |
| total | 236/1161 (20.3%) | 0/33 (0.0%) | 128/1704 (7.5%) |

<!-- CLI_COVERAGE_END -->