### PR TITLE
chore: release size/install optimization

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -120,12 +120,13 @@ jobs:
 
   # Create GitHub release on tag push
   create-release:
-    name: Create Release
+    name: Upload Release Assets
     runs-on: ubuntu-latest
     needs: [build-cli, create-checksums]
     if: startsWith(github.ref, 'refs/tags/')
     permissions:
       contents: write
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -139,49 +140,9 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ github.ref_name }}
           files: |
             dist/llamafarm-*
             dist/checksums.txt
-          generate_release_notes: true
-          draft: false
-          prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') || contains(github.ref, 'rc') }}
-          body: |
-            ## LlamaFarm CLI ${{ github.ref_name }}
-
-            ### Downloads
-
-            Choose the appropriate binary for your platform:
-
-            **Linux:**
-            - [llamafarm-linux-amd64](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/llamafarm-linux-amd64) (Intel/AMD 64-bit)
-            - [llamafarm-linux-arm64](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/llamafarm-linux-arm64) (ARM 64-bit)
-
-            **macOS:**
-            - [llamafarm-darwin-amd64](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/llamafarm-darwin-amd64) (Intel Macs)
-            - [llamafarm-darwin-arm64](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/llamafarm-darwin-arm64) (Apple Silicon Macs)
-
-            **Windows:**
-            - [llamafarm-windows-amd64.exe](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/llamafarm-windows-amd64.exe) (Intel/AMD 64-bit)
-            - [llamafarm-windows-arm64.exe](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/llamafarm-windows-arm64.exe) (ARM 64-bit)
-
-            **Verification:**
-            - [checksums.txt](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/checksums.txt) - SHA256 checksums for all binaries
-
-            ### Installation
-
-            1. Download the appropriate binary for your platform
-            2. Make it executable (Linux/macOS): `chmod +x llamafarm-*`
-            3. Move to your PATH: `sudo mv llamafarm-* /usr/local/bin/llamafarm`
-            4. Verify installation: `llamafarm version`
-
-            ### Verification
-
-            You can verify the integrity of downloaded binaries using the checksums:
-
-            ```bash
-            # Download checksums
-            curl -L -O https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/checksums.txt
-
-            # Verify (replace with your downloaded binary)
-            sha256sum -c checksums.txt --ignore-missing
-            ```
+          fail_on_unmatched_files: true
+          append_body: true

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,7 +7,7 @@ This guide covers multiple ways to install the LlamaFarm CLI (`lf`) on your syst
 The easiest way to install LlamaFarm CLI is using our installation script:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/llamafarm/llamafarm/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/llama-farm/llamafarm/main/install.sh | bash
 ```
 
 This will:

--- a/cli/cmd/init.go
+++ b/cli/cmd/init.go
@@ -16,7 +16,7 @@ import (
 var initCmd = &cobra.Command{
 	Use:   "init",
 	Short: "Initialize a new LlamaFarm project",
-	Long:  `Initialize a new LlamaFarm project by creating it on the server for the current directory (or a target path).`,
+	Long:  `Initialize a new LlamaFarm project in the current directory (or a target path).`,
 	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("Initializing a new LlamaFarm project...")

--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,7 @@ set -e
 REPO="llama-farm/llamafarm"
 BINARY_NAME="lf"
 INSTALL_DIR="/usr/local/bin"
-CLI_NAME="llamafarm-cli"
+CLI_NAME="llamafarm"
 
 # Colors for output
 RED='\033[0;31m'
@@ -55,7 +55,7 @@ detect_platform() {
         *)              error "Unsupported architecture: $(uname -m)" ;;
     esac
 
-    echo "${os}_${arch}"
+    echo "${os}-${arch}"
 }
 
 # Check if command exists
@@ -144,28 +144,19 @@ install_cli() {
     fi
 
     # Construct download URL
-    local filename="${CLI_NAME}_${version#v}_${platform}"
+    local filename="${CLI_NAME}-${platform}"
     if [[ "$platform" == *"windows"* ]]; then
         filename="${filename}.exe"
     fi
-    download_url="https://github.com/$REPO/releases/download/$version/${filename}.tar.gz"
+    download_url="https://github.com/$REPO/releases/download/$version/${filename}"
 
     # Create temporary directory
     temp_dir=$(mktemp -d)
     trap 'rm -rf $temp_dir' EXIT
 
     # Download and extract
-    local archive_path="$temp_dir/archive.tar.gz"
-    download_file "$download_url" "$archive_path"
-
-    info "Extracting archive..."
-    tar -xzf "$archive_path" -C "$temp_dir" || error "Failed to extract archive"
-
-    # Find the binary
-    binary_path=$(find "$temp_dir" -name "$BINARY_NAME*" -type f | head -1)
-    if [[ -z "$binary_path" ]]; then
-        error "Binary not found in archive"
-    fi
+    local download_path="$temp_dir/${filename}"
+    download_file "$download_url" "$download_path"
 
     # Check permissions and prepare for installation
     check_permissions
@@ -173,7 +164,7 @@ install_cli() {
 
     # Install binary
     info "Installing binary to $INSTALL_DIR/$BINARY_NAME"
-    $SUDO_CMD cp "$binary_path" "$INSTALL_DIR/$BINARY_NAME" || error "Failed to copy binary"
+    $SUDO_CMD cp "$download_path" "$INSTALL_DIR/$BINARY_NAME" || error "Failed to copy binary"
     $SUDO_CMD chmod +x "$INSTALL_DIR/$BINARY_NAME" || error "Failed to make binary executable"
 
     success "LlamaFarm CLI installed successfully!"

--- a/install.sh
+++ b/install.sh
@@ -119,7 +119,7 @@ ensure_install_dir() {
 
 # Main installation function
 install_cli() {
-    local platform version download_url temp_dir binary_path
+    local platform version download_url temp_dir
 
     info "Starting LlamaFarm CLI installation..."
 

--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@
 set -e
 
 # Configuration
-REPO="llamafarm/llamafarm"
+REPO="llama-farm/llamafarm"
 BINARY_NAME="lf"
 INSTALL_DIR="/usr/local/bin"
 CLI_NAME="llamafarm-cli"

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,15 +1,13 @@
 # Use Python 3.12 slim image
-FROM python:3.12-slim
+FROM ghcr.io/astral-sh/uv:python3.13-alpine
 
-RUN apt update && apt install -y curl && rm -rf /var/lib/apt/lists/*
+ENV UV_COMPILE_BYTECODE=1
+
+RUN apk add --no-cache curl
 
 
 # Set working directory
 WORKDIR /app
-
-# Install uv for fast Python package management
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
-
 
 # Copy the required packages from the monorepo
 # Note: This Dockerfile should be run from the repo root: docker build -f server/Dockerfile .

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,9 +1,9 @@
 # Use Python 3.12 slim image
-FROM ghcr.io/astral-sh/uv:python3.13-alpine
+FROM ghcr.io/astral-sh/uv:python3.12-trixie-slim
 
 ENV UV_COMPILE_BYTECODE=1
 
-RUN apk add --no-cache curl
+RUN apt update && apt install -y curl && rm -rf /var/lib/apt/lists/*
 
 
 # Set working directory


### PR DESCRIPTION
## Summary by Sourcery

Optimize the CLI release workflow, installation script, and Docker setup to reduce package size and streamline installation.

Enhancements:
- Rename release job and switch to fail_on_unmatched_files and append_body flags in GitHub Actions
- Simplify install.sh to download standalone binaries with updated naming, platform delimiter, and repository path
- Refine CLI init command description

Build:
- Update GitHub Actions CLI release workflow to use new upload release assets configuration

Deployment:
- Switch server Dockerfile to use uv-based Python 3.12 slim image with bytecode compilation enabled

Documentation:
- Correct installation script URL in INSTALL.md to use the updated GitHub repository path

<!-- CLI_COVERAGE_START -->

### CLI Coverage

| File | Lines (cov/total) | Functions (cov/total) | Statements (cov/total) |
|---|---:|---:|---:|
| llamafarm-cli/cmd/chat_client.go | 86/195 (44.1%) | 0/7 (0.0%) | 61/280 (21.8%) |
| llamafarm-cli/cmd/config/schema.go | 0/62 (0.0%) | 0/2 (0.0%) | 0/76 (0.0%) |
| llamafarm-cli/cmd/config/types.go | 86/141 (61.0%) | 0/8 (0.0%) | 52/174 (29.9%) |
| llamafarm-cli/cmd/datasets.go | 20/234 (8.5%) | 0/3 (0.0%) | 10/378 (2.6%) |
| llamafarm-cli/cmd/designer.go | 7/52 (13.5%) | 0/2 (0.0%) | 2/56 (3.6%) |
| llamafarm-cli/cmd/docker_utils.go | 27/33 (81.8%) | 0/4 (0.0%) | 20/46 (43.5%) |
| llamafarm-cli/cmd/httpclient.go | 60/89 (67.4%) | 0/6 (0.0%) | 40/116 (34.5%) |
| llamafarm-cli/cmd/init.go | 5/93 (5.4%) | 0/1 (0.0%) | 3/126 (2.4%) |
| llamafarm-cli/cmd/models.go | 3/7 (42.9%) | 0/1 (0.0%) | 1/6 (16.7%) |
| llamafarm-cli/cmd/projects.go | 23/195 (11.8%) | 0/3 (0.0%) | 10/232 (4.3%) |
| llamafarm-cli/cmd/rag.go | 3/7 (42.9%) | 0/1 (0.0%) | 1/6 (16.7%) |
| llamafarm-cli/cmd/root.go | 6/16 (37.5%) | 0/2 (0.0%) | 3/16 (18.8%) |
| llamafarm-cli/cmd/run.go | 4/101 (4.0%) | 0/1 (0.0%) | 2/114 (1.8%) |
| llamafarm-cli/cmd/server_utils.go | 57/155 (36.8%) | 0/7 (0.0%) | 43/204 (21.1%) |
| llamafarm-cli/cmd/url_utils.go | 9/9 (100.0%) | 0/1 (0.0%) | 6/12 (50.0%) |
| llamafarm-cli/cmd/version.go | 3/6 (50.0%) | 0/1 (0.0%) | 1/4 (25.0%) |
| llamafarm-cli/main.go | 0/3 (0.0%) | 0/1 (0.0%) | 0/3 (0.0%) |
| llamafarm-cli/tools/copy/main.go | 0/22 (0.0%) | 0/1 (0.0%) | 0/42 (0.0%) |
| llamafarm-cli/tools/cover2lcov/main.go | 0/86 (0.0%) | 0/1 (0.0%) | 0/204 (0.0%) |
| llamafarm-cli/tools/coverreport/main.go | 0/177 (0.0%) | 0/2 (0.0%) | 0/381 (0.0%) |
| total | 399/1683 (23.7%) | 0/55 (0.0%) | 255/2476 (10.3%) |

<!-- CLI_COVERAGE_END -->