### PR TITLE
designer chat scroll and state fix

### DIFF
--- a/designer/src/components/Chatbox/Chatbox.tsx
+++ b/designer/src/components/Chatbox/Chatbox.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import Message from './Message'
 import FontIcon from '../../common/FontIcon'
 
@@ -43,6 +43,17 @@ function Chatbox({ isPanelOpen, setIsPanelOpen }: ChatboxProps) {
   ])
 
   const [inputValue, setInputValue] = useState('')
+  const listRef = useRef<HTMLDivElement | null>(null)
+  const endRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    // Scroll to bottom on mount and whenever messages change
+    if (endRef.current) {
+      endRef.current.scrollIntoView({ behavior: 'smooth', block: 'end' })
+    } else if (listRef.current) {
+      listRef.current.scrollTop = listRef.current.scrollHeight
+    }
+  }, [messages])
 
   const handleSendClick = () => {
     const text = inputValue.trim()
@@ -62,11 +73,9 @@ function Chatbox({ isPanelOpen, setIsPanelOpen }: ChatboxProps) {
   }
 
   return (
-    <div className="w-full h-full flex flex-col transition-colors bg-[#FFFFFF] text-gray-900 dark:bg-blue-500 dark:text-white">
+    <div className="w-full h-full flex flex-col transition-colors bg-white text-foreground dark:bg-blue-500 dark:text-white">
       <div
-        className={`flex  ${
-          isPanelOpen ? 'justify-end mr-1 mt-1' : 'justify-center mt-3'
-        }`}
+        className={`flex ${isPanelOpen ? 'justify-end mr-1 mt-1' : 'justify-center mt-3'}`}
       >
         <FontIcon
           isButton
@@ -76,27 +85,29 @@ function Chatbox({ isPanelOpen, setIsPanelOpen }: ChatboxProps) {
         />
       </div>
       <div
-        className={`flex flex-col justify-between h-full p-4 ${
-          isPanelOpen ? 'flex' : 'hidden'
-        }`}
+        className={`flex flex-col h-full p-4 overflow-hidden ${isPanelOpen ? 'flex' : 'hidden'}`}
       >
-        <div className="flex flex-col gap-5">
+        <div
+          ref={listRef}
+          className="flex-1 overflow-y-auto flex flex-col gap-5 pr-1"
+        >
           {messages.map((message, index) => (
             <Message key={index} message={message} />
           ))}
+          <div ref={endRef} />
         </div>
-        <div className="flex flex-col gap-3 p-3 rounded-lg bg-[#F4F4F4] dark:bg-blue-700">
+        <div className="shrink-0 flex flex-col gap-3 p-3 rounded-lg bg-secondary mt-3 border border-input dark:border-white/20 focus-within:border-blue-500 dark:focus-within:border-teal-400 transition-colors">
           <textarea
             value={inputValue}
             onChange={e => setInputValue(e.target.value)}
             onKeyDown={handleKeyDown}
-            className="w-full h-10 resize-none bg-transparent border-none placeholder-opacity-60 focus:outline-none focus:ring-0 font-sans text-sm sm:text-base leading-relaxed overflow-hidden text-gray-900 placeholder-gray-500 dark:text-white dark:placeholder-white"
+            className="w-full h-10 resize-none bg-transparent border-none placeholder-opacity-60 focus:outline-none focus:ring-0 font-sans text-sm sm:text-base leading-relaxed overflow-hidden text-foreground placeholder-foreground/60 caret-blue-500 dark:caret-teal-400"
             placeholder="Type here..."
           />
           <FontIcon
             isButton
             type="arrow-filled"
-            className="w-8 h-8 self-end text-blue-200 dark:text-green-100"
+            className="w-8 h-8 self-end text-primary"
             handleOnClick={handleSendClick}
           />
         </div>


### PR DESCRIPTION
## Summary by Sourcery

Improve the chatbox UX by enabling automatic smooth scrolling to the newest message and overhauling styling to use consistent theme tokens and better interaction states.

Enhancements:
- Automatically scroll the chat view to the bottom when messages update using refs and useEffect
- Wrap the message list in an `overflow-y-auto` container and insert a dummy end element to facilitate smooth scrolling
- Replace hard‐coded colors with theme variables (bg-white, text-foreground, bg-secondary, etc.) and consolidate class names for the chat wrapper and input area
- Add focus-within border transitions, placeholder opacity, and caret color tokens to the textarea and restyle the send icon to use the primary color

<!-- CLI_COVERAGE_START -->

### CLI Coverage

| File | Lines (cov/total) | Functions (cov/total) | Statements (cov/total) |
|---|---:|---:|---:|
| llamafarm-cli/cmd/config/schema.go | 0/62 (0.0%) | 0/2 (0.0%) | 0/76 (0.0%) |
| llamafarm-cli/cmd/config/types.go | 86/141 (61.0%) | 0/8 (0.0%) | 52/174 (29.9%) |
| llamafarm-cli/cmd/datasets.go | 21/259 (8.1%) | 0/4 (0.0%) | 11/402 (2.7%) |
| llamafarm-cli/cmd/designer.go | 7/55 (12.7%) | 0/2 (0.0%) | 2/62 (3.2%) |
| llamafarm-cli/cmd/httpclient.go | 10/49 (20.4%) | 0/5 (0.0%) | 7/70 (10.0%) |
| llamafarm-cli/cmd/init.go | 3/33 (9.1%) | 0/1 (0.0%) | 1/42 (2.4%) |
| llamafarm-cli/cmd/projects.go | 107/335 (31.9%) | 0/9 (0.0%) | 66/420 (15.7%) |
| llamafarm-cli/cmd/root.go | 11/21 (52.4%) | 0/2 (0.0%) | 0/10 (0.0%) |
| llamafarm-cli/cmd/run.go | 4/49 (8.2%) | 0/1 (0.0%) | 2/66 (3.0%) |
| llamafarm-cli/cmd/version.go | 3/6 (50.0%) | 0/1 (0.0%) | 1/4 (25.0%) |
| llamafarm-cli/main.go | 0/3 (0.0%) | 0/1 (0.0%) | 0/3 (0.0%) |
| llamafarm-cli/tools/copy/main.go | 0/22 (0.0%) | 0/1 (0.0%) | 0/42 (0.0%) |
| llamafarm-cli/tools/cover2lcov/main.go | 0/86 (0.0%) | 0/1 (0.0%) | 0/204 (0.0%) |
| llamafarm-cli/tools/coverreport/main.go | 0/177 (0.0%) | 0/2 (0.0%) | 0/381 (0.0%) |
| total | 252/1298 (19.4%) | 0/40 (0.0%) | 142/1956 (7.3%) |

<!-- CLI_COVERAGE_END -->