### PR TITLE
chore: release automation

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -4,6 +4,17 @@
   },
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
   "nxCloudId": "6890fca1e55dc20a336b5529",
+  "release": {
+    "projectsRelationship": "fixed",
+    "projects": ["*"],
+    "version": {
+      "conventionalCommits": true
+    },
+    "changelog": {
+      "workspaceChangelog": true,
+      "projectChangelogs": false
+    }
+  },
   "targets": {
   }
 }


### PR DESCRIPTION
<!-- CLI_COVERAGE_START -->

### CLI Coverage

| File | Lines (cov/total) | Functions (cov/total) | Statements (cov/total) |
|---|---:|---:|---:|
| llamafarm-cli/cmd/chat_client.go | 86/195 (44.1%) | 0/7 (0.0%) | 61/280 (21.8%) |
| llamafarm-cli/cmd/config/schema.go | 0/62 (0.0%) | 0/2 (0.0%) | 0/76 (0.0%) |
| llamafarm-cli/cmd/config/types.go | 86/141 (61.0%) | 0/8 (0.0%) | 52/174 (29.9%) |
| llamafarm-cli/cmd/datasets.go | 20/234 (8.5%) | 0/3 (0.0%) | 10/378 (2.6%) |
| llamafarm-cli/cmd/designer.go | 7/52 (13.5%) | 0/2 (0.0%) | 2/56 (3.6%) |
| llamafarm-cli/cmd/docker_utils.go | 27/33 (81.8%) | 0/4 (0.0%) | 20/46 (43.5%) |
| llamafarm-cli/cmd/httpclient.go | 60/89 (67.4%) | 0/6 (0.0%) | 40/116 (34.5%) |
| llamafarm-cli/cmd/init.go | 3/33 (9.1%) | 0/1 (0.0%) | 1/42 (2.4%) |
| llamafarm-cli/cmd/models.go | 3/7 (42.9%) | 0/1 (0.0%) | 1/6 (16.7%) |
| llamafarm-cli/cmd/projects.go | 23/195 (11.8%) | 0/3 (0.0%) | 10/232 (4.3%) |
| llamafarm-cli/cmd/rag.go | 3/7 (42.9%) | 0/1 (0.0%) | 1/6 (16.7%) |
| llamafarm-cli/cmd/root.go | 6/16 (37.5%) | 0/2 (0.0%) | 3/16 (18.8%) |
| llamafarm-cli/cmd/run.go | 4/101 (4.0%) | 0/1 (0.0%) | 2/114 (1.8%) |
| llamafarm-cli/cmd/server_utils.go | 57/155 (36.8%) | 0/7 (0.0%) | 43/204 (21.1%) |
| llamafarm-cli/cmd/url_utils.go | 9/9 (100.0%) | 0/1 (0.0%) | 6/12 (50.0%) |
| llamafarm-cli/cmd/version.go | 3/6 (50.0%) | 0/1 (0.0%) | 1/4 (25.0%) |
| llamafarm-cli/main.go | 0/3 (0.0%) | 0/1 (0.0%) | 0/3 (0.0%) |
| llamafarm-cli/tools/copy/main.go | 0/22 (0.0%) | 0/1 (0.0%) | 0/42 (0.0%) |
| llamafarm-cli/tools/cover2lcov/main.go | 0/86 (0.0%) | 0/1 (0.0%) | 0/204 (0.0%) |
| llamafarm-cli/tools/coverreport/main.go | 0/177 (0.0%) | 0/2 (0.0%) | 0/381 (0.0%) |
| total | 397/1623 (24.5%) | 0/55 (0.0%) | 253/2392 (10.6%) |

<!-- CLI_COVERAGE_END -->