### PR TITLE
fix(server): fix celery logging configuration

### DIFF
--- a/server/core/celery/celery.py
+++ b/server/core/celery/celery.py
@@ -1,12 +1,43 @@
+import os
 import threading
 
-from celery import Celery  # type: ignore
+from celery import Celery, signals
 
-app = Celery(
-    "LlamaFarm",
-    broker="memory://localhost",  # in-process broker
-    backend="cache+memory://localhost",  # in-process result backend
+from core.settings import settings
+
+app = Celery("LlamaFarm")
+
+
+_folders = [
+    f"{settings.lf_data_dir}/broker/in",
+    f"{settings.lf_data_dir}/broker/processed",
+    f"{settings.lf_data_dir}/broker/results",
+]
+
+for folder in _folders:
+    os.makedirs(folder, exist_ok=True)
+
+app.conf.update(
+    {
+        "broker_url": "filesystem://",
+        "broker_transport_options": {
+            "data_folder_in": f"{settings.lf_data_dir}/broker/in",
+            "data_folder_out": f"{settings.lf_data_dir}/broker/in",  # has to be the same as 'data_folder_in'  # noqa: E501
+            "data_folder_processed": f"{settings.lf_data_dir}/broker/processed",
+        },
+        "result_backend": f"file://{settings.lf_data_dir}/broker/results",
+        "result_persistent": True,
+    }
 )
+
+
+# Intentionally empty function to prevent Celery from overriding root logger config
+@signals.setup_logging.connect
+def setup_celery_logging(**kwargs):
+    pass
+
+
+# app.log.setup()
 
 # Create a thread and run the worker in it. This is not a long-term solution.
 # Eventually we should use a proper broker and backend for this like Redis and

--- a/server/main.py
+++ b/server/main.py
@@ -16,12 +16,12 @@ os.makedirs(os.path.join(settings.lf_data_dir, "projects"), exist_ok=True)
 app = llama_farm_api()
 
 if __name__ == "__main__":
-  uvicorn.run(
-    "server.main:app",
-    host="0.0.0.0",
-    port=8000,
-    reload=True,
-    reload_dirs=["../"],
-    log_config=None,  # Disable uvicorn's log config (handled in setup_logging)
-    access_log=False, # Disable uvicorn access logs (handled by StructLogMiddleware)
-  )
+    uvicorn.run(
+        "server.main:app",
+        host="0.0.0.0",
+        port=8000,
+        reload=True,
+        reload_dirs=["../"],
+        log_config=None,  # Disable uvicorn's log config (handled in setup_logging)
+        access_log=False,  # Disable uvicorn access logs (handled by StructLogMiddleware)
+    )


### PR DESCRIPTION
## Summary by Sourcery

Reconfigure Celery to use a filesystem-based broker and file-backed result backend with dynamic data directories, add a stub for custom logging setup, and relax the atomic-agents version pinning.

Enhancements:
- Switch Celery broker to filesystem transport and result backend to file storage via app.conf
- Automatically create broker in, processed, and result folders under the configured data directory
- Add a no-op setup_logging signal handler to enable custom Celery logging integration

Build:
- Loosen atomic-agents dependency to >=2.1.0 in pyproject.toml

<!-- CLI_COVERAGE_START -->

### CLI Coverage

| File | Lines (cov/total) | Functions (cov/total) | Statements (cov/total) |
|---|---:|---:|---:|
| llamafarm-cli/cmd/chat_client.go | 102/153 (66.7%) | 0/5 (0.0%) | 74/224 (33.0%) |
| llamafarm-cli/cmd/config/schema.go | 0/62 (0.0%) | 0/2 (0.0%) | 0/76 (0.0%) |
| llamafarm-cli/cmd/config/types.go | 86/141 (61.0%) | 0/8 (0.0%) | 52/174 (29.9%) |
| llamafarm-cli/cmd/datasets.go | 20/249 (8.0%) | 0/3 (0.0%) | 10/376 (2.7%) |
| llamafarm-cli/cmd/designer.go | 7/54 (13.0%) | 0/2 (0.0%) | 2/58 (3.4%) |
| llamafarm-cli/cmd/dev.go | 7/15 (46.7%) | 0/1 (0.0%) | 3/16 (18.8%) |
| llamafarm-cli/cmd/docker_utils.go | 27/33 (81.8%) | 0/4 (0.0%) | 20/46 (43.5%) |
| llamafarm-cli/cmd/httpclient.go | 54/78 (69.2%) | 0/5 (0.0%) | 35/100 (35.0%) |
| llamafarm-cli/cmd/init.go | 5/97 (5.2%) | 0/1 (0.0%) | 3/134 (2.2%) |
| llamafarm-cli/cmd/log.go | 20/31 (64.5%) | 0/3 (0.0%) | 14/40 (35.0%) |
| llamafarm-cli/cmd/models.go | 3/7 (42.9%) | 0/1 (0.0%) | 1/6 (16.7%) |
| llamafarm-cli/cmd/projects.go | 10/70 (14.3%) | 0/1 (0.0%) | 3/82 (3.7%) |
| llamafarm-cli/cmd/rag.go | 3/7 (42.9%) | 0/1 (0.0%) | 1/6 (16.7%) |
| llamafarm-cli/cmd/root.go | 7/28 (25.0%) | 0/3 (0.0%) | 4/34 (11.8%) |
| llamafarm-cli/cmd/run.go | 4/95 (4.2%) | 0/1 (0.0%) | 2/106 (1.9%) |
| llamafarm-cli/cmd/server_utils.go | 55/153 (35.9%) | 0/7 (0.0%) | 42/202 (20.8%) |
| llamafarm-cli/cmd/tui_chat.go | 0/236 (0.0%) | 0/10 (0.0%) | 0/336 (0.0%) |
| llamafarm-cli/cmd/url_utils.go | 9/9 (100.0%) | 0/1 (0.0%) | 6/12 (50.0%) |
| llamafarm-cli/cmd/version.go | 3/6 (50.0%) | 0/1 (0.0%) | 1/4 (25.0%) |
| llamafarm-cli/main.go | 0/3 (0.0%) | 0/1 (0.0%) | 0/3 (0.0%) |
| llamafarm-cli/tools/copy/main.go | 0/22 (0.0%) | 0/1 (0.0%) | 0/42 (0.0%) |
| llamafarm-cli/tools/cover2lcov/main.go | 0/86 (0.0%) | 0/1 (0.0%) | 0/204 (0.0%) |
| llamafarm-cli/tools/coverreport/main.go | 0/177 (0.0%) | 0/2 (0.0%) | 0/381 (0.0%) |
| total | 422/1812 (23.3%) | 0/65 (0.0%) | 273/2662 (10.3%) |

<!-- CLI_COVERAGE_END -->