### PR TITLE
chore: publish docker images during release

### DIFF
--- a/.github/workflows/cli-installer.yml
+++ b/.github/workflows/cli-installer.yml
@@ -11,7 +11,7 @@ on:
       - 'install.sh'
       - 'cli/**'
       - 'cli/hack/**'
-      - '.github/workflows/cli-release.yml'
+      - '.github/workflows/release-cli.yml'
       - '.github/workflows/cli-installer.yml'
   push:
     branches: [main]
@@ -19,7 +19,7 @@ on:
       - 'install.sh'
       - 'cli/**'
       - 'cli/hack/**'
-      - '.github/workflows/cli-release.yml'
+      - '.github/workflows/release-cli.yml'
       - '.github/workflows/test-installer.yml'
   workflow_dispatch:
 

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -3,7 +3,6 @@ name: Build CLI
 on:
   push:
     branches: [ main ]
-    tags: [ 'v*' ]
   pull_request:
     branches: [ main ]
     paths:
@@ -117,32 +116,3 @@ jobs:
           name: checksums
           path: dist/checksums.txt
           retention-days: 30
-
-  # Create GitHub release on tag push
-  create-release:
-    name: Upload Release Assets
-    runs-on: ubuntu-latest
-    needs: [build-cli, create-checksums]
-    if: startsWith(github.ref, 'refs/tags/')
-    permissions:
-      contents: write
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Download all artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: dist/
-          merge-multiple: true
-
-      - name: Create Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ github.ref_name }}
-          files: |
-            dist/llamafarm-*
-            dist/checksums.txt
-          fail_on_unmatched_files: true
-          append_body: true

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,4 +1,4 @@
-name: Build and Release CLI
+name: Release - CLI
 
 on:
   release:
@@ -19,7 +19,7 @@ env:
   BINARY_NAME: lf
 
 jobs:
-  build:
+  build-cli:
     name: Build CLI Binaries
     runs-on: ubuntu-latest
     strategy:
@@ -99,9 +99,9 @@ jobs:
           name: "${{ steps.build.outputs.binary_name }}"
           path: cli/${{ steps.build.outputs.binary_name }}
 
-  test-install:
+  test-cli-install:
     name: Test Installation Script
-    needs: build
+    needs: build-cli
     runs-on: ${{ matrix.os }}
     if: github.event_name == 'release'
     strategy:

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -1,0 +1,78 @@
+name: Release - Docker images
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to build (e.g., v1.0.0)'
+        required: true
+        default: 'v1.0.0'
+
+jobs:
+  tag-docker-images:
+    name: Tag Docker Images
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Tag Docker images
+        env:
+          REGISTRY: ghcr.io
+          IMAGE_NAME: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Determine the release tag
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            TAG="${{ github.event.inputs.version }}"
+          else
+            TAG="${{ github.event.release.tag_name }}"
+          fi
+          echo "Release tag: ${TAG}"
+
+          # Resolve commit SHA for the tag
+          FULL_SHA=$(git rev-list -n 1 "${TAG}")
+          SHORT_SHA=${FULL_SHA:0:7}
+          echo "Full SHA: ${FULL_SHA} | Short SHA: ${SHORT_SHA}"
+
+          # Login to GHCR
+          echo "Logging in to GHCR"
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login "${REGISTRY}" -u "${{ github.actor }}" --password-stdin
+
+          # Services to retag
+          SERVICES=(designer server runtime)
+
+          # Try main-<fullsha> first, then main-<shortsha>
+          for SERVICE in "${SERVICES[@]}"; do
+            SRC1="${REGISTRY}/${IMAGE_NAME}/${SERVICE}:main-${FULL_SHA}"
+            SRC2="${REGISTRY}/${IMAGE_NAME}/${SERVICE}:main-${SHORT_SHA}"
+            DST="${REGISTRY}/${IMAGE_NAME}/${SERVICE}:${TAG}"
+
+            echo "Attempting to retag ${SERVICE} from ${SRC1} -> ${DST}"
+            if docker pull "${SRC1}"; then
+              docker tag "${SRC1}" "${DST}"
+              docker push "${DST}"
+              echo "Retagged ${SERVICE} using full SHA"
+              continue
+            fi
+
+            echo "Full SHA tag not found, trying short SHA: ${SRC2}"
+            if docker pull "${SRC2}"; then
+              docker tag "${SRC2}" "${DST}"
+              docker push "${DST}"
+              echo "Retagged ${SERVICE} using short SHA"
+              continue
+            fi
+
+            echo "ERROR: Could not find source image for ${SERVICE} with either ${SRC1} or ${SRC2}" >&2
+            exit 1
+          done
+
+          echo "Docker images retagged for ${TAG}"

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -11,6 +11,10 @@ on:
         required: true
         default: 'v1.0.0'
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   tag-docker-images:
     name: Tag Docker Images
@@ -21,6 +25,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Tag Docker images
         env:

--- a/cli/hack/test-installer-docker.sh
+++ b/cli/hack/test-installer-docker.sh
@@ -234,7 +234,7 @@ test_documentation() {
         "install.sh"
         "INSTALL.md"
         "cli/README.md"
-        ".github/workflows/cli-release.yml"
+        ".github/workflows/release-cli.yml"
     )
 
     for file in "${required_files[@]}"; do

--- a/cli/hack/test-installer-quick.sh
+++ b/cli/hack/test-installer-quick.sh
@@ -283,7 +283,7 @@ test_documentation() {
         "install.sh"
         "INSTALL.md"
         "cli/README.md"
-        ".github/workflows/cli-release.yml"
+        ".github/workflows/release-cli.yml"
     )
 
     local missing_files=()


### PR DESCRIPTION
## Summary by Sourcery

Refine CI workflows by extracting CLI release steps, removing tag-based triggers, renaming jobs, and introducing a dedicated Docker image release workflow.

CI:
- Remove tag trigger and GitHub release asset upload from the main CLI build workflow
- Rename and restructure the CLI release workflow (release-cli.yml) with updated job names and triggers
- Add a new workflow (release-docker.yml) to retag and publish Docker service images to GHCR on release or manual dispatch

<!-- CLI_COVERAGE_START -->

### CLI Coverage

| File | Lines (cov/total) | Functions (cov/total) | Statements (cov/total) |
|---|---:|---:|---:|
| llamafarm-cli/cmd/chat_client.go | 138/220 (62.7%) | 0/7 (0.0%) | 97/306 (31.7%) |
| llamafarm-cli/cmd/config/config.go | 109/162 (67.3%) | 0/12 (0.0%) | 62/190 (32.6%) |
| llamafarm-cli/cmd/config/schema.go | 0/62 (0.0%) | 0/2 (0.0%) | 0/76 (0.0%) |
| llamafarm-cli/cmd/datasets.go | 20/249 (8.0%) | 0/3 (0.0%) | 10/376 (2.7%) |
| llamafarm-cli/cmd/designer.go | 7/46 (15.2%) | 0/1 (0.0%) | 2/48 (4.2%) |
| llamafarm-cli/cmd/dev.go | 4/26 (15.4%) | 0/1 (0.0%) | 1/32 (3.1%) |
| llamafarm-cli/cmd/docker_utils.go | 27/33 (81.8%) | 0/4 (0.0%) | 20/46 (43.5%) |
| llamafarm-cli/cmd/httpclient.go | 54/78 (69.2%) | 0/5 (0.0%) | 35/100 (35.0%) |
| llamafarm-cli/cmd/init.go | 5/97 (5.2%) | 0/1 (0.0%) | 3/138 (2.2%) |
| llamafarm-cli/cmd/log.go | 33/43 (76.7%) | 0/3 (0.0%) | 20/54 (37.0%) |
| llamafarm-cli/cmd/models.go | 3/7 (42.9%) | 0/1 (0.0%) | 1/6 (16.7%) |
| llamafarm-cli/cmd/projects.go | 10/70 (14.3%) | 0/1 (0.0%) | 3/82 (3.7%) |
| llamafarm-cli/cmd/rag.go | 3/7 (42.9%) | 0/1 (0.0%) | 1/6 (16.7%) |
| llamafarm-cli/cmd/root.go | 13/47 (27.7%) | 0/3 (0.0%) | 9/60 (15.0%) |
| llamafarm-cli/cmd/run.go | 4/95 (4.2%) | 0/1 (0.0%) | 2/106 (1.9%) |
| llamafarm-cli/cmd/server_utils.go | 60/149 (40.3%) | 0/6 (0.0%) | 45/198 (22.7%) |
| llamafarm-cli/cmd/tui_chat.go | 0/255 (0.0%) | 0/10 (0.0%) | 0/368 (0.0%) |
| llamafarm-cli/cmd/url_utils.go | 9/9 (100.0%) | 0/1 (0.0%) | 6/12 (50.0%) |
| llamafarm-cli/cmd/version.go | 3/6 (50.0%) | 0/1 (0.0%) | 1/4 (25.0%) |
| llamafarm-cli/cmd/watcher.go | 0/157 (0.0%) | 0/2 (0.0%) | 0/212 (0.0%) |
| llamafarm-cli/main.go | 0/3 (0.0%) | 0/1 (0.0%) | 0/3 (0.0%) |
| llamafarm-cli/tools/copy/main.go | 0/22 (0.0%) | 0/1 (0.0%) | 0/42 (0.0%) |
| llamafarm-cli/tools/cover2lcov/main.go | 0/86 (0.0%) | 0/1 (0.0%) | 0/204 (0.0%) |
| llamafarm-cli/tools/coverreport/main.go | 0/177 (0.0%) | 0/2 (0.0%) | 0/381 (0.0%) |
| total | 502/2106 (23.8%) | 0/71 (0.0%) | 318/3050 (10.4%) |

<!-- CLI_COVERAGE_END -->