### PR TITLE
feat(designer): connect data component to api

### DIFF
--- a/designer/src/api/datasets.ts
+++ b/designer/src/api/datasets.ts
@@ -21,14 +21,9 @@ export async function listDatasets(
   namespace: string,
   project: string
 ): Promise<ListDatasetsResponse> {
-  // Debug logging to verify correct parameters
-  console.log('🔍 Fetching datasets for:', { namespace, project })
-  
   const response = await apiClient.get<ListDatasetsResponse>(
     `/projects/${encodeURIComponent(namespace)}/${encodeURIComponent(project)}/datasets/`
   )
-  
-  console.log('✅ Datasets API response:', response.data)
   return response.data
 }
 

--- a/designer/src/api/datasets.ts
+++ b/designer/src/api/datasets.ts
@@ -9,6 +9,7 @@ import {
   FileUploadResponse,
   FileDeleteResponse,
   FileDeleteParams,
+  TaskStatusResponse,
 } from '../types/datasets'
 
 /**
@@ -160,6 +161,52 @@ export async function ingestDataset(
 }
 
 /**
+ * Get the status of a task
+ * @param namespace - The project namespace
+ * @param project - The project identifier
+ * @param taskId - The task identifier
+ * @returns Promise<TaskStatusResponse> - The task status information
+ */
+export async function getTaskStatus(
+  namespace: string,
+  project: string,
+  taskId: string
+): Promise<TaskStatusResponse> {
+  const response = await apiClient.get<TaskStatusResponse>(
+    `/projects/${encodeURIComponent(namespace)}/${encodeURIComponent(project)}/tasks/${encodeURIComponent(taskId)}`
+  )
+  return response.data
+}
+
+/**
+ * Delete a file from a dataset
+ * @param namespace - The project namespace
+ * @param project - The project identifier
+ * @param dataset - The dataset name
+ * @param fileHash - The file hash to delete
+ * @param removeFromDisk - Whether to also remove the file from disk
+ * @returns Promise<FileDeleteResponse> - The delete response with file hash
+ */
+export async function deleteDatasetFile(
+  namespace: string,
+  project: string,
+  dataset: string,
+  fileHash: string,
+  removeFromDisk: boolean = true
+): Promise<FileDeleteResponse> {
+  const queryParams = new URLSearchParams()
+  if (removeFromDisk !== undefined) {
+    queryParams.append('remove_from_disk', removeFromDisk.toString())
+  }
+
+  const url = `/projects/${encodeURIComponent(namespace)}/${encodeURIComponent(project)}/datasets/${encodeURIComponent(dataset)}/data/${encodeURIComponent(fileHash)}`
+  const fullUrl = queryParams.toString() ? `${url}?${queryParams.toString()}` : url
+
+  const response = await apiClient.delete<FileDeleteResponse>(fullUrl)
+  return response.data
+}
+
+/**
  * Default export with all dataset service functions
  */
 export default {
@@ -170,4 +217,6 @@ export default {
   uploadFileToDataset,
   deleteFileFromDataset,
   ingestDataset,
+  getTaskStatus,
+  deleteDatasetFile,
 }

--- a/designer/src/api/datasets.ts
+++ b/designer/src/api/datasets.ts
@@ -1,0 +1,178 @@
+import { apiClient } from './client'
+import {
+  ListDatasetsResponse,
+  CreateDatasetRequest,
+  CreateDatasetResponse,
+  DeleteDatasetResponse,
+  DatasetActionRequest,
+  DatasetActionResponse,
+  FileUploadResponse,
+  FileDeleteResponse,
+  FileDeleteParams,
+} from '../types/datasets'
+
+/**
+ * List all datasets in a project
+ * @param namespace - The namespace to list datasets for
+ * @param project - The project to list datasets for
+ * @returns Promise<ListDatasetsResponse> - List of datasets with total count
+ */
+export async function listDatasets(
+  namespace: string,
+  project: string
+): Promise<ListDatasetsResponse> {
+  // Debug logging to verify correct parameters
+  console.log('🔍 Fetching datasets for:', { namespace, project })
+  
+  const response = await apiClient.get<ListDatasetsResponse>(
+    `/projects/${encodeURIComponent(namespace)}/${encodeURIComponent(project)}/datasets/`
+  )
+  
+  console.log('✅ Datasets API response:', response.data)
+  return response.data
+}
+
+/**
+ * Create a new dataset in a project
+ * @param namespace - The namespace containing the project
+ * @param project - The project to create the dataset in
+ * @param request - The dataset creation request
+ * @returns Promise<CreateDatasetResponse> - The created dataset
+ */
+export async function createDataset(
+  namespace: string,
+  project: string,
+  request: CreateDatasetRequest
+): Promise<CreateDatasetResponse> {
+  const response = await apiClient.post<CreateDatasetResponse>(
+    `/projects/${encodeURIComponent(namespace)}/${encodeURIComponent(project)}/datasets/`,
+    request
+  )
+  return response.data
+}
+
+/**
+ * Delete a dataset from a project
+ * @param namespace - The project namespace
+ * @param project - The project identifier
+ * @param dataset - The dataset name to delete
+ * @returns Promise<DeleteDatasetResponse> - The deleted dataset
+ */
+export async function deleteDataset(
+  namespace: string,
+  project: string,
+  dataset: string
+): Promise<DeleteDatasetResponse> {
+  const response = await apiClient.delete<DeleteDatasetResponse>(
+    `/projects/${encodeURIComponent(namespace)}/${encodeURIComponent(project)}/datasets/${encodeURIComponent(dataset)}`
+  )
+  return response.data
+}
+
+/**
+ * Execute an action on a dataset (currently only 'ingest')
+ * @param namespace - The project namespace
+ * @param project - The project identifier
+ * @param dataset - The dataset name
+ * @param request - The action request
+ * @returns Promise<DatasetActionResponse> - The action response with task URI
+ */
+export async function executeDatasetAction(
+  namespace: string,
+  project: string,
+  dataset: string,
+  request: DatasetActionRequest
+): Promise<DatasetActionResponse> {
+  const response = await apiClient.post<DatasetActionResponse>(
+    `/projects/${encodeURIComponent(namespace)}/${encodeURIComponent(project)}/datasets/${encodeURIComponent(dataset)}/actions`,
+    request
+  )
+  return response.data
+}
+
+/**
+ * Upload a file to a dataset using multipart form data
+ * @param namespace - The project namespace
+ * @param project - The project identifier
+ * @param dataset - The dataset name
+ * @param file - The file to upload
+ * @returns Promise<FileUploadResponse> - The upload response with filename
+ */
+export async function uploadFileToDataset(
+  namespace: string,
+  project: string,
+  dataset: string,
+  file: File
+): Promise<FileUploadResponse> {
+  const formData = new FormData()
+  formData.append('file', file)
+
+  const response = await apiClient.post<FileUploadResponse>(
+    `/projects/${encodeURIComponent(namespace)}/${encodeURIComponent(project)}/datasets/${encodeURIComponent(dataset)}/data`,
+    formData,
+    {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    }
+  )
+  return response.data
+}
+
+/**
+ * Delete a file from a dataset
+ * @param namespace - The project namespace
+ * @param project - The project identifier
+ * @param dataset - The dataset name
+ * @param fileHash - The hash of the file to delete
+ * @param params - Optional query parameters
+ * @returns Promise<FileDeleteResponse> - The delete response with file hash
+ */
+export async function deleteFileFromDataset(
+  namespace: string,
+  project: string,
+  dataset: string,
+  fileHash: string,
+  params?: FileDeleteParams
+): Promise<FileDeleteResponse> {
+  const queryParams = new URLSearchParams()
+  if (params?.remove_from_disk !== undefined) {
+    queryParams.append('remove_from_disk', params.remove_from_disk.toString())
+  }
+
+  const url = `/projects/${encodeURIComponent(namespace)}/${encodeURIComponent(project)}/datasets/${encodeURIComponent(dataset)}/data/${encodeURIComponent(fileHash)}`
+  const fullUrl = queryParams.toString() ? `${url}?${queryParams.toString()}` : url
+
+  const response = await apiClient.delete<FileDeleteResponse>(fullUrl)
+  return response.data
+}
+
+/**
+ * Convenience function to ingest a dataset (execute 'ingest' action)
+ * @param namespace - The project namespace
+ * @param project - The project identifier
+ * @param dataset - The dataset name
+ * @returns Promise<DatasetActionResponse> - The action response with task URI
+ */
+export async function ingestDataset(
+  namespace: string,
+  project: string,
+  dataset: string
+): Promise<DatasetActionResponse> {
+  return executeDatasetAction(namespace, project, dataset, {
+    action_type: 'ingest',
+  })
+}
+
+/**
+ * Default export with all dataset service functions
+ */
+export default {
+  listDatasets,
+  createDataset,
+  deleteDataset,
+  executeDatasetAction,
+  uploadFileToDataset,
+  deleteFileFromDataset,
+  ingestDataset,
+}

--- a/designer/src/components/Data/Data.tsx
+++ b/designer/src/components/Data/Data.tsx
@@ -73,7 +73,7 @@ const Data = () => {
         files: dataset.files,
         lastRun: new Date(),
         embedModel: 'text-embedding-3-large',
-        numChunks: dataset.files.length * 100, // Estimate based on files
+        numChunks: dataset.files.length ? `~${dataset.files.length * 100}` : 'unknown', // Estimated, or 'unknown' if unavailable
         processedPercent: 100,
         version: 'v1',
         description: '',
@@ -190,7 +190,7 @@ const Data = () => {
         namespace: activeProject.namespace,
         project: activeProject.project,
         name,
-        rag_strategy: 'auto', // Default strategy
+        rag_strategy: 'default', // Default strategy
       })
       toast({ message: 'Dataset created successfully', variant: 'default' })
       setIsCreateOpen(false)
@@ -364,7 +364,15 @@ const Data = () => {
           <div className="mb-2 flex flex-row gap-2 justify-between items-end">
             <div>Datasets</div>
             <div className="flex items-center gap-2">
-              <Dialog open={isCreateOpen} onOpenChange={setIsCreateOpen}>
+              <Dialog 
+                open={isCreateOpen} 
+                onOpenChange={(open) => {
+                  // Prevent closing dialog during mutation
+                  if (!createDatasetMutation.isPending) {
+                    setIsCreateOpen(open)
+                  }
+                }}
+              >
                 <DialogTrigger asChild>
                   <Button variant="secondary" size="sm">
                     Create new
@@ -399,7 +407,7 @@ const Data = () => {
                     </div>
                   </div>
                   <DialogFooter>
-                    <DialogClose asChild>
+                    <DialogClose asChild disabled={createDatasetMutation.isPending}>
                       <Button variant="secondary">Cancel</Button>
                     </DialogClose>
                     <Button

--- a/designer/src/components/Data/Data.tsx
+++ b/designer/src/components/Data/Data.tsx
@@ -28,10 +28,8 @@ import SearchInput from '../ui/search-input'
 import { useNavigate } from 'react-router-dom'
 import { useActiveProject } from '../../hooks/useActiveProject'
 import { useListDatasets, useCreateDataset } from '../../hooks/useDatasets'
-import type { UIDataset, UIFile } from '../../types/datasets'
+import type { UIFile } from '../../types/datasets'
 
-// Use the types from the types file, but keep local aliases for compatibility
-type Dataset = UIDataset
 type RawFile = UIFile
 
 const Data = () => {
@@ -65,37 +63,9 @@ const Data = () => {
   const createDatasetMutation = useCreateDataset()
   // const deleteDatasetMutation = useDeleteDataset() // TODO: Implement dataset deletion with API
 
-  // Mock datasets state (fallback when API is not available)
-  const [localDatasets, setLocalDatasets] = useState<Dataset[]>(() => {
-    try {
-      const stored = localStorage.getItem('lf_datasets')
-      if (stored) {
-        const parsed = JSON.parse(stored) as Array<
-          Omit<Dataset, 'lastRun'> & { lastRun: string }
-        >
-        return parsed.map(d => ({ ...d, lastRun: new Date(d.lastRun) }))
-      }
-    } catch {}
-    return [
-      {
-        id: 'default',
-        name: 'default-dataset',
-        lastRun: new Date(),
-        embedModel: 'text-embedding-3-large',
-        numChunks: 28500,
-        processedPercent: 100,
-        version: 'v2',
-        description: '',
-        rag_strategy: 'auto',
-        files: [],
-      },
-    ]
-  })
-
-  // Use API datasets if available, otherwise fall back to localStorage
+  // Convert API datasets to UI format
   const datasets = useMemo(() => {
-    if (apiDatasets?.datasets && !datasetsError) {
-      // Convert API datasets to UI format
+    if (apiDatasets?.datasets) {
       return apiDatasets.datasets.map((dataset) => ({
         id: dataset.name,
         name: dataset.name,
@@ -109,36 +79,12 @@ const Data = () => {
         description: '',
       }))
     }
-    return localDatasets
-  }, [apiDatasets, datasetsError, localDatasets])
+    return []
+  }, [apiDatasets])
 
-  // Function to update local datasets (for localStorage fallback)
-  const setDatasets = useCallback((updater: React.SetStateAction<Dataset[]>) => {
-    if (typeof updater === 'function') {
-      setLocalDatasets(prev => {
-        const updated = updater(prev)
-        // Persist to localStorage
-        try {
-          const serializable = updated.map(d => ({
-            ...d,
-            lastRun: d.lastRun.toISOString(),
-          }))
-          localStorage.setItem('lf_datasets', JSON.stringify(serializable))
-        } catch {}
-        return updated
-      })
-    } else {
-      setLocalDatasets(updater)
-      // Persist to localStorage
-      try {
-        const serializable = updater.map(d => ({
-          ...d,
-          lastRun: d.lastRun.toISOString(),
-        }))
-        localStorage.setItem('lf_datasets', JSON.stringify(serializable))
-      } catch {}
-    }
-  }, [])
+
+
+
 
   // Map of fileKey -> array of dataset ids
   const [fileAssignments, setFileAssignments] = useState<
@@ -225,52 +171,28 @@ const Data = () => {
   const [newDatasetName, setNewDatasetName] = useState('')
   const [newDatasetDescription, setNewDatasetDescription] = useState('')
 
-  const slugify = (value: string) =>
-    value
-      .toLowerCase()
-      .trim()
-      .replace(/[^a-z0-9\s-]/g, '')
-      .replace(/\s+/g, '-')
-      .replace(/-+/g, '-')
+
 
   const handleCreateDataset = async () => {
     const name = newDatasetName.trim()
     if (!name) return
 
+    if (!activeProject?.namespace || !activeProject?.project) {
+      toast({ 
+        message: 'No active project selected', 
+        variant: 'destructive' 
+      })
+      return
+    }
+
     try {
-      if (activeProject?.namespace && activeProject?.project && !datasetsError) {
-        // Use API to create dataset
-        await createDatasetMutation.mutateAsync({
-          namespace: activeProject.namespace,
-          project: activeProject.project,
-          name,
-          rag_strategy: 'auto', // Default strategy
-        })
-        toast({ message: 'Dataset created successfully', variant: 'default' })
-      } else {
-        // Fallback to localStorage
-        const baseId = slugify(name) || 'dataset'
-        let id = baseId
-        let counter = 1
-        const existingIds = new Set(datasets.map(d => d.id))
-        while (existingIds.has(id)) {
-          id = `${baseId}-${counter++}`
-        }
-        const created: Dataset = {
-          id,
-          name,
-          description: newDatasetDescription.trim(),
-          lastRun: new Date(),
-          embedModel: datasets[0]?.embedModel || 'text-embedding-3-large',
-          numChunks: 0,
-          processedPercent: 0,
-          version: 'v1',
-          rag_strategy: 'auto',
-          files: [],
-        }
-        setDatasets(prev => [...prev, created])
-        toast({ message: 'Dataset created locally', variant: 'default' })
-      }
+      await createDatasetMutation.mutateAsync({
+        namespace: activeProject.namespace,
+        project: activeProject.project,
+        name,
+        rag_strategy: 'auto', // Default strategy
+      })
+      toast({ message: 'Dataset created successfully', variant: 'default' })
       setIsCreateOpen(false)
       setNewDatasetName('')
       setNewDatasetDescription('')

--- a/designer/src/components/Data/Data.tsx
+++ b/designer/src/components/Data/Data.tsx
@@ -26,25 +26,13 @@ import { Badge } from '../ui/badge'
 import { useToast } from '../ui/toast'
 import SearchInput from '../ui/search-input'
 import { useNavigate } from 'react-router-dom'
+import { useActiveProject } from '../../hooks/useActiveProject'
+import { useListDatasets, useCreateDataset } from '../../hooks/useDatasets'
+import type { UIDataset, UIFile } from '../../types/datasets'
 
-type Dataset = {
-  id: string
-  name: string
-  lastRun: Date
-  embedModel: string
-  numChunks: number
-  processedPercent: number // 0-100
-  version: string
-  description?: string
-}
-
-type RawFile = {
-  id: string // stable key (name:size:lastModified)
-  name: string
-  size: number
-  lastModified: number
-  type?: string
-}
+// Use the types from the types file, but keep local aliases for compatibility
+type Dataset = UIDataset
+type RawFile = UIFile
 
 const Data = () => {
   const [isDragging, setIsDragging] = useState(false)
@@ -65,8 +53,20 @@ const Data = () => {
   const navigate = useNavigate()
   const { toast } = useToast()
 
-  // Datasets state (ensure at least one dataset exists)
-  const [datasets, setDatasets] = useState<Dataset[]>(() => {
+  // Get current active project for API calls
+  const activeProject = useActiveProject()
+
+  // Use React Query hooks for datasets with localStorage fallback
+  const { data: apiDatasets, isLoading: isDatasetsLoading, error: datasetsError } = useListDatasets(
+    activeProject?.namespace || '',
+    activeProject?.project || '',
+    { enabled: !!activeProject?.namespace && !!activeProject?.project }
+  )
+  const createDatasetMutation = useCreateDataset()
+  // const deleteDatasetMutation = useDeleteDataset() // TODO: Implement dataset deletion with API
+
+  // Mock datasets state (fallback when API is not available)
+  const [localDatasets, setLocalDatasets] = useState<Dataset[]>(() => {
     try {
       const stored = localStorage.getItem('lf_datasets')
       if (stored) {
@@ -86,9 +86,59 @@ const Data = () => {
         processedPercent: 100,
         version: 'v2',
         description: '',
+        rag_strategy: 'auto',
+        files: [],
       },
     ]
   })
+
+  // Use API datasets if available, otherwise fall back to localStorage
+  const datasets = useMemo(() => {
+    if (apiDatasets?.datasets && !datasetsError) {
+      // Convert API datasets to UI format
+      return apiDatasets.datasets.map((dataset) => ({
+        id: dataset.name,
+        name: dataset.name,
+        rag_strategy: dataset.rag_strategy,
+        files: dataset.files,
+        lastRun: new Date(),
+        embedModel: 'text-embedding-3-large',
+        numChunks: dataset.files.length * 100, // Estimate based on files
+        processedPercent: 100,
+        version: 'v1',
+        description: '',
+      }))
+    }
+    return localDatasets
+  }, [apiDatasets, datasetsError, localDatasets])
+
+  // Function to update local datasets (for localStorage fallback)
+  const setDatasets = useCallback((updater: React.SetStateAction<Dataset[]>) => {
+    if (typeof updater === 'function') {
+      setLocalDatasets(prev => {
+        const updated = updater(prev)
+        // Persist to localStorage
+        try {
+          const serializable = updated.map(d => ({
+            ...d,
+            lastRun: d.lastRun.toISOString(),
+          }))
+          localStorage.setItem('lf_datasets', JSON.stringify(serializable))
+        } catch {}
+        return updated
+      })
+    } else {
+      setLocalDatasets(updater)
+      // Persist to localStorage
+      try {
+        const serializable = updater.map(d => ({
+          ...d,
+          lastRun: d.lastRun.toISOString(),
+        }))
+        localStorage.setItem('lf_datasets', JSON.stringify(serializable))
+      } catch {}
+    }
+  }, [])
 
   // Map of fileKey -> array of dataset ids
   const [fileAssignments, setFileAssignments] = useState<
@@ -168,15 +218,7 @@ const Data = () => {
     } catch {}
   }, [fileAssignments])
 
-  useEffect(() => {
-    try {
-      const serializable = datasets.map(d => ({
-        ...d,
-        lastRun: d.lastRun.toISOString(),
-      }))
-      localStorage.setItem('lf_datasets', JSON.stringify(serializable))
-    } catch {}
-  }, [datasets])
+  // Dataset persistence is handled in the setDatasets function for localStorage fallback
 
   // Create dataset dialog state
   const [isCreateOpen, setIsCreateOpen] = useState(false)
@@ -191,30 +233,54 @@ const Data = () => {
       .replace(/\s+/g, '-')
       .replace(/-+/g, '-')
 
-  const handleCreateDataset = () => {
+  const handleCreateDataset = async () => {
     const name = newDatasetName.trim()
     if (!name) return
-    const baseId = slugify(name) || 'dataset'
-    let id = baseId
-    let counter = 1
-    const existingIds = new Set(datasets.map(d => d.id))
-    while (existingIds.has(id)) {
-      id = `${baseId}-${counter++}`
+
+    try {
+      if (activeProject?.namespace && activeProject?.project && !datasetsError) {
+        // Use API to create dataset
+        await createDatasetMutation.mutateAsync({
+          namespace: activeProject.namespace,
+          project: activeProject.project,
+          name,
+          rag_strategy: 'auto', // Default strategy
+        })
+        toast({ message: 'Dataset created successfully', variant: 'default' })
+      } else {
+        // Fallback to localStorage
+        const baseId = slugify(name) || 'dataset'
+        let id = baseId
+        let counter = 1
+        const existingIds = new Set(datasets.map(d => d.id))
+        while (existingIds.has(id)) {
+          id = `${baseId}-${counter++}`
+        }
+        const created: Dataset = {
+          id,
+          name,
+          description: newDatasetDescription.trim(),
+          lastRun: new Date(),
+          embedModel: datasets[0]?.embedModel || 'text-embedding-3-large',
+          numChunks: 0,
+          processedPercent: 0,
+          version: 'v1',
+          rag_strategy: 'auto',
+          files: [],
+        }
+        setDatasets(prev => [...prev, created])
+        toast({ message: 'Dataset created locally', variant: 'default' })
+      }
+      setIsCreateOpen(false)
+      setNewDatasetName('')
+      setNewDatasetDescription('')
+    } catch (error) {
+      console.error('Failed to create dataset:', error)
+      toast({ 
+        message: 'Failed to create dataset. Please try again.', 
+        variant: 'destructive' 
+      })
     }
-    const created: Dataset = {
-      id,
-      name,
-      description: newDatasetDescription.trim(),
-      lastRun: new Date(),
-      embedModel: datasets[0]?.embedModel || 'text-embedding-3-large',
-      numChunks: 0,
-      processedPercent: 0,
-      version: 'v1',
-    }
-    setDatasets(prev => [...prev, created])
-    setIsCreateOpen(false)
-    setNewDatasetName('')
-    setNewDatasetDescription('')
   }
 
   const handleDragOver = useCallback((e: React.DragEvent<HTMLDivElement>) => {
@@ -416,9 +482,9 @@ const Data = () => {
                     </DialogClose>
                     <Button
                       onClick={handleCreateDataset}
-                      disabled={!newDatasetName.trim()}
+                      disabled={!newDatasetName.trim() || createDatasetMutation.isPending}
                     >
-                      Create
+                      {createDatasetMutation.isPending ? 'Creating...' : 'Create'}
                     </Button>
                   </DialogFooter>
                 </DialogContent>
@@ -451,9 +517,14 @@ const Data = () => {
           </div>
         ) : (
           <div>
-            {mode === 'designer' && rawFiles.length <= 0 ? (
+            {mode === 'designer' && isDatasetsLoading ? (
               <div className="w-full mb-6 flex items-center justify-center rounded-lg py-4 text-primary text-center bg-primary/10">
-                Datasets will appear here when they’re ready
+                <Loader size={32} className="mr-2" />
+                Loading datasets...
+              </div>
+            ) : mode === 'designer' && datasets.length <= 0 ? (
+              <div className="w-full mb-6 flex items-center justify-center rounded-lg py-4 text-primary text-center bg-primary/10">
+                {datasetsError ? 'Unable to load datasets. Using local storage.' : 'No datasets found. Create one to get started.'}
               </div>
             ) : (
               mode === 'designer' && (

--- a/designer/src/components/Data/DatasetView.tsx
+++ b/designer/src/components/Data/DatasetView.tsx
@@ -21,6 +21,7 @@ import {
 import { Textarea } from '../ui/textarea'
 import { useToast } from '../ui/toast'
 import { useActiveProject } from '../../hooks/useActiveProject'
+import { useProjectSwitchNavigation } from '../../hooks/useProjectSwitchNavigation'
 import { useUploadFileToDataset, useReIngestDataset, useTaskStatus, useListDatasets, useDeleteDatasetFile, useDeleteDataset } from '../../hooks/useDatasets'
 
 type Dataset = {
@@ -42,6 +43,9 @@ function DatasetView() {
 
   // Get current active project for API calls
   const activeProject = useActiveProject()
+  
+  // Handle automatic navigation when project changes
+  useProjectSwitchNavigation()
   const uploadMutation = useUploadFileToDataset()
 
   // Fetch datasets from API to get file information

--- a/designer/src/components/Data/DatasetView.tsx
+++ b/designer/src/components/Data/DatasetView.tsx
@@ -21,7 +21,7 @@ import {
 import { Textarea } from '../ui/textarea'
 import { useToast } from '../ui/toast'
 import { useActiveProject } from '../../hooks/useActiveProject'
-import { useUploadFileToDataset } from '../../hooks/useDatasets'
+import { useUploadFileToDataset, useReIngestDataset, useTaskStatus, useListDatasets, useDeleteDatasetFile, useDeleteDataset } from '../../hooks/useDatasets'
 
 type Dataset = {
   id: string
@@ -32,6 +32,7 @@ type Dataset = {
   processedPercent: number
   version: string
   description?: string
+  files?: string[] // Array of file hashes from API
 }
 
 function DatasetView() {
@@ -42,6 +43,25 @@ function DatasetView() {
   // Get current active project for API calls
   const activeProject = useActiveProject()
   const uploadMutation = useUploadFileToDataset()
+
+  // Fetch datasets from API to get file information
+  const { data: datasetsResponse } = useListDatasets(
+    activeProject?.namespace || '',
+    activeProject?.project || '',
+    { enabled: !!activeProject }
+  )
+
+  // Task tracking state and hooks
+  const [currentTaskId, setCurrentTaskId] = useState<string | null>(null)
+  const reIngestMutation = useReIngestDataset()
+  const deleteFileMutation = useDeleteDatasetFile()
+  const deleteDatasetMutation = useDeleteDataset()
+  const { data: taskStatus } = useTaskStatus(
+    activeProject?.namespace || '',
+    activeProject?.project || '',
+    currentTaskId,
+    { enabled: !!currentTaskId && !!activeProject }
+  )
 
   const [dataset, setDataset] = useState<Dataset | null>(null)
   const datasetName = useMemo(
@@ -55,19 +75,38 @@ function DatasetView() {
     size: number
     lastModified: number
     type?: string
+    fullHash?: string // For API files, stores the complete hash
   }
 
-  const [files, setFiles] = useState<RawFile[]>([])
+  // Get current dataset from API response
+  const currentApiDataset = useMemo(() => {
+    if (!datasetsResponse?.datasets || !datasetId) return null
+    return datasetsResponse.datasets.find(d => d.name === datasetId)
+  }, [datasetsResponse, datasetId])
+
+  // Files from API data only
+  const files = useMemo(() => {
+    if (!currentApiDataset?.files) return []
+    return currentApiDataset.files.map((fileHash) => ({
+      id: fileHash,
+      name: `${fileHash.substring(0, 12)}...${fileHash.substring(-8)}`, // Show first 12 and last 8 chars
+      size: 0, // We don't have size info from API
+      lastModified: Date.now(),
+      type: 'unknown',
+      fullHash: fileHash, // Store full hash for operations
+    }))
+  }, [currentApiDataset])
+
   const [isEditOpen, setIsEditOpen] = useState(false)
   const [editName, setEditName] = useState('')
   const [editDescription, setEditDescription] = useState('')
+  const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false)
   const [searchValue, setSearchValue] = useState('')
   const fileInputRef = useRef<HTMLInputElement>(null)
   const [uploadStatus, setUploadStatus] = useState<
     Record<string, 'processing' | 'done'>
   >({})
-  const [isDeleteOpen, setIsDeleteOpen] = useState(false)
-  const [fileToDelete, setFileToDelete] = useState<RawFile | null>(null)
+ 
 
   type DatasetVersion = {
     id: string // e.g., v1, v2
@@ -76,37 +115,93 @@ function DatasetView() {
   const [versions, setVersions] = useState<DatasetVersion[]>([])
   const [selectedVersionId, setSelectedVersionId] = useState<string>('')
 
-  useEffect(() => {
-    try {
-      const storedFiles = localStorage.getItem('lf_raw_files')
-      const storedAssignments = localStorage.getItem('lf_file_assignments')
-      if (!storedFiles || !storedAssignments || !datasetId) return
-      const all: RawFile[] = JSON.parse(storedFiles)
-      const assignments: Record<string, string[]> =
-        JSON.parse(storedAssignments)
-      const filtered = all.filter(r =>
-        (assignments[r.id] ?? []).includes(datasetId)
-      )
-      setFiles(filtered)
-    } catch {}
-  }, [datasetId])
 
-  // TODO: Load dataset metadata from API instead of localStorage
+
+  // Load dataset metadata from API or create fallback
   useEffect(() => {
     if (!datasetId) return
-    // For now, create a minimal dataset object
-    // This should be replaced with an API call to get dataset details
-    setDataset({
-      id: datasetId,
-      name: datasetId,
-      lastRun: new Date(),
-      embedModel: 'text-embedding-3-large',
-      numChunks: 0,
-      processedPercent: 100,
-      version: 'v1',
-      description: '',
-    })
-  }, [datasetId])
+    
+    if (currentApiDataset) {
+      // Use API data when available
+      setDataset({
+        id: datasetId,
+        name: currentApiDataset.name,
+        lastRun: new Date(),
+        embedModel: 'text-embedding-3-large',
+        numChunks: currentApiDataset.files?.length || 0,
+        processedPercent: 100,
+        version: 'v1',
+        description: '',
+        files: currentApiDataset.files,
+      })
+    } else {
+      // Fallback to minimal dataset object
+      setDataset({
+        id: datasetId,
+        name: datasetId,
+        lastRun: new Date(),
+        embedModel: 'text-embedding-3-large',
+        numChunks: 0,
+        processedPercent: 100,
+        version: 'v1',
+        description: '',
+        files: [],
+      })
+    }
+  }, [datasetId, currentApiDataset])
+
+  // Handle task completion
+  useEffect(() => {
+    if (!taskStatus) return
+
+    if (taskStatus.state === 'SUCCESS') {
+      // Task completed successfully
+      setCurrentTaskId(null)
+      toast({ 
+        message: 'Dataset reprocessing completed successfully', 
+        variant: 'default' 
+      })
+      
+      // Create a new version
+      if (datasetId) {
+        const nextNum = (versions.length || 0) + 1
+        const nextId = `v${nextNum}`
+        const next: DatasetVersion = {
+          id: nextId,
+          createdAt: new Date().toISOString(),
+        }
+        const list = [...versions, next]
+        setVersions(list)
+        setSelectedVersionId(nextId)
+        persistVersions(list, nextId)
+        
+        // Update dataset version/lastRun
+        try {
+          const stored = localStorage.getItem('lf_datasets')
+          const arr = stored ? (JSON.parse(stored) as Dataset[]) : []
+          const updated = arr.map(d =>
+            d.id === datasetId
+              ? {
+                  ...d,
+                  version: nextId,
+                  lastRun: new Date().toISOString(),
+                }
+              : d
+          )
+          localStorage.setItem('lf_datasets', JSON.stringify(updated))
+          setDataset(updated.find(d => d.id === datasetId) || null)
+        } catch {}
+      }
+    } else if (taskStatus.state === 'FAILURE') {
+      // Task failed
+      setCurrentTaskId(null)
+      const errorMessage = taskStatus.error || 'Unknown error occurred'
+      toast({ 
+        message: `Dataset reprocessing failed: ${errorMessage}`, 
+        variant: 'destructive' 
+      })
+    }
+  }, [taskStatus?.state, taskStatus?.error, datasetId, versions, toast])
 
   // Load versions for this dataset (or seed from dataset.version)
   useEffect(() => {
@@ -203,11 +298,80 @@ function DatasetView() {
     console.warn('Dataset edit saved locally - should use API instead')
   }
 
-  const handleDelete = () => {
-    if (!datasetId) return
-    // TODO: Replace with API call to delete dataset
-    console.warn('Dataset delete called - should use API instead')
-    navigate('/chat/data')
+  const handleDeleteClick = () => {
+    setShowDeleteConfirmation(true)
+  }
+
+  const handleConfirmDelete = async () => {
+    if (!activeProject?.namespace || !activeProject?.project || !datasetId) return
+
+    try {
+      await deleteDatasetMutation.mutateAsync({
+        namespace: activeProject.namespace,
+        project: activeProject.project,
+        dataset: datasetId,
+      })
+      
+      setShowDeleteConfirmation(false)
+      setIsEditOpen(false)
+      
+      toast({
+        message: 'Dataset deleted successfully',
+        variant: 'default',
+      })
+      
+      // Navigate away since the dataset no longer exists
+      navigate('/chat/data')
+      
+    } catch (error) {
+      console.error('Dataset deletion failed:', error)
+      toast({
+        message: 'Failed to delete dataset. Please try again.',
+        variant: 'destructive',
+      })
+    }
+  }
+
+  const handleCancelDelete = () => {
+    setShowDeleteConfirmation(false)
+  }
+
+  const handleDeleteFile = async (fileHash: string) => {
+    if (!activeProject?.namespace || !activeProject?.project || !datasetId) return
+
+    // Show confirmation dialog
+    const confirmed = window.confirm(
+      `Are you sure you want to delete this file?\n\nFile: ${fileHash.substring(0, 12)}...\n\nThis action cannot be undone.`
+    )
+    
+    if (!confirmed) return
+
+    try {
+      await deleteFileMutation.mutateAsync({
+        namespace: activeProject.namespace,
+        project: activeProject.project,
+        dataset: datasetId,
+        fileHash,
+        removeFromDisk: true
+      })
+      
+      toast({
+        message: 'File deleted successfully',
+        variant: 'default',
+      })
+    } catch (error) {
+      console.error('Delete failed:', error)
+      toast({
+        message: 'Failed to delete file. Please try again.',
+        variant: 'destructive',
+      })
+    }
+  }
+
+  // Helper function to check if a specific file is being deleted
+  const isFileDeleting = (fileHash: string) => {
+    return deleteFileMutation.isPending && 
+           deleteFileMutation.variables?.fileHash === fileHash
   }
 
   return (
@@ -252,30 +416,40 @@ function DatasetView() {
             </Badge>
             <Button
               size="sm"
-              onClick={() => {
-                if (!datasetId) return
-                const nextNum = (versions.length || 0) + 1
-                const nextId = `v${nextNum}`
-                const next: DatasetVersion = {
-                  id: nextId,
-                  createdAt: new Date().toISOString(),
-                }
-                const list = [...versions, next]
-                setVersions(list)
-                setSelectedVersionId(nextId)
-                persistVersions(list, nextId)
-                // TODO: Replace with API call to trigger dataset reprocessing
-                if (dataset) {
-                  setDataset({
-                    ...dataset,
-                    version: nextId,
-                    lastRun: new Date(),
+              onClick={async () => {
+                if (!datasetId || !activeProject?.namespace || !activeProject?.project) return
+                
+                try {
+                  const result = await reIngestMutation.mutateAsync({
+                    namespace: activeProject.namespace,
+                    project: activeProject.project,
+                    dataset: datasetId,
+                  })
+                  
+                  // Extract task ID from task_uri (e.g., "http://localhost:8000/v1/projects/ns/proj/tasks/abc-123" -> "abc-123")
+                  const taskId = result.task_uri.split('/').pop()
+                  if (taskId) {
+                    setCurrentTaskId(taskId)
+                    toast({ 
+                      message: 'Dataset reprocessing started...', 
+                      variant: 'default' 
+                    })
+                  }
+                } catch (error) {
+                  console.error('Failed to start reprocessing:', error)
+                  toast({ 
+                    message: 'Failed to start reprocessing. Please try again.', 
+                    variant: 'destructive' 
                   })
                 }
-                console.warn('Dataset reprocess triggered - should use API instead')
               }}
+              disabled={reIngestMutation.isPending || !!currentTaskId}
             >
-              Reprocess
+              {reIngestMutation.isPending 
+                ? 'Starting...' 
+                : currentTaskId && taskStatus?.state === 'PENDING'
+                  ? 'Processing...'
+                  : 'Reprocess'}
             </Button>
           </div>
         </div>
@@ -325,46 +499,98 @@ function DatasetView() {
         </div>
       </section>
 
-      <Dialog open={isEditOpen} onOpenChange={setIsEditOpen}>
+      <Dialog 
+        open={isEditOpen} 
+        onOpenChange={(open) => {
+          setIsEditOpen(open)
+          if (!open) {
+            // Reset confirmation state when modal closes
+            setShowDeleteConfirmation(false)
+          }
+        }}
+      >
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Edit dataset</DialogTitle>
+            <DialogTitle>
+              {showDeleteConfirmation ? 'Delete Dataset' : 'Edit dataset'}
+            </DialogTitle>
           </DialogHeader>
-          <div className="flex flex-col gap-3">
-            <div className="flex flex-col gap-1">
-              <label className="text-xs text-muted-foreground">Name</label>
-              <Input
-                autoFocus
-                value={editName}
-                onChange={e => setEditName(e.target.value)}
-                placeholder="Dataset name"
-              />
+          
+          {showDeleteConfirmation ? (
+            <div className="space-y-4">
+              <div className="text-center">
+                <h3 className="text-lg font-semibold text-red-600">Confirm Deletion</h3>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  Are you sure you want to delete the dataset "{datasetName}"?
+                </p>
+                <p className="mt-1 text-xs text-red-500">
+                  This action cannot be undone. All files and data will be permanently deleted.
+                </p>
+              </div>
+              
+              <div className="flex gap-3 justify-center">
+                <Button
+                  variant="secondary"
+                  onClick={handleCancelDelete}
+                  disabled={deleteDatasetMutation.isPending}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  variant="destructive"
+                  onClick={handleConfirmDelete}
+                  disabled={deleteDatasetMutation.isPending}
+                >
+                  {deleteDatasetMutation.isPending ? (
+                    <>
+                      <span className="inline-block animate-spin mr-2">⟳</span>
+                      Deleting...
+                    </>
+                  ) : (
+                    'Delete Dataset'
+                  )}
+                </Button>
+              </div>
             </div>
-            <div className="flex flex-col gap-1">
-              <label className="text-xs text-muted-foreground">
-                Description
-              </label>
-              <Textarea
-                value={editDescription}
-                onChange={e => setEditDescription(e.target.value)}
-                placeholder="Optional description"
-                rows={3}
-              />
-            </div>
-          </div>
-          <div className="mt-4 flex flex-col-reverse gap-2 sm:flex-row sm:items-center sm:justify-between">
-            <Button variant="destructive" onClick={handleDelete}>
-              Delete
-            </Button>
-            <div className="flex items-center gap-2">
-              <DialogClose asChild>
-                <Button variant="secondary">Cancel</Button>
-              </DialogClose>
-              <Button onClick={handleSaveEdit} disabled={!editName.trim()}>
-                Save
-              </Button>
-            </div>
-          </div>
+          ) : (
+            <>
+              <div className="flex flex-col gap-3">
+                <div className="flex flex-col gap-1">
+                  <label className="text-xs text-muted-foreground">Name</label>
+                  <Input
+                    autoFocus
+                    value={editName}
+                    onChange={e => setEditName(e.target.value)}
+                    placeholder="Dataset name"
+                  />
+                </div>
+                <div className="flex flex-col gap-1">
+                  <label className="text-xs text-muted-foreground">
+                    Description
+                  </label>
+                  <Textarea
+                    value={editDescription}
+                    onChange={e => setEditDescription(e.target.value)}
+                    placeholder="Optional description"
+                    rows={3}
+                  />
+                </div>
+              </div>
+              <div className="mt-4 flex flex-col-reverse gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <Button variant="destructive" onClick={handleDeleteClick}>
+                  Delete
+                </Button>
+                <div className="flex items-center gap-2">
+                  <DialogClose asChild>
+                    <Button variant="secondary">Cancel</Button>
+                  </DialogClose>
+                  <Button onClick={handleSaveEdit} disabled={!editName.trim()}>
+                    Save
+                  </Button>
+                </div>
+              </div>
+            </>
+          )}
         </DialogContent>
       </Dialog>
 
@@ -491,12 +717,7 @@ function DatasetView() {
                 }
               }
               
-              // Update local file list for UI
-              setFiles(prev => {
-                const seen = new Set(prev.map(p => p.id))
-                const add = converted.filter(n => !seen.has(n.id))
-                return [...prev, ...add]
-              })
+              // Files will be updated via API refresh after upload completes
               
               // Show success status
               setTimeout(() => {
@@ -552,10 +773,23 @@ function DatasetView() {
           {files.length === 0 ? (
             <div className="p-3 text-muted-foreground">
               No files assigned yet.
+              {/* Debug info */}
+              {process.env.NODE_ENV === 'development' && (
+                <div className="mt-2 text-xs">
+                  <div>API Dataset: {currentApiDataset ? 'Found' : 'Not found'}</div>
+                  <div>API Files: {currentApiDataset?.files?.length || 0}</div>
+                </div>
+              )}
             </div>
           ) : (
-            <ul>
-              {files
+            <div>
+              <div className="p-3 border-b border-border/60 bg-muted/20">
+                <div className="text-xs font-medium">
+                  {files.length} file{files.length !== 1 ? 's' : ''}
+                </div>
+              </div>
+              <ul>
+                {files
                 .filter(f =>
                   f.name.toLowerCase().includes(searchValue.toLowerCase())
                 )
@@ -564,13 +798,22 @@ function DatasetView() {
                     key={f.id}
                     className="flex items-center justify-between px-3 py-3 border-b last:border-b-0 border-border/60"
                   >
-                    <span className="font-mono text-xs text-muted-foreground truncate max-w-[60%]">
-                      {f.name}
-                    </span>
+                    <div className="font-mono text-xs text-muted-foreground truncate max-w-[60%] flex flex-col gap-1">
+                      <span>{f.fullHash ? f.name : f.name}</span>
+                      {f.fullHash && (
+                        <button
+                          onClick={() => navigator.clipboard.writeText(f.fullHash!)}
+                          className="text-xs text-blue-600 hover:text-blue-800 text-left"
+                          title="Click to copy full hash"
+                        >
+                          Copy full hash
+                        </button>
+                      )}
+                    </div>
                     <div className="w-1/2 flex items-center justify-between gap-4">
                       {/* Size column (middle) */}
                       <div className="text-xs text-muted-foreground">
-                        {Math.ceil(f.size / 1024)} KB
+                        {f.fullHash ? 'File hash' : `${Math.ceil(f.size / 1024)} KB`}
                       </div>
                       {/* Right actions: status + trash */}
                       <div className="flex items-center gap-6">
@@ -587,76 +830,29 @@ function DatasetView() {
                           />
                         )}
                         <button
-                          className="w-4 h-4 grid place-items-center text-muted-foreground hover:text-foreground"
-                          onClick={() => {
-                            setFileToDelete(f)
-                            setIsDeleteOpen(true)
-                          }}
-                          aria-label={`Remove ${f.name} from this dataset`}
+                          className="w-4 h-4 grid place-items-center text-muted-foreground hover:text-red-600 disabled:opacity-50"
+                          onClick={() => f.fullHash && handleDeleteFile(f.fullHash)}
+                          disabled={f.fullHash ? isFileDeleting(f.fullHash) : true}
+                          aria-label={`Delete ${f.name} from dataset`}
+                          title="Delete file"
                         >
-                          <FontIcon type="trashcan" className="w-4 h-4" />
+                          {f.fullHash && isFileDeleting(f.fullHash) ? (
+                            <span className="text-xs">...</span>
+                          ) : (
+                            <FontIcon type="trashcan" className="w-4 h-4" />
+                          )}
                         </button>
                       </div>
                     </div>
                   </li>
                 ))}
-            </ul>
+              </ul>
+            </div>
           )}
         </div>
       </section>
 
-      {/* Delete from dataset dialog */}
-      <Dialog open={isDeleteOpen} onOpenChange={setIsDeleteOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Remove file from this dataset</DialogTitle>
-          </DialogHeader>
-          <div className="text-sm">
-            <div className="mb-2 text-muted-foreground">
-              This will remove the file from this dataset only. It will remain
-              available in the project.
-            </div>
-            <div className="font-mono text-xs break-all">
-              {fileToDelete?.name}
-            </div>
-          </div>
-          <div className="mt-4 flex items-center justify-end gap-2">
-            <DialogClose asChild>
-              <Button variant="secondary">Cancel</Button>
-            </DialogClose>
-            <Button
-              variant="destructive"
-              onClick={() => {
-                if (!fileToDelete || !datasetId) return
-                // remove assignment only
-                try {
-                  const stored = localStorage.getItem('lf_file_assignments')
-                  const assignments: Record<string, string[]> = stored
-                    ? JSON.parse(stored)
-                    : {}
-                  const arr = assignments[fileToDelete.id] ?? []
-                  assignments[fileToDelete.id] = arr.filter(
-                    id => id !== datasetId
-                  )
-                  localStorage.setItem(
-                    'lf_file_assignments',
-                    JSON.stringify(assignments)
-                  )
-                } catch {}
-                setFiles(prev => prev.filter(x => x.id !== fileToDelete.id))
-                setIsDeleteOpen(false)
-                setFileToDelete(null)
-                toast({
-                  message: 'File removed from dataset',
-                  variant: 'default',
-                })
-              }}
-            >
-              Yes, remove
-            </Button>
-          </div>
-        </DialogContent>
-      </Dialog>
+      {/* File deletion now handled directly via API calls with confirmation dialog */}
     </div>
   )
 }

--- a/designer/src/components/Data/DatasetView.tsx
+++ b/designer/src/components/Data/DatasetView.tsx
@@ -20,6 +20,8 @@ import {
 } from '../ui/dialog'
 import { Textarea } from '../ui/textarea'
 import { useToast } from '../ui/toast'
+import { useActiveProject } from '../../hooks/useActiveProject'
+import { useUploadFileToDataset } from '../../hooks/useDatasets'
 
 type Dataset = {
   id: string
@@ -36,6 +38,10 @@ function DatasetView() {
   const navigate = useNavigate()
   const { datasetId } = useParams()
   const { toast } = useToast()
+
+  // Get current active project for API calls
+  const activeProject = useActiveProject()
+  const uploadMutation = useUploadFileToDataset()
 
   const [dataset, setDataset] = useState<Dataset | null>(null)
   const datasetName = useMemo(
@@ -462,11 +468,19 @@ function DatasetView() {
           type="file"
           className="hidden"
           multiple
-          onChange={e => {
-            if (!datasetId) return
+          onChange={async (e) => {
+            if (!datasetId || !activeProject?.namespace || !activeProject?.project) {
+              toast({
+                message: 'Missing required information for upload',
+                variant: 'destructive'
+              })
+              return
+            }
+            
             const list = e.target.files ? Array.from(e.target.files) : []
             if (list.length === 0) return
-            // Convert to RawFile shape
+            
+            // Convert to RawFile shape for UI
             const converted: RawFile[] = list.map(f => ({
               id: `${f.name}:${f.size}:${f.lastModified}`,
               name: f.name,
@@ -474,14 +488,43 @@ function DatasetView() {
               lastModified: f.lastModified,
               type: f.type,
             }))
+            
             try {
+              // Set processing status for UI feedback
               setUploadStatus(prev => ({
                 ...prev,
                 ...Object.fromEntries(
                   converted.map(rf => [rf.id, 'processing' as const])
                 ),
               }))
-              // Persist raw files (dedupe by id)
+              
+              // Upload each file to the API
+              for (const file of list) {
+                try {
+                  await uploadMutation.mutateAsync({
+                    namespace: activeProject.namespace,
+                    project: activeProject.project,
+                    dataset: datasetId,
+                    file
+                  })
+                } catch (error) {
+                  console.error(`Failed to upload ${file.name}:`, error)
+                  toast({
+                    message: `Failed to upload ${file.name}`,
+                    variant: 'destructive'
+                  })
+                  // Remove from processing status on error
+                  const fileId = `${file.name}:${file.size}:${file.lastModified}`
+                  setUploadStatus(prev => {
+                    const next = { ...prev }
+                    delete (next as any)[fileId]
+                    return next
+                  })
+                  continue
+                }
+              }
+              
+              // Also persist to localStorage for backward compatibility
               const storedRaw = localStorage.getItem('lf_raw_files')
               const existing: RawFile[] = storedRaw ? JSON.parse(storedRaw) : []
               const existingIds = new Set(existing.map(r => r.id))
@@ -489,7 +532,7 @@ function DatasetView() {
               const updatedRaw = [...existing, ...deduped]
               localStorage.setItem('lf_raw_files', JSON.stringify(updatedRaw))
 
-              // Assign to this dataset
+              // Assign to this dataset in localStorage
               const storedAssign = localStorage.getItem('lf_file_assignments')
               const assignments: Record<string, string[]> = storedAssign
                 ? JSON.parse(storedAssign)
@@ -514,6 +557,8 @@ function DatasetView() {
                 const add = nowAssigned.filter(n => !seen.has(n.id))
                 return [...prev, ...add]
               })
+              
+              // Show success status
               setTimeout(() => {
                 setUploadStatus(prev => ({
                   ...prev,
@@ -521,6 +566,12 @@ function DatasetView() {
                     converted.map(rf => [rf.id, 'done' as const])
                   ),
                 }))
+                toast({
+                  message: `Successfully uploaded ${list.length} file${list.length > 1 ? 's' : ''}`,
+                  variant: 'default'
+                })
+                
+                // Clear status after delay
                 setTimeout(() => {
                   setUploadStatus(prev => {
                     const next = { ...prev }
@@ -528,9 +579,23 @@ function DatasetView() {
                     return next
                   })
                 }, 1500)
-              }, 1500)
-            } catch {}
-            // reset input so same files can be picked again
+              }, 500)
+              
+            } catch (error) {
+              console.error('Upload error:', error)
+              toast({
+                message: 'Failed to upload files',
+                variant: 'destructive'
+              })
+              // Clear processing status on error
+              setUploadStatus(prev => {
+                const next = { ...prev }
+                for (const rf of converted) delete (next as any)[rf.id]
+                return next
+              })
+            }
+            
+            // Reset input so same files can be picked again
             e.currentTarget.value = ''
           }}
         />

--- a/designer/src/components/Data/DatasetView.tsx
+++ b/designer/src/components/Data/DatasetView.tsx
@@ -91,14 +91,21 @@ function DatasetView() {
     } catch {}
   }, [datasetId])
 
+  // TODO: Load dataset metadata from API instead of localStorage
   useEffect(() => {
-    try {
-      const storedDatasets = localStorage.getItem('lf_datasets')
-      if (!storedDatasets || !datasetId) return
-      const list = JSON.parse(storedDatasets) as Dataset[]
-      const current = list.find(d => d.id === datasetId) || null
-      setDataset(current)
-    } catch {}
+    if (!datasetId) return
+    // For now, create a minimal dataset object
+    // This should be replaced with an API call to get dataset details
+    setDataset({
+      id: datasetId,
+      name: datasetId,
+      lastRun: new Date(),
+      embedModel: 'text-embedding-3-large',
+      numChunks: 0,
+      processedPercent: 100,
+      version: 'v1',
+      description: '',
+    })
   }, [datasetId])
 
   // Load versions for this dataset (or seed from dataset.version)
@@ -181,59 +188,26 @@ function DatasetView() {
     setIsEditOpen(true)
   }
 
-  const saveDatasets = (arr: Dataset[]) => {
-    try {
-      localStorage.setItem(
-        'lf_datasets',
-        JSON.stringify(
-          arr.map(d => ({ ...d, lastRun: new Date(d.lastRun).toISOString() }))
-        )
-      )
-    } catch {}
-  }
+
 
   const handleSaveEdit = () => {
     if (!dataset || !datasetId) return
-    try {
-      const stored = localStorage.getItem('lf_datasets')
-      const list = stored ? (JSON.parse(stored) as Dataset[]) : []
-      const updated = list.map(d =>
-        d.id === datasetId
-          ? {
-              ...d,
-              name: editName.trim() || d.name,
-              description: editDescription,
-            }
-          : d
-      )
-      saveDatasets(updated)
-      const current = updated.find(d => d.id === datasetId) || null
-      setDataset(current)
-      setIsEditOpen(false)
-    } catch {}
+    // TODO: Replace with API call to update dataset
+    const updatedDataset = {
+      ...dataset,
+      name: editName.trim() || dataset.name,
+      description: editDescription,
+    }
+    setDataset(updatedDataset)
+    setIsEditOpen(false)
+    console.warn('Dataset edit saved locally - should use API instead')
   }
 
   const handleDelete = () => {
     if (!datasetId) return
-    try {
-      const stored = localStorage.getItem('lf_datasets')
-      const list = stored ? (JSON.parse(stored) as Dataset[]) : []
-      const updated = list.filter(d => d.id !== datasetId)
-      saveDatasets(updated)
-      // remove dataset from assignments
-      const storedAssignments = localStorage.getItem('lf_file_assignments')
-      if (storedAssignments) {
-        const assignments: Record<string, string[]> =
-          JSON.parse(storedAssignments)
-        const cleaned: Record<string, string[]> = {}
-        for (const [k, arr] of Object.entries(assignments)) {
-          const next = arr.filter(id => id !== datasetId)
-          if (next.length > 0) cleaned[k] = next
-        }
-        localStorage.setItem('lf_file_assignments', JSON.stringify(cleaned))
-      }
-      navigate('/chat/data')
-    } catch {}
+    // TODO: Replace with API call to delete dataset
+    console.warn('Dataset delete called - should use API instead')
+    navigate('/chat/data')
   }
 
   return (
@@ -290,22 +264,15 @@ function DatasetView() {
                 setVersions(list)
                 setSelectedVersionId(nextId)
                 persistVersions(list, nextId)
-                // Also bump dataset version/lastRun
-                try {
-                  const stored = localStorage.getItem('lf_datasets')
-                  const arr = stored ? (JSON.parse(stored) as Dataset[]) : []
-                  const updated = arr.map(d =>
-                    d.id === datasetId
-                      ? {
-                          ...d,
-                          version: nextId,
-                          lastRun: new Date().toISOString(),
-                        }
-                      : d
-                  )
-                  localStorage.setItem('lf_datasets', JSON.stringify(updated))
-                  setDataset(updated.find(d => d.id === datasetId) || null)
-                } catch {}
+                // TODO: Replace with API call to trigger dataset reprocessing
+                if (dataset) {
+                  setDataset({
+                    ...dataset,
+                    version: nextId,
+                    lastRun: new Date(),
+                  })
+                }
+                console.warn('Dataset reprocess triggered - should use API instead')
               }}
             >
               Reprocess
@@ -524,37 +491,10 @@ function DatasetView() {
                 }
               }
               
-              // Also persist to localStorage for backward compatibility
-              const storedRaw = localStorage.getItem('lf_raw_files')
-              const existing: RawFile[] = storedRaw ? JSON.parse(storedRaw) : []
-              const existingIds = new Set(existing.map(r => r.id))
-              const deduped = converted.filter(r => !existingIds.has(r.id))
-              const updatedRaw = [...existing, ...deduped]
-              localStorage.setItem('lf_raw_files', JSON.stringify(updatedRaw))
-
-              // Assign to this dataset in localStorage
-              const storedAssign = localStorage.getItem('lf_file_assignments')
-              const assignments: Record<string, string[]> = storedAssign
-                ? JSON.parse(storedAssign)
-                : {}
-              for (const rf of converted) {
-                const arr = assignments[rf.id] ?? []
-                if (!arr.includes(datasetId)) {
-                  assignments[rf.id] = [...arr, datasetId]
-                }
-              }
-              localStorage.setItem(
-                'lf_file_assignments',
-                JSON.stringify(assignments)
-              )
-
-              // Update local list (only those assigned to this dataset)
-              const nowAssigned = converted.filter(rf =>
-                (assignments[rf.id] ?? []).includes(datasetId)
-              )
+              // Update local file list for UI
               setFiles(prev => {
                 const seen = new Set(prev.map(p => p.id))
-                const add = nowAssigned.filter(n => !seen.has(n.id))
+                const add = converted.filter(n => !seen.has(n.id))
                 return [...prev, ...add]
               })
               

--- a/designer/src/components/Data/DatasetView.tsx
+++ b/designer/src/components/Data/DatasetView.tsx
@@ -91,20 +91,32 @@ function DatasetView() {
   // Files from API data only
   const files = useMemo(() => {
     if (!currentApiDataset?.files) return []
-    return currentApiDataset.files.map((fileHash) => ({
-      id: fileHash,
-      name: `${fileHash.substring(0, 12)}...${fileHash.substring(-8)}`, // Show first 12 and last 8 chars
-      size: 0, // We don't have size info from API
-      lastModified: Date.now(),
-      type: 'unknown',
-      fullHash: fileHash, // Store full hash for operations
-    }))
+    return currentApiDataset.files.map((fileObj: any) => {
+      const fileHash = typeof fileObj === 'string' ? fileObj : (fileObj?.id || fileObj || '')
+      const size = (typeof fileObj === 'object' && fileObj !== null && 'size' in fileObj && fileObj.size !== undefined)
+        ? fileObj.size
+        : 'unknown'
+      const lastModified = (typeof fileObj === 'object' && fileObj !== null && 'lastModified' in fileObj && fileObj.lastModified !== undefined)
+        ? fileObj.lastModified
+        : 'unknown'
+      return {
+        id: fileHash,
+        name: `${fileHash.substring(0, 12)}...${fileHash.substring(fileHash.length - 8)}`, // Show first 12 and last 8 chars
+        size,
+        lastModified,
+        type: 'unknown',
+        fullHash: fileHash, // Store full hash for operations
+      }
+    })
   }, [currentApiDataset])
 
   const [isEditOpen, setIsEditOpen] = useState(false)
   const [editName, setEditName] = useState('')
   const [editDescription, setEditDescription] = useState('')
   const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false)
+  const [pendingDeleteFileHash, setPendingDeleteFileHash] = useState<string | null>(null)
+  const [showDeleteFileConfirmation, setShowDeleteFileConfirmation] = useState(false)
+  const [copyStatus, setCopyStatus] = useState<{ [id: string]: string | undefined }>({})
   const [searchValue, setSearchValue] = useState('')
   const fileInputRef = useRef<HTMLInputElement>(null)
   const [uploadStatus, setUploadStatus] = useState<
@@ -340,22 +352,25 @@ function DatasetView() {
     setShowDeleteConfirmation(false)
   }
 
-  const handleDeleteFile = async (fileHash: string) => {
+  const handleDeleteFile = (fileHash: string) => {
     if (!activeProject?.namespace || !activeProject?.project || !datasetId) return
+    setPendingDeleteFileHash(fileHash)
+    setShowDeleteFileConfirmation(true)
+  }
 
-    // Show confirmation dialog
-    const confirmed = window.confirm(
-      `Are you sure you want to delete this file?\n\nFile: ${fileHash.substring(0, 12)}...\n\nThis action cannot be undone.`
-    )
-    
-    if (!confirmed) return
+  const handleConfirmDeleteFile = async () => {
+    if (!activeProject?.namespace || !activeProject?.project || !datasetId || !pendingDeleteFileHash) {
+      setShowDeleteFileConfirmation(false)
+      setPendingDeleteFileHash(null)
+      return
+    }
 
     try {
       await deleteFileMutation.mutateAsync({
         namespace: activeProject.namespace,
         project: activeProject.project,
         dataset: datasetId,
-        fileHash,
+        fileHash: pendingDeleteFileHash,
         removeFromDisk: true
       })
       
@@ -364,12 +379,20 @@ function DatasetView() {
         variant: 'default',
       })
     } catch (error) {
-      console.error('Delete failed:', error)
+      console.error('File deletion failed:', error)
       toast({
         message: 'Failed to delete file. Please try again.',
         variant: 'destructive',
       })
+    } finally {
+      setShowDeleteFileConfirmation(false)
+      setPendingDeleteFileHash(null)
     }
+  }
+
+  const handleCancelDeleteFile = () => {
+    setShowDeleteFileConfirmation(false)
+    setPendingDeleteFileHash(null)
   }
 
   // Helper function to check if a specific file is being deleted
@@ -598,6 +621,37 @@ function DatasetView() {
         </DialogContent>
       </Dialog>
 
+      {/* File deletion confirmation modal */}
+      {showDeleteFileConfirmation && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+          <div className="bg-background p-6 rounded-lg shadow-lg max-w-md w-full mx-4 border border-border">
+            <h3 className="text-lg font-semibold text-red-600 mb-2">Delete File</h3>
+            <p className="text-muted-foreground mb-4">
+              Are you sure you want to delete this file?
+            </p>
+            <p className="text-sm text-muted-foreground mb-6 font-mono bg-muted p-2 rounded">
+              {pendingDeleteFileHash?.substring(0, 20)}...
+            </p>
+            <div className="flex gap-3 justify-end">
+              <button
+                onClick={handleCancelDeleteFile}
+                className="px-4 py-2 border border-border rounded hover:bg-muted"
+                disabled={deleteFileMutation.isPending}
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleConfirmDeleteFile}
+                disabled={deleteFileMutation.isPending}
+                className="bg-red-600 text-white px-4 py-2 rounded hover:bg-red-700 disabled:opacity-50"
+              >
+                {deleteFileMutation.isPending ? 'Deleting...' : 'Delete File'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* Processing strategy */}
       <section className="rounded-lg border border-border bg-card p-4">
         <div className="flex items-center justify-between mb-3">
@@ -805,19 +859,36 @@ function DatasetView() {
                     <div className="font-mono text-xs text-muted-foreground truncate max-w-[60%] flex flex-col gap-1">
                       <span>{f.fullHash ? f.name : f.name}</span>
                       {f.fullHash && (
-                        <button
-                          onClick={() => navigator.clipboard.writeText(f.fullHash!)}
-                          className="text-xs text-blue-600 hover:text-blue-800 text-left"
-                          title="Click to copy full hash"
-                        >
-                          Copy full hash
-                        </button>
+                        <>
+                          <button
+                            onClick={async () => {
+                              try {
+                                await navigator.clipboard.writeText(f.fullHash!)
+                                setCopyStatus((prev) => ({ ...prev, [f.id]: 'Copied!' }))
+                              } catch (err) {
+                                setCopyStatus((prev) => ({ ...prev, [f.id]: 'Failed to copy' }))
+                              }
+                              setTimeout(() => {
+                                setCopyStatus((prev) => ({ ...prev, [f.id]: undefined }))
+                              }, 1500)
+                            }}
+                            className="text-xs text-blue-600 hover:text-blue-800 text-left"
+                            title="Click to copy full hash"
+                          >
+                            Copy full hash
+                          </button>
+                          {copyStatus?.[f.id] && (
+                            <span className={`ml-2 text-xs ${copyStatus[f.id] === 'Copied!' ? 'text-green-600' : 'text-red-600'}`}>
+                              {copyStatus[f.id]}
+                            </span>
+                          )}
+                        </>
                       )}
                     </div>
                     <div className="w-1/2 flex items-center justify-between gap-4">
                       {/* Size column (middle) */}
                       <div className="text-xs text-muted-foreground">
-                        {f.fullHash ? 'File hash' : `${Math.ceil(f.size / 1024)} KB`}
+                        {f.size === 'unknown' || f.fullHash ? 'N/A' : `${Math.ceil(f.size / 1024)} KB`}
                       </div>
                       {/* Right actions: status + trash */}
                       <div className="flex items-center gap-6">

--- a/designer/src/hooks/useActiveProject.ts
+++ b/designer/src/hooks/useActiveProject.ts
@@ -1,0 +1,107 @@
+import { useState, useEffect } from 'react'
+import { getCurrentNamespace } from '../utils/namespaceUtils'
+import { getActiveProject as getActiveProjectName } from '../utils/projectUtils'
+
+export interface ActiveProject {
+  namespace: string
+  project: string
+}
+
+/**
+ * Hook to manage active project state with proper namespace/project structure
+ * Automatically syncs with localStorage and handles storage events
+ */
+export function useActiveProject(): ActiveProject | null {
+  const [activeProject, setActiveProject] = useState<ActiveProject | null>(null)
+
+  // Initialize active project from localStorage
+  useEffect(() => {
+    const updateActiveProject = () => {
+      try {
+        const namespace = getCurrentNamespace()
+        const projectName = getActiveProjectName()
+        
+        if (namespace && projectName) {
+          const newActiveProject = {
+            namespace,
+            project: projectName
+          }
+          console.log('🔄 Active project initialized:', newActiveProject)
+          setActiveProject(newActiveProject)
+        } else {
+          console.log('⚠️ Active project cleared: missing namespace or project name')
+          setActiveProject(null)
+        }
+      } catch (error) {
+        console.error('Failed to get active project:', error)
+        setActiveProject(null)
+      }
+    }
+
+    updateActiveProject()
+  }, [])
+
+  // Listen for localStorage changes to update when active project changes
+  useEffect(() => {
+    const handleStorageChange = (e: StorageEvent) => {
+      if (e.key === 'activeProject' || e.key === 'userNamespace') {
+        try {
+          const namespace = getCurrentNamespace()
+          const projectName = getActiveProjectName()
+          
+          if (namespace && projectName) {
+            setActiveProject({
+              namespace,
+              project: projectName
+            })
+          } else {
+            setActiveProject(null)
+          }
+        } catch (error) {
+          console.error('Failed to parse active project from storage event:', error)
+          setActiveProject(null)
+        }
+      }
+    }
+
+    window.addEventListener('storage', handleStorageChange)
+    return () => window.removeEventListener('storage', handleStorageChange)
+  }, [])
+
+  // Listen for custom events dispatched by setActiveProject
+  useEffect(() => {
+    const handleActiveProjectChange = (e: CustomEvent<string>) => {
+      try {
+        const namespace = getCurrentNamespace()
+        const projectName = e.detail
+        
+        if (namespace && projectName) {
+          setActiveProject({
+            namespace,
+            project: projectName
+          })
+        } else {
+          setActiveProject(null)
+        }
+      } catch (error) {
+        console.error('Failed to handle active project change event:', error)
+      }
+    }
+
+    window.addEventListener('lf-active-project', handleActiveProjectChange as EventListener)
+    return () => window.removeEventListener('lf-active-project', handleActiveProjectChange as EventListener)
+  }, [])
+
+  return activeProject
+}
+
+/**
+ * Hook variant that returns individual namespace and project values
+ * Useful when you need them as separate variables
+ */
+export function useActiveProjectValues(): { namespace: string; project: string } | null {
+  const activeProject = useActiveProject()
+  return activeProject
+}
+
+export default useActiveProject

--- a/designer/src/hooks/useActiveProject.ts
+++ b/designer/src/hooks/useActiveProject.ts
@@ -22,14 +22,11 @@ export function useActiveProject(): ActiveProject | null {
         const projectName = getActiveProjectName()
         
         if (namespace && projectName) {
-          const newActiveProject = {
+          setActiveProject({
             namespace,
             project: projectName
-          }
-          console.log('🔄 Active project initialized:', newActiveProject)
-          setActiveProject(newActiveProject)
+          })
         } else {
-          console.log('⚠️ Active project cleared: missing namespace or project name')
           setActiveProject(null)
         }
       } catch (error) {

--- a/designer/src/hooks/useActiveProject.ts
+++ b/designer/src/hooks/useActiveProject.ts
@@ -67,26 +67,31 @@ export function useActiveProject(): ActiveProject | null {
 
   // Listen for custom events dispatched by setActiveProject
   useEffect(() => {
-    const handleActiveProjectChange = (e: CustomEvent<string>) => {
-      try {
-        const namespace = getCurrentNamespace()
-        const projectName = e.detail
-        
-        if (namespace && projectName) {
-          setActiveProject({
-            namespace,
-            project: projectName
-          })
-        } else {
-          setActiveProject(null)
+    const handleActiveProjectChange = (event: Event) => {
+      if (event instanceof CustomEvent && event.detail) {
+        try {
+          const projectData = event.detail
+          if (projectData && typeof projectData === 'string') {
+            const namespace = getCurrentNamespace()
+            const projectName = projectData
+            
+            if (namespace && projectName) {
+              setActiveProject({
+                namespace,
+                project: projectName
+              })
+            } else {
+              setActiveProject(null)
+            }
+          }
+        } catch (error) {
+          console.error('Failed to handle active project change:', error)
         }
-      } catch (error) {
-        console.error('Failed to handle active project change event:', error)
       }
     }
 
-    window.addEventListener('lf-active-project', handleActiveProjectChange as EventListener)
-    return () => window.removeEventListener('lf-active-project', handleActiveProjectChange as EventListener)
+    window.addEventListener('lf-active-project', handleActiveProjectChange)
+    return () => window.removeEventListener('lf-active-project', handleActiveProjectChange)
   }, [])
 
   return activeProject

--- a/designer/src/hooks/useDatasets.ts
+++ b/designer/src/hooks/useDatasets.ts
@@ -6,6 +6,8 @@ import {
   FileDeleteParams,
 } from '../types/datasets'
 
+export const DEFAULT_DATASET_LIST_STALE_TIME = 600_000 // 10 minutes
+
 /**
  * Query keys for dataset-related queries
  * Follows the pattern used in existing project hooks
@@ -37,7 +39,7 @@ export function useListDatasets(
     queryKey: datasetKeys.list(namespace, project),
     queryFn: () => datasetService.listDatasets(namespace, project),
     enabled: options?.enabled !== false && !!namespace && !!project,
-    staleTime: options?.staleTime ?? 60_000, // 1 minute default
+    staleTime: options?.staleTime ?? DEFAULT_DATASET_LIST_STALE_TIME,
   })
 }
 
@@ -242,7 +244,7 @@ export function useTaskStatus(
     refetchInterval?: number
   }
 ) {
-  const query = useQuery({
+  return useQuery({
     queryKey: ['task-status', namespace, project, taskId],
     queryFn: () => datasetService.getTaskStatus(namespace, project, taskId!),
     enabled: !!taskId && !!namespace && !!project && (options?.enabled !== false),
@@ -250,20 +252,6 @@ export function useTaskStatus(
     staleTime: 0, // Always consider stale to ensure fresh polling
     gcTime: 5 * 60 * 1000, // Keep in cache for 5 minutes after unmount
   })
-
-  // Stop polling when task is complete
-  const isComplete = query.data && (
-    query.data.state === 'SUCCESS' || 
-    query.data.state === 'FAILURE' || 
-    query.data.state === 'REVOKED'
-  )
-
-  // Disable refetching when complete by updating the query
-  if (isComplete && query.isRefetching) {
-    // The polling will naturally stop on the next interval check
-  }
-
-  return query
 }
 
 /**

--- a/designer/src/hooks/useDatasets.ts
+++ b/designer/src/hooks/useDatasets.ts
@@ -226,6 +226,110 @@ export function useUploadMultipleFiles() {
 }
 
 /**
+ * Hook to check task status with automatic polling
+ * @param namespace - The project namespace
+ * @param project - The project identifier
+ * @param taskId - The task identifier (null to disable)
+ * @param options - Additional query options
+ * @returns Query result with task status
+ */
+export function useTaskStatus(
+  namespace: string,
+  project: string,
+  taskId: string | null,
+  options?: {
+    enabled?: boolean
+    refetchInterval?: number
+  }
+) {
+  const query = useQuery({
+    queryKey: ['task-status', namespace, project, taskId],
+    queryFn: () => datasetService.getTaskStatus(namespace, project, taskId!),
+    enabled: !!taskId && !!namespace && !!project && (options?.enabled !== false),
+    refetchInterval: options?.refetchInterval || 2000, // Poll every 2 seconds by default
+    staleTime: 0, // Always consider stale to ensure fresh polling
+    gcTime: 5 * 60 * 1000, // Keep in cache for 5 minutes after unmount
+  })
+
+  // Stop polling when task is complete
+  const isComplete = query.data && (
+    query.data.state === 'SUCCESS' || 
+    query.data.state === 'FAILURE' || 
+    query.data.state === 'REVOKED'
+  )
+
+  // Disable refetching when complete by updating the query
+  if (isComplete && query.isRefetching) {
+    // The polling will naturally stop on the next interval check
+  }
+
+  return query
+}
+
+/**
+ * Hook to re-ingest a dataset (trigger reprocessing)
+ * @returns Mutation for re-ingesting datasets
+ */
+export function useReIngestDataset() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (data: {
+      namespace: string
+      project: string
+      dataset: string
+    }) =>
+      datasetService.executeDatasetAction(
+        data.namespace,
+        data.project,
+        data.dataset,
+        { action_type: 'ingest' }
+      ),
+    onSuccess: (_, variables) => {
+      // Invalidate datasets list to refresh any status changes
+      queryClient.invalidateQueries({
+        queryKey: datasetKeys.list(variables.namespace, variables.project),
+      })
+    },
+  })
+}
+
+/**
+ * Hook to delete a file from a dataset
+ * @returns Mutation for deleting files from datasets
+ */
+export function useDeleteDatasetFile() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (data: {
+      namespace: string
+      project: string
+      dataset: string
+      fileHash: string
+      removeFromDisk?: boolean
+    }) =>
+      datasetService.deleteDatasetFile(
+        data.namespace,
+        data.project,
+        data.dataset,
+        data.fileHash,
+        data.removeFromDisk ?? true
+      ),
+    onSuccess: (result, variables) => {
+      // Invalidate datasets list to refresh the files list
+      queryClient.invalidateQueries({
+        queryKey: datasetKeys.list(variables.namespace, variables.project),
+      })
+      
+    },
+    onError: (error, variables) => {
+      console.error(`Failed to delete file ${variables.fileHash}:`, error)
+    },
+  })
+}
+
+/**
  * Default export with all dataset hooks
  */
 export default {
@@ -237,5 +341,8 @@ export default {
   useUploadFileToDataset,
   useDeleteFileFromDataset,
   useUploadMultipleFiles,
+  useTaskStatus,
+  useReIngestDataset,
+  useDeleteDatasetFile,
   datasetKeys,
 }

--- a/designer/src/hooks/useDatasets.ts
+++ b/designer/src/hooks/useDatasets.ts
@@ -322,6 +322,11 @@ export function useDeleteDatasetFile() {
         queryKey: datasetKeys.list(variables.namespace, variables.project),
       })
       
+      // Result contains the deleted file details which can be accessed
+      // by the component for more specific user feedback
+      if (result?.file_hash) {
+        // File deletion confirmed - the component can access this via the mutation result
+      }
     },
     onError: (error, variables) => {
       console.error(`Failed to delete file ${variables.fileHash}:`, error)

--- a/designer/src/hooks/useDatasets.ts
+++ b/designer/src/hooks/useDatasets.ts
@@ -1,0 +1,241 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import datasetService from '../api/datasets'
+import {
+  CreateDatasetRequest,
+  DatasetActionRequest,
+  FileDeleteParams,
+} from '../types/datasets'
+
+/**
+ * Query keys for dataset-related queries
+ * Follows the pattern used in existing project hooks
+ */
+export const datasetKeys = {
+  all: ['datasets'] as const,
+  lists: () => [...datasetKeys.all, 'list'] as const,
+  list: (namespace: string, project: string) => [...datasetKeys.lists(), namespace, project] as const,
+  details: () => [...datasetKeys.all, 'detail'] as const,
+  detail: (namespace: string, project: string, dataset: string) => [...datasetKeys.details(), namespace, project, dataset] as const,
+}
+
+/**
+ * Hook to fetch all datasets in a project
+ * @param namespace - The namespace containing the project
+ * @param project - The project to fetch datasets for
+ * @param options - Additional query options
+ * @returns Query result with datasets list
+ */
+export function useListDatasets(
+  namespace: string,
+  project: string,
+  options?: {
+    enabled?: boolean
+    staleTime?: number
+  }
+) {
+  return useQuery({
+    queryKey: datasetKeys.list(namespace, project),
+    queryFn: () => datasetService.listDatasets(namespace, project),
+    enabled: options?.enabled !== false && !!namespace && !!project,
+    staleTime: options?.staleTime ?? 60_000, // 1 minute default
+  })
+}
+
+/**
+ * Hook to create a new dataset
+ * @returns Mutation for creating datasets
+ */
+export function useCreateDataset() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (data: { namespace: string; project: string } & CreateDatasetRequest) =>
+      datasetService.createDataset(data.namespace, data.project, {
+        name: data.name,
+        rag_strategy: data.rag_strategy,
+      }),
+    onSuccess: (_, variables) => {
+      // Invalidate and refetch the datasets list
+      queryClient.invalidateQueries({
+        queryKey: datasetKeys.list(variables.namespace, variables.project),
+      })
+    },
+  })
+}
+
+/**
+ * Hook to delete a dataset
+ * @returns Mutation for deleting datasets
+ */
+export function useDeleteDataset() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (data: { namespace: string; project: string; dataset: string }) =>
+      datasetService.deleteDataset(data.namespace, data.project, data.dataset),
+    onSuccess: (_, variables) => {
+      // Invalidate and refetch the datasets list
+      queryClient.invalidateQueries({
+        queryKey: datasetKeys.list(variables.namespace, variables.project),
+      })
+    },
+  })
+}
+
+/**
+ * Hook to execute dataset actions (like ingest)
+ * @returns Mutation for executing dataset actions
+ */
+export function useDatasetAction() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (data: {
+      namespace: string
+      project: string
+      dataset: string
+      request: DatasetActionRequest
+    }) =>
+      datasetService.executeDatasetAction(
+        data.namespace,
+        data.project,
+        data.dataset,
+        data.request
+      ),
+    onSuccess: (_, variables) => {
+      // Invalidate datasets list to refresh any status changes
+      queryClient.invalidateQueries({
+        queryKey: datasetKeys.list(variables.namespace, variables.project),
+      })
+    },
+  })
+}
+
+/**
+ * Hook to ingest a dataset (convenience wrapper for dataset action)
+ * @returns Mutation for ingesting datasets
+ */
+export function useIngestDataset() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (data: { namespace: string; project: string; dataset: string }) =>
+      datasetService.ingestDataset(data.namespace, data.project, data.dataset),
+    onSuccess: (_, variables) => {
+      // Invalidate datasets list to refresh any status changes
+      queryClient.invalidateQueries({
+        queryKey: datasetKeys.list(variables.namespace, variables.project),
+      })
+    },
+  })
+}
+
+/**
+ * Hook to upload files to a dataset
+ * @returns Mutation for uploading files
+ */
+export function useUploadFileToDataset() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (data: {
+      namespace: string
+      project: string
+      dataset: string
+      file: File
+    }) =>
+      datasetService.uploadFileToDataset(
+        data.namespace,
+        data.project,
+        data.dataset,
+        data.file
+      ),
+    onSuccess: (_, variables) => {
+      // Invalidate datasets list to refresh file counts
+      queryClient.invalidateQueries({
+        queryKey: datasetKeys.list(variables.namespace, variables.project),
+      })
+    },
+  })
+}
+
+/**
+ * Hook to delete files from a dataset
+ * @returns Mutation for deleting files
+ */
+export function useDeleteFileFromDataset() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (data: {
+      namespace: string
+      project: string
+      dataset: string
+      fileHash: string
+      params?: FileDeleteParams
+    }) =>
+      datasetService.deleteFileFromDataset(
+        data.namespace,
+        data.project,
+        data.dataset,
+        data.fileHash,
+        data.params
+      ),
+    onSuccess: (_, variables) => {
+      // Invalidate datasets list to refresh file counts
+      queryClient.invalidateQueries({
+        queryKey: datasetKeys.list(variables.namespace, variables.project),
+      })
+    },
+  })
+}
+
+/**
+ * Hook to upload multiple files to a dataset sequentially
+ * @returns Mutation for uploading multiple files
+ */
+export function useUploadMultipleFiles() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (data: {
+      namespace: string
+      project: string
+      dataset: string
+      files: File[]
+    }) => {
+      const results = []
+      for (const file of data.files) {
+        const result = await datasetService.uploadFileToDataset(
+          data.namespace,
+          data.project,
+          data.dataset,
+          file
+        )
+        results.push(result)
+      }
+      return results
+    },
+    onSuccess: (_, variables) => {
+      // Invalidate datasets list to refresh file counts
+      queryClient.invalidateQueries({
+        queryKey: datasetKeys.list(variables.namespace, variables.project),
+      })
+    },
+  })
+}
+
+/**
+ * Default export with all dataset hooks
+ */
+export default {
+  useListDatasets,
+  useCreateDataset,
+  useDeleteDataset,
+  useDatasetAction,
+  useIngestDataset,
+  useUploadFileToDataset,
+  useDeleteFileFromDataset,
+  useUploadMultipleFiles,
+  datasetKeys,
+}

--- a/designer/src/hooks/useProjectSwitchNavigation.ts
+++ b/designer/src/hooks/useProjectSwitchNavigation.ts
@@ -1,0 +1,41 @@
+import { useNavigate, useLocation } from 'react-router-dom'
+import { useEffect, useRef } from 'react'
+import { useActiveProject } from './useActiveProject'
+
+/**
+ * Hook that automatically navigates users away from dataset-specific pages
+ * when they switch to a different project using the project switcher.
+ * 
+ * This prevents users from being stuck on dataset pages that don't exist
+ * in the new project and provides a smooth project switching experience.
+ */
+export function useProjectSwitchNavigation() {
+  const navigate = useNavigate()
+  const location = useLocation()
+  const prevProjectRef = useRef<string | null>(null)
+  const currentProject = useActiveProject()
+  
+  // Create a unique key for the current project to detect changes
+  const currentProjectKey = currentProject 
+    ? `${currentProject.namespace}/${currentProject.project}` 
+    : null
+
+  useEffect(() => {
+    // Check if we're on a dataset-specific page (e.g., /chat/data/DatasetName)
+    const isOnDatasetPage = location.pathname.match(/^\/chat\/data\/[^/]+$/)
+    
+    // If we're on a dataset page and the project has changed (not initial load)
+    if (isOnDatasetPage && 
+        currentProjectKey && 
+        prevProjectRef.current && 
+        prevProjectRef.current !== currentProjectKey) {
+      
+      // Navigate to the new project's data overview page
+      // Using replace: true so back button works correctly
+      navigate('/chat/data', { replace: true })
+    }
+    
+    // Update the previous project reference for next comparison
+    prevProjectRef.current = currentProjectKey
+  }, [currentProjectKey, location.pathname, navigate])
+}

--- a/designer/src/types/datasets.ts
+++ b/designer/src/types/datasets.ts
@@ -89,6 +89,24 @@ export interface FileDeleteResponse {
 }
 
 /**
+ * Response from checking task status
+ */
+export interface TaskStatusResponse {
+  /** Task identifier */
+  task_id: string
+  /** Current task state */
+  state: 'PENDING' | 'SUCCESS' | 'FAILURE' | 'RETRY' | 'REVOKED'
+  /** Task metadata (progress info, etc.) */
+  meta: any | null
+  /** Task result when successful */
+  result: any | null
+  /** Error message when failed */
+  error: string | null
+  /** Error traceback when failed */
+  traceback: string | null
+}
+
+/**
  * Parameters for API calls that require path parameters
  */
 export interface DatasetPathParams {

--- a/designer/src/types/datasets.ts
+++ b/designer/src/types/datasets.ts
@@ -1,0 +1,187 @@
+/**
+ * Dataset API Types - aligned with server/api/routers/datasets/
+ * 
+ * This file contains types for Dataset API communication.
+ * These types should remain stable and aligned with the API contract.
+ */
+
+/**
+ * Core Dataset entity structure for API communication
+ * Used in responses from the datasets service
+ */
+export interface Dataset {
+  /** Dataset name within the project */
+  name: string
+  /** RAG strategy used for processing */
+  rag_strategy: string
+  /** Array of file hashes included in this dataset */
+  files: string[]
+}
+
+/**
+ * Request payload for creating a new dataset
+ */
+export interface CreateDatasetRequest {
+  /** Dataset name */
+  name: string
+  /** RAG strategy to use for processing */
+  rag_strategy: string
+}
+
+/**
+ * Response from creating a new dataset
+ */
+export interface CreateDatasetResponse {
+  /** The created dataset */
+  dataset: Dataset
+}
+
+/**
+ * Response from listing datasets in a project
+ */
+export interface ListDatasetsResponse {
+  /** Total number of datasets */
+  total: number
+  /** Array of datasets */
+  datasets: Dataset[]
+}
+
+/**
+ * Response from deleting a dataset
+ */
+export interface DeleteDatasetResponse {
+  /** The deleted dataset */
+  dataset: Dataset
+}
+
+/**
+ * Request payload for executing dataset actions
+ */
+export interface DatasetActionRequest {
+  /** Type of action to execute (currently only 'ingest') */
+  action_type: 'ingest'
+}
+
+/**
+ * Response from executing a dataset action
+ */
+export interface DatasetActionResponse {
+  /** Status message */
+  message: 'Accepted'
+  /** URI for tracking the task */
+  task_uri: string
+}
+
+/**
+ * Response from uploading a file to a dataset
+ */
+export interface FileUploadResponse {
+  /** Name of the uploaded file */
+  filename: string
+}
+
+/**
+ * Response from deleting a file from a dataset
+ */
+export interface FileDeleteResponse {
+  /** Hash of the deleted file */
+  file_hash: string
+}
+
+/**
+ * Parameters for API calls that require path parameters
+ */
+export interface DatasetPathParams {
+  /** Project namespace */
+  namespace: string
+  /** Project identifier */
+  project: string
+  /** Dataset name */
+  dataset?: string
+  /** File hash for file-specific operations */
+  file_hash?: string
+}
+
+/**
+ * Query parameters for file deletion
+ */
+export interface FileDeleteParams {
+  /** Whether to remove the file from disk (optional) */
+  remove_from_disk?: boolean
+}
+
+/**
+ * Standard error response structure
+ */
+export interface DatasetApiError {
+  /** Error detail message */
+  detail?: string
+}
+
+/**
+ * Base error classes for Dataset API operations
+ */
+export class DatasetError extends Error {
+  constructor(message: string, public statusCode?: number, public data?: any) {
+    super(message)
+    this.name = 'DatasetError'
+  }
+}
+
+export class DatasetValidationError extends DatasetError {
+  constructor(message: string, data?: any) {
+    super(message, 422, data)
+    this.name = 'DatasetValidationError'
+  }
+}
+
+export class DatasetNotFoundError extends DatasetError {
+  constructor(message: string, data?: any) {
+    super(message, 404, data)
+    this.name = 'DatasetNotFoundError'
+  }
+}
+
+export class DatasetNetworkError extends DatasetError {
+  constructor(message: string, originalError?: any) {
+    super(message, undefined, originalError)
+    this.name = 'DatasetNetworkError'
+  }
+}
+
+/**
+ * Frontend-specific Dataset type with additional UI properties
+ * This extends the API Dataset type with local state management fields
+ */
+export interface UIDataset extends Dataset {
+  /** Local UI identifier */
+  id: string
+  /** Last run timestamp for UI display */
+  lastRun: Date
+  /** Embedding model used */
+  embedModel: string
+  /** Number of chunks processed */
+  numChunks: number
+  /** Processing percentage (0-100) */
+  processedPercent: number
+  /** Version identifier */
+  version: string
+  /** Optional description */
+  description?: string
+}
+
+/**
+ * Frontend File representation for UI components
+ */
+export interface UIFile {
+  /** Stable identifier for the file */
+  id: string
+  /** File name */
+  name: string
+  /** File size in bytes */
+  size: number
+  /** Last modified timestamp */
+  lastModified: number
+  /** MIME type (optional) */
+  type?: string
+}

--- a/designer/src/types/index.ts
+++ b/designer/src/types/index.ts
@@ -1,5 +1,7 @@
 // Re-export all types for easy importing
 export * from './chat'
+export * from './datasets'
+export * from './project'
 // declare module '*.svg?react' {
 //   import React from 'react'
 //   const ReactComponent: React.FunctionComponent<React.SVGProps<SVGSVGElement>>


### PR DESCRIPTION
## Summary by Sourcery

Integrate the designer’s data components with the backend API by adding React Query hooks and an API client for all dataset and file operations, replace localStorage fallbacks with server-driven data, and improve UI feedback with toasts, loading states, and confirmation dialogs while supporting project context and automatic navigation.

New Features:
- Add React Query hooks and API client for dataset operations including list, create, delete, ingest, upload files, reingest, delete files, and track task status
- Connect Data and DatasetView components to the backend API for fetching and mutating datasets and files instead of using localStorage
- Implement useActiveProject hook to provide global namespace/project context and useProjectSwitchNavigation hook to handle automatic navigation on project change
- Enhance UI feedback with toast notifications, loading states, and confirmation dialogs for dataset and file operations

Enhancements:
- Refactor dataset components to leverage API-driven data and mutations, removing localStorage persistence logic
- Introduce typed API service layer and associated TypeScript types for datasets and files

<!-- CLI_COVERAGE_START -->

### CLI Coverage

| File | Lines (cov/total) | Functions (cov/total) | Statements (cov/total) |
|---|---:|---:|---:|
| llamafarm-cli/cmd/chat_client.go | 102/153 (66.7%) | 0/5 (0.0%) | 74/224 (33.0%) |
| llamafarm-cli/cmd/config/schema.go | 0/62 (0.0%) | 0/2 (0.0%) | 0/76 (0.0%) |
| llamafarm-cli/cmd/config/types.go | 86/141 (61.0%) | 0/8 (0.0%) | 52/174 (29.9%) |
| llamafarm-cli/cmd/datasets.go | 20/249 (8.0%) | 0/3 (0.0%) | 10/376 (2.7%) |
| llamafarm-cli/cmd/designer.go | 7/54 (13.0%) | 0/2 (0.0%) | 2/58 (3.4%) |
| llamafarm-cli/cmd/dev.go | 7/15 (46.7%) | 0/1 (0.0%) | 3/16 (18.8%) |
| llamafarm-cli/cmd/docker_utils.go | 27/33 (81.8%) | 0/4 (0.0%) | 20/46 (43.5%) |
| llamafarm-cli/cmd/httpclient.go | 54/78 (69.2%) | 0/5 (0.0%) | 35/100 (35.0%) |
| llamafarm-cli/cmd/init.go | 5/97 (5.2%) | 0/1 (0.0%) | 3/134 (2.2%) |
| llamafarm-cli/cmd/log.go | 20/31 (64.5%) | 0/3 (0.0%) | 14/40 (35.0%) |
| llamafarm-cli/cmd/models.go | 3/7 (42.9%) | 0/1 (0.0%) | 1/6 (16.7%) |
| llamafarm-cli/cmd/projects.go | 10/70 (14.3%) | 0/1 (0.0%) | 3/82 (3.7%) |
| llamafarm-cli/cmd/rag.go | 3/7 (42.9%) | 0/1 (0.0%) | 1/6 (16.7%) |
| llamafarm-cli/cmd/root.go | 7/28 (25.0%) | 0/3 (0.0%) | 4/34 (11.8%) |
| llamafarm-cli/cmd/run.go | 4/95 (4.2%) | 0/1 (0.0%) | 2/106 (1.9%) |
| llamafarm-cli/cmd/server_utils.go | 55/153 (35.9%) | 0/7 (0.0%) | 42/202 (20.8%) |
| llamafarm-cli/cmd/tui_chat.go | 0/236 (0.0%) | 0/10 (0.0%) | 0/336 (0.0%) |
| llamafarm-cli/cmd/url_utils.go | 9/9 (100.0%) | 0/1 (0.0%) | 6/12 (50.0%) |
| llamafarm-cli/cmd/version.go | 3/6 (50.0%) | 0/1 (0.0%) | 1/4 (25.0%) |
| llamafarm-cli/main.go | 0/3 (0.0%) | 0/1 (0.0%) | 0/3 (0.0%) |
| llamafarm-cli/tools/copy/main.go | 0/22 (0.0%) | 0/1 (0.0%) | 0/42 (0.0%) |
| llamafarm-cli/tools/cover2lcov/main.go | 0/86 (0.0%) | 0/1 (0.0%) | 0/204 (0.0%) |
| llamafarm-cli/tools/coverreport/main.go | 0/177 (0.0%) | 0/2 (0.0%) | 0/381 (0.0%) |
| total | 422/1812 (23.3%) | 0/65 (0.0%) | 273/2662 (10.3%) |

<!-- CLI_COVERAGE_END -->