### PR TITLE
Test and chat designer experience

### DIFF
--- a/designer/Dockerfile
+++ b/designer/Dockerfile
@@ -25,7 +25,6 @@ COPY . .
 # npm recommends reinstalling without lock after copying sources
 RUN npm cache clean --force \
     && rm -rf node_modules package-lock.json \
-    && npm pkg set dependencies.@radix-ui/react-checkbox=^1.1.4 dependencies.@radix-ui/react-switch=^1.1.4 \
     && npm install --legacy-peer-deps
 
 # Build

--- a/designer/Dockerfile
+++ b/designer/Dockerfile
@@ -25,6 +25,7 @@ COPY . .
 # npm recommends reinstalling without lock after copying sources
 RUN npm cache clean --force \
     && rm -rf node_modules package-lock.json \
+    && npm pkg set dependencies.@radix-ui/react-checkbox=^1.1.4 dependencies.@radix-ui/react-switch=^1.1.4 \
     && npm install --legacy-peer-deps
 
 # Build

--- a/designer/dist/index.html
+++ b/designer/dist/index.html
@@ -9,11 +9,11 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
     <title>Designer</title>
-    <script type="module" crossorigin src="/assets/index-BkaaUr1b.js"></script>
+    <script type="module" crossorigin src="/assets/index-CFd46ctS.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/react-vendor-DIkOdxEs.js">
-    <link rel="modulepreload" crossorigin href="/assets/ui-vendor-D62gZNfd.js">
-    <link rel="modulepreload" crossorigin href="/assets/utils-vendor-5QGq_n-e.js">
-    <link rel="stylesheet" crossorigin href="/assets/index-C2Edumf7.css">
+    <link rel="modulepreload" crossorigin href="/assets/ui-vendor-z1KV6gpS.js">
+    <link rel="modulepreload" crossorigin href="/assets/utils-vendor-B14GXoRL.js">
+    <link rel="stylesheet" crossorigin href="/assets/index-_XcJTCdI.css">
   </head>
   <body>
     <div id="root"></div>

--- a/designer/package-lock.json
+++ b/designer/package-lock.json
@@ -16,10 +16,12 @@
         "@codemirror/theme-one-dark": "^6.1.3",
         "@codemirror/view": "^6.38.2",
         "@lezer/highlight": "^1.2.1",
+        "@radix-ui/react-checkbox": "^1.1.4",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-slot": "^1.2.3",
+        "@radix-ui/react-switch": "^1.1.4",
         "@tanstack/react-query": "^5.85.5",
         "axios": "^1.11.0",
         "lucide-react": "^0.539.0",
@@ -1328,6 +1330,36 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-checkbox": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.3.tgz",
+      "integrity": "sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-collection": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
@@ -1764,6 +1796,35 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-switch": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.2.6.tgz",
+      "integrity": "sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-use-callback-ref": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
@@ -1838,6 +1899,21 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
       "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",

--- a/designer/package.json
+++ b/designer/package.json
@@ -24,6 +24,8 @@
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-slot": "^1.2.3",
+    "@radix-ui/react-checkbox": "^1.1.4",
+    "@radix-ui/react-switch": "^1.1.4",
     "@tanstack/react-query": "^5.85.5",
     "axios": "^1.11.0",
     "lucide-react": "^0.539.0",

--- a/designer/src/Chat.tsx
+++ b/designer/src/Chat.tsx
@@ -1,9 +1,17 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import Chatbox from './components/Chatbox/Chatbox'
-import { Outlet } from 'react-router-dom'
+import { Outlet, useLocation } from 'react-router-dom'
 
 function Chat() {
   const [isPanelOpen, setIsPanelOpen] = useState<boolean>(true)
+  const location = useLocation()
+
+  // Close the designer chat panel when viewing the Test page
+  useEffect(() => {
+    if (location.pathname.startsWith('/chat/test')) {
+      setIsPanelOpen(false)
+    }
+  }, [location.pathname])
 
   return (
     <div className="w-full h-full flex transition-colors bg-gray-200 dark:bg-blue-800 pt-12">

--- a/designer/src/Chat.tsx
+++ b/designer/src/Chat.tsx
@@ -1,15 +1,21 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import Chatbox from './components/Chatbox/Chatbox'
 import { Outlet, useLocation } from 'react-router-dom'
 
 function Chat() {
   const [isPanelOpen, setIsPanelOpen] = useState<boolean>(true)
   const location = useLocation()
+  const prevPanelOpenRef = useRef<boolean>(true)
 
-  // Close the designer chat panel when viewing the Test page
+  // Close the designer chat panel when viewing the Test page, and restore previous state when leaving
   useEffect(() => {
     if (location.pathname.startsWith('/chat/test')) {
+      // Save current state before closing
+      prevPanelOpenRef.current = isPanelOpen
       setIsPanelOpen(false)
+    } else {
+      // Restore previous state when leaving /chat/test
+      setIsPanelOpen(prevPanelOpenRef.current)
     }
   }, [location.pathname])
 

--- a/designer/src/components/Chatbox/Chatbox.tsx
+++ b/designer/src/components/Chatbox/Chatbox.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useCallback } from 'react'
+import { useEffect, useRef, useCallback, useState } from 'react'
 import Message from './Message'
 import FontIcon from '../../common/FontIcon'
 import useChatbox from '../../hooks/useChatbox'
@@ -9,6 +9,7 @@ interface ChatboxProps {
 }
 
 function Chatbox({ isPanelOpen, setIsPanelOpen }: ChatboxProps) {
+  const [isDiagnosing, setIsDiagnosing] = useState<boolean>(false)
   // Use the custom chatbox hook for all chat logic
   const {
     messages,
@@ -98,12 +99,15 @@ function Chatbox({ isPanelOpen, setIsPanelOpen }: ChatboxProps) {
     const onDiagnose = async (e: Event) => {
       const detail = (e as CustomEvent).detail as any
       try {
+        setIsDiagnosing(true)
         setIsPanelOpen(true)
         const message = composeDiagnoseMessage(detail)
         if (message && message.trim()) {
           await sendMessage(message)
           updateInput('')
         }
+        // keep the diagnose indicator visible briefly
+        setTimeout(() => setIsDiagnosing(false), 800)
       } catch {}
     }
 
@@ -133,6 +137,12 @@ function Chatbox({ isPanelOpen, setIsPanelOpen }: ChatboxProps) {
           handleOnClick={() => setIsPanelOpen(!isPanelOpen)}
         />
       </div>
+      {isPanelOpen && isDiagnosing && (
+        <div className="mx-4 mb-2 flex items-center gap-2 text-xs text-muted-foreground">
+          <span className="inline-block h-3 w-3 animate-spin rounded-full border-2 border-teal-500 border-t-transparent" />
+          <span>Diagnosing…</span>
+        </div>
+      )}
 
       {/* Error display */}
       {error && isPanelOpen && (

--- a/designer/src/components/Chatbox/Chatbox.tsx
+++ b/designer/src/components/Chatbox/Chatbox.tsx
@@ -10,6 +10,7 @@ interface ChatboxProps {
 
 function Chatbox({ isPanelOpen, setIsPanelOpen }: ChatboxProps) {
   const [isDiagnosing, setIsDiagnosing] = useState<boolean>(false)
+  const diagnosingInFlightRef = useRef<boolean>(false)
   // Use the custom chatbox hook for all chat logic
   const {
     messages,
@@ -99,6 +100,9 @@ function Chatbox({ isPanelOpen, setIsPanelOpen }: ChatboxProps) {
     const onDiagnose = async (e: Event) => {
       const detail = (e as CustomEvent).detail as any
       try {
+        // Prevent overlapping diagnoses if events fire rapidly
+        if (diagnosingInFlightRef.current) return
+        diagnosingInFlightRef.current = true
         setIsDiagnosing(true)
         setIsPanelOpen(true)
         const message = composeDiagnoseMessage(detail)
@@ -107,7 +111,10 @@ function Chatbox({ isPanelOpen, setIsPanelOpen }: ChatboxProps) {
           updateInput('')
         }
         // keep the diagnose indicator visible briefly
-        setTimeout(() => setIsDiagnosing(false), 800)
+        setTimeout(() => {
+          setIsDiagnosing(false)
+          diagnosingInFlightRef.current = false
+        }, 800)
       } catch {}
     }
 
@@ -137,7 +144,7 @@ function Chatbox({ isPanelOpen, setIsPanelOpen }: ChatboxProps) {
           handleOnClick={() => setIsPanelOpen(!isPanelOpen)}
         />
       </div>
-      {isPanelOpen && isDiagnosing && (
+      {isDiagnosing && (
         <div className="mx-4 mb-2 flex items-center gap-2 text-xs text-muted-foreground">
           <span className="inline-block h-3 w-3 animate-spin rounded-full border-2 border-teal-500 border-t-transparent" />
           <span>Diagnosing…</span>

--- a/designer/src/components/Test.tsx
+++ b/designer/src/components/Test.tsx
@@ -240,6 +240,21 @@ const Test = () => {
     const v = localStorage.getItem('lf_test_showReferences')
     return v == null ? true : v === 'true'
   })
+  const [showGenSettings, setShowGenSettings] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false
+    const v = localStorage.getItem('lf_test_showGenSettings')
+    return v == null ? false : v === 'true'
+  })
+  const [showPrompts, setShowPrompts] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false
+    const v = localStorage.getItem('lf_test_showPrompts')
+    return v == null ? false : v === 'true'
+  })
+  const [showThinking, setShowThinking] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false
+    const v = localStorage.getItem('lf_test_showThinking')
+    return v == null ? false : v === 'true'
+  })
   const [allowRanking, setAllowRanking] = useState<boolean>(() => {
     if (typeof window === 'undefined') return true
     const v = localStorage.getItem('lf_test_allowRanking')
@@ -256,6 +271,18 @@ const Test = () => {
     if (typeof window === 'undefined') return
     localStorage.setItem('lf_test_showReferences', String(showReferences))
   }, [showReferences])
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    localStorage.setItem('lf_test_showGenSettings', String(showGenSettings))
+  }, [showGenSettings])
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    localStorage.setItem('lf_test_showPrompts', String(showPrompts))
+  }, [showPrompts])
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    localStorage.setItem('lf_test_showThinking', String(showThinking))
+  }, [showThinking])
   useEffect(() => {
     if (typeof window === 'undefined') return
     localStorage.setItem('lf_test_allowRanking', String(allowRanking))
@@ -277,6 +304,17 @@ const Test = () => {
           </div>
         </div>
         <div className="flex items-center gap-3">
+          <div className="flex items-center gap-2 text-sm mr-1">
+            <span className="text-muted-foreground">Use test data</span>
+            <Switch
+              checked={useTestData}
+              onCheckedChange={v => setUseTestData(Boolean(v))}
+              aria-label="Use test data"
+            />
+            <span className="text-muted-foreground">
+              {useTestData ? 'On' : 'Off'}
+            </span>
+          </div>
           <ModeToggle mode={mode} onToggle={setMode} />
           <Button variant="outline" size="sm" onClick={openPackageModal}>
             Package
@@ -287,25 +325,41 @@ const Test = () => {
       {/* Settings bar */}
       <div className="mb-4 flex items-start gap-4">
         <div className="flex-1 rounded-xl bg-muted/30 border border-border h-11 px-4 flex items-center justify-between">
-          <label className="inline-flex items-center gap-3 text-sm">
-            <Checkbox
-              id="show-processed"
-              checked={showReferences}
-              onCheckedChange={v => setShowReferences(Boolean(v))}
-            />
-            <span>Show referenced chunks</span>
-          </label>
+          <div className="flex items-center gap-6 text-sm">
+            <label className="inline-flex items-center gap-2">
+              <Checkbox
+                id="show-processed"
+                checked={showReferences}
+                onCheckedChange={v => setShowReferences(Boolean(v))}
+              />
+              <span>Show referenced chunks</span>
+            </label>
+            <label className="inline-flex items-center gap-2">
+              <Checkbox
+                id="show-prompts"
+                checked={showPrompts}
+                onCheckedChange={v => setShowPrompts(Boolean(v))}
+              />
+              <span>Show prompts sent</span>
+            </label>
+            <label className="inline-flex items-center gap-2">
+              <Checkbox
+                id="show-thinking"
+                checked={showThinking}
+                onCheckedChange={v => setShowThinking(Boolean(v))}
+              />
+              <span>Show thinking steps</span>
+            </label>
+            <label className="inline-flex items-center gap-2">
+              <Checkbox
+                id="show-gen-settings"
+                checked={showGenSettings}
+                onCheckedChange={v => setShowGenSettings(Boolean(v))}
+              />
+              <span>Show generation settings</span>
+            </label>
+          </div>
           <div className="flex items-center gap-3 text-sm">
-            <span className="text-muted-foreground">Use test data</span>
-            <Switch
-              checked={useTestData}
-              onCheckedChange={v => setUseTestData(Boolean(v))}
-              aria-label="Use test data"
-            />
-            <span className="text-muted-foreground">
-              {useTestData ? 'On' : 'Off'}
-            </span>
-            <span className="mx-2 h-5 w-px bg-border" />
             <span className="text-muted-foreground">Allow ranking</span>
             <Switch
               checked={allowRanking}
@@ -352,9 +406,14 @@ const Test = () => {
           ) : (
             <div className="h-full">
               <TestChat
-                showReferences={showReferences}
-                allowRanking={allowRanking}
-                useTestData={useTestData}
+                {...({
+                  showReferences,
+                  allowRanking,
+                  useTestData,
+                  showPrompts,
+                  showThinking,
+                  showGenSettings,
+                } as any)}
               />
             </div>
           )}

--- a/designer/src/components/Test.tsx
+++ b/designer/src/components/Test.tsx
@@ -467,6 +467,32 @@ const Test = () => {
                             >
                               {test.score}%
                             </span>
+                            {test.score < 80 && (
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                className="ml-3 h-7 px-2 py-0 text-teal-700 border-teal-500/50 hover:bg-teal-500/10 dark:text-teal-300"
+                                onClick={() => {
+                                  try {
+                                    window.dispatchEvent(
+                                      new CustomEvent('lf-diagnose', {
+                                        detail: {
+                                          source: 'low_score',
+                                          testId: test.id,
+                                          testName: test.name,
+                                          input: test.input ?? '',
+                                          expected: test.expected ?? '',
+                                          matchScore: test.score,
+                                        },
+                                      })
+                                    )
+                                  } catch {}
+                                  setIsPanelOpen(false)
+                                }}
+                              >
+                                Diagnose
+                              </Button>
+                            )}
                           </div>
                         </div>
                       ))}

--- a/designer/src/components/Test.tsx
+++ b/designer/src/components/Test.tsx
@@ -1,10 +1,11 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import FontIcon from '../common/FontIcon'
 import ModeToggle, { Mode } from './ModeToggle'
 import { Button } from './ui/button'
 import { Checkbox } from './ui/checkbox'
 import { Switch } from './ui/switch'
 import ConfigEditor from './ConfigEditor/ConfigEditor'
+import TestChat from './TestChat/TestChat'
 import { usePackageModal } from '../contexts/PackageModalContext'
 
 interface TestCase {
@@ -195,7 +196,36 @@ const Test = () => {
   }
 
   const [mode, setMode] = useState<Mode>('designer')
-  const [isPanelOpen, setIsPanelOpen] = useState<boolean>(true)
+  const [isPanelOpen, setIsPanelOpen] = useState<boolean>(false)
+  const [showReferences, setShowReferences] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return true
+    const v = localStorage.getItem('lf_test_showReferences')
+    return v == null ? true : v === 'true'
+  })
+  const [allowRanking, setAllowRanking] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return true
+    const v = localStorage.getItem('lf_test_allowRanking')
+    return v == null ? true : v === 'true'
+  })
+  const [useTestData, setUseTestData] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false
+    const v = localStorage.getItem('lf_test_useTestData')
+    return v == null ? false : v === 'true'
+  })
+
+  // Persist preferences
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    localStorage.setItem('lf_test_showReferences', String(showReferences))
+  }, [showReferences])
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    localStorage.setItem('lf_test_allowRanking', String(allowRanking))
+  }, [allowRanking])
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    localStorage.setItem('lf_test_useTestData', String(useTestData))
+  }, [useTestData])
 
   return (
     <div className="w-full h-full flex flex-col">
@@ -220,13 +250,33 @@ const Test = () => {
       <div className="mb-4 flex items-start gap-4">
         <div className="flex-1 rounded-xl bg-muted/30 border border-border h-11 px-4 flex items-center justify-between">
           <label className="inline-flex items-center gap-3 text-sm">
-            <Checkbox id="show-processed" defaultChecked />
+            <Checkbox
+              id="show-processed"
+              checked={showReferences}
+              onCheckedChange={v => setShowReferences(Boolean(v))}
+            />
             <span>Show referenced chunks</span>
           </label>
           <div className="flex items-center gap-3 text-sm">
+            <span className="text-muted-foreground">Use test data</span>
+            <Switch
+              checked={useTestData}
+              onCheckedChange={v => setUseTestData(Boolean(v))}
+              aria-label="Use test data"
+            />
+            <span className="text-muted-foreground">
+              {useTestData ? 'On' : 'Off'}
+            </span>
+            <span className="mx-2 h-5 w-px bg-border" />
             <span className="text-muted-foreground">Allow ranking</span>
-            <Switch defaultChecked aria-label="Allow ranking" />
-            <span className="text-muted-foreground">On</span>
+            <Switch
+              checked={allowRanking}
+              onCheckedChange={v => setAllowRanking(Boolean(v))}
+              aria-label="Allow ranking"
+            />
+            <span className="text-muted-foreground">
+              {allowRanking ? 'On' : 'Off'}
+            </span>
           </div>
         </div>
         <div className="w-[360px]">
@@ -256,16 +306,18 @@ const Test = () => {
 
       <div className="flex-1 min-h-0 flex relative">
         {/* Main work area */}
-        <div className="flex-1 min-h-0 pb-6 pr-4">
+        <div className="flex-1 min-h-0 pb-6 pr-0">
           {mode !== 'designer' ? (
             <div className="h-full overflow-hidden">
               <ConfigEditor className="h-full" />
             </div>
           ) : (
             <div className="h-full">
-              <div className="h-full w-full rounded-xl border border-dashed border-border/60 text-muted-foreground flex items-center justify-center">
-                <div className="text-sm">Your workspace goes here</div>
-              </div>
+              <TestChat
+                showReferences={showReferences}
+                allowRanking={allowRanking}
+                useTestData={useTestData}
+              />
             </div>
           )}
         </div>

--- a/designer/src/components/Test.tsx
+++ b/designer/src/components/Test.tsx
@@ -701,9 +701,9 @@ const Test = () => {
         </div>
       </div>
 
-      <div className="flex-1 min-h-0 flex relative">
+      <div className="flex-1 min-h-0 flex flex-col relative">
         {/* Main work area */}
-        <div className="flex-1 min-h-0 pb-6 pr-0">
+        <div className="flex-1 min-h-0 pb-2 pr-0">
           {mode !== 'designer' ? (
             <div className="h-full overflow-hidden">
               <ConfigEditor className="h-full" />
@@ -723,6 +723,15 @@ const Test = () => {
             </div>
           )}
         </div>
+        {/* Helper text below chat window, on dark background */}
+        {mode === 'designer' && (
+          <div className="px-1 pb-3">
+            <div className="text-[11px] text-muted-foreground">
+              Not sure where to start? Think about the questions people will
+              actually ask to test model reliability.
+            </div>
+          </div>
+        )}
       </div>
 
       {isEditOpen && (

--- a/designer/src/components/Test.tsx
+++ b/designer/src/components/Test.tsx
@@ -356,7 +356,9 @@ const Test = () => {
               <Checkbox
                 id="show-processed"
                 checked={showReferences}
-                onCheckedChange={v => setShowReferences(Boolean(v))}
+                onCheckedChange={(v: boolean | 'indeterminate') =>
+                  setShowReferences(Boolean(v))
+                }
               />
               <span className="whitespace-nowrap">Show referenced chunks</span>
             </label>
@@ -364,7 +366,9 @@ const Test = () => {
               <Checkbox
                 id="show-prompts"
                 checked={showPrompts}
-                onCheckedChange={v => setShowPrompts(Boolean(v))}
+                onCheckedChange={(v: boolean | 'indeterminate') =>
+                  setShowPrompts(Boolean(v))
+                }
               />
               <span className="whitespace-nowrap">Show prompts sent</span>
             </label>
@@ -372,7 +376,9 @@ const Test = () => {
               <Checkbox
                 id="show-thinking"
                 checked={showThinking}
-                onCheckedChange={v => setShowThinking(Boolean(v))}
+                onCheckedChange={(v: boolean | 'indeterminate') =>
+                  setShowThinking(Boolean(v))
+                }
               />
               <span className="whitespace-nowrap">Show thinking steps</span>
             </label>
@@ -385,7 +391,7 @@ const Test = () => {
             </span>
             <Switch
               checked={allowRanking}
-              onCheckedChange={v => setAllowRanking(Boolean(v))}
+              onCheckedChange={(v: boolean) => setAllowRanking(Boolean(v))}
               aria-label="Allow ranking"
             />
             <span className="text-muted-foreground whitespace-nowrap">
@@ -560,7 +566,9 @@ const Test = () => {
                     <div className="flex items-center gap-2">
                       <Switch
                         checked={useTestData}
-                        onCheckedChange={v => setUseTestData(Boolean(v))}
+                        onCheckedChange={(v: boolean) =>
+                          setUseTestData(Boolean(v))
+                        }
                         aria-label="Use test data"
                       />
                       <span className="text-muted-foreground">
@@ -572,7 +580,9 @@ const Test = () => {
                   <label className="inline-flex items-center gap-2">
                     <Checkbox
                       checked={showGenSettings}
-                      onCheckedChange={v => setShowGenSettings(Boolean(v))}
+                      onCheckedChange={(v: boolean | 'indeterminate') =>
+                        setShowGenSettings(Boolean(v))
+                      }
                     />
                     <span className="whitespace-nowrap">
                       Show generation settings in responses
@@ -678,7 +688,7 @@ const Test = () => {
                     <label className="inline-flex items-center gap-2">
                       <Checkbox
                         checked={gen.streaming}
-                        onCheckedChange={v =>
+                        onCheckedChange={(v: boolean | 'indeterminate') =>
                           setGen({ ...gen, streaming: Boolean(v) })
                         }
                       />
@@ -687,7 +697,7 @@ const Test = () => {
                     <label className="inline-flex items-center gap-2">
                       <Checkbox
                         checked={gen.jsonMode}
-                        onCheckedChange={v =>
+                        onCheckedChange={(v: boolean | 'indeterminate') =>
                           setGen({ ...gen, jsonMode: Boolean(v) })
                         }
                       />

--- a/designer/src/components/Test.tsx
+++ b/designer/src/components/Test.tsx
@@ -293,6 +293,9 @@ const Test = () => {
     }
   })
 
+  // Local diagnose loading for origin CTAs
+  const [diagnosing, setDiagnosing] = useState<Record<string, boolean>>({})
+
   // Persist preferences
   useEffect(() => {
     if (typeof window === 'undefined') return
@@ -473,6 +476,10 @@ const Test = () => {
                                 size="sm"
                                 className="ml-3 h-7 px-2 py-0 text-teal-700 border-teal-500/50 hover:bg-teal-500/10 dark:text-teal-300"
                                 onClick={() => {
+                                  setDiagnosing(prev => ({
+                                    ...prev,
+                                    [String(test.id)]: true,
+                                  }))
                                   try {
                                     window.dispatchEvent(
                                       new CustomEvent('lf-diagnose', {
@@ -488,9 +495,24 @@ const Test = () => {
                                     )
                                   } catch {}
                                   setIsPanelOpen(false)
+                                  setTimeout(
+                                    () =>
+                                      setDiagnosing(prev => ({
+                                        ...prev,
+                                        [String(test.id)]: false,
+                                      })),
+                                    1000
+                                  )
                                 }}
                               >
-                                Diagnose
+                                {diagnosing[String(test.id)] ? (
+                                  <span className="inline-flex items-center gap-2">
+                                    <span className="inline-block h-3 w-3 animate-spin rounded-full border-2 border-teal-500 border-t-transparent" />
+                                    <span>Diagnosing…</span>
+                                  </span>
+                                ) : (
+                                  'Diagnose'
+                                )}
                               </Button>
                             )}
                           </div>

--- a/designer/src/components/TestChat/TestChat.tsx
+++ b/designer/src/components/TestChat/TestChat.tsx
@@ -477,13 +477,36 @@ function TestChatMessage({
               <ThumbButton
                 kind="down"
                 active={thumb === 'down'}
-                onClick={() => onThumb('down')}
+                onClick={() => {
+                  const next = thumb === 'down' ? null : 'down'
+                  onThumb('down')
+                  // Show a subtle troubleshoot nudge when giving thumbs down
+                  if (next === 'down') {
+                    try {
+                      // Lightweight toast via alert-style for now: inline nudge button below
+                    } catch {}
+                  }
+                }}
               />
               <span className="mx-1 opacity-40">•</span>
             </>
           )}
           {/* Copy button removed */}
           <span className="opacity-40">•</span>
+          <ActionLink
+            label="Diagnose"
+            onClick={() =>
+              window.dispatchEvent(
+                new CustomEvent('lf-diagnose', {
+                  detail: {
+                    source: 'message_action',
+                    responseText: message.content,
+                  },
+                })
+              )
+            }
+          />
+          <span className="opacity-40">/</span>
           <ActionLink
             label="Retry"
             onClick={() =>
@@ -557,6 +580,32 @@ function TestChatMessage({
               {showExpected ? 'Hide expected' : 'View expected'}
             </button>
           </div>
+          {typeof message.metadata.testResult.score === 'number' &&
+            message.metadata.testResult.score < 80 && (
+              <div className="mt-2 text-xs">
+                <button
+                  type="button"
+                  className="px-2 py-0.5 rounded border border-teal-500/50 text-teal-700 hover:bg-teal-500/10 dark:text-teal-300"
+                  onClick={() =>
+                    window.dispatchEvent(
+                      new CustomEvent('lf-diagnose', {
+                        detail: {
+                          source: 'low_score',
+                          testId: message.metadata?.testId,
+                          testName: message.metadata?.testName,
+                          input: lastUserInput || '',
+                          expected:
+                            message.metadata?.testResult?.expected || '',
+                          matchScore: message.metadata?.testResult?.score,
+                        },
+                      })
+                    )
+                  }
+                >
+                  Diagnose
+                </button>
+              </div>
+            )}
           <div className="mt-2 text-xs text-muted-foreground flex items-center gap-4">
             <div>{message.metadata.testResult.latencyMs}ms result</div>
             <div>

--- a/designer/src/components/TestChat/TestChat.tsx
+++ b/designer/src/components/TestChat/TestChat.tsx
@@ -1,0 +1,435 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import FontIcon from '../../common/FontIcon'
+import useChatbox from '../../hooks/useChatbox'
+import { ChatboxMessage } from '../../types/chatbox'
+
+export interface TestChatProps {
+  showReferences: boolean
+  allowRanking: boolean
+  useTestData?: boolean
+}
+
+const containerClasses =
+  // Match page background with clear outlines
+  'w-full h-full flex flex-col rounded-xl border border-border bg-background text-foreground'
+
+const inputContainerClasses =
+  'flex flex-col gap-2 p-3 md:p-4 bg-background/60 border-t border-border rounded-b-xl'
+
+const textareaClasses =
+  'w-full h-auto min-h-[3rem] md:min-h-[3.5rem] resize-none bg-transparent border-none placeholder-opacity-60 focus:outline-none focus:ring-0 font-sans text-sm md:text-base leading-relaxed overflow-y-auto text-foreground placeholder-foreground/60'
+
+function EmptyState() {
+  return (
+    <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
+      Start testing your tuned model by sending a message…
+    </div>
+  )
+}
+
+export default function TestChat({
+  showReferences,
+  allowRanking,
+  useTestData,
+}: TestChatProps) {
+  const {
+    messages,
+    inputValue,
+    isSending,
+    isClearing,
+    error,
+    sendMessage,
+    clearChat,
+    updateInput,
+    hasMessages,
+    canSend,
+    addMessage,
+    updateMessage,
+  } = useChatbox()
+
+  // Mock mode controlled by parent
+  const MOCK_MODE = Boolean(useTestData)
+
+  const listRef = useRef<HTMLDivElement | null>(null)
+  const endRef = useRef<HTMLDivElement | null>(null)
+  const inputRef = useRef<HTMLTextAreaElement | null>(null)
+
+  // Auto-grow textarea up to a comfortable max height before scrolling
+  const resizeTextarea = useCallback(() => {
+    const el = inputRef.current
+    if (!el) return
+    const maxHeight = 220 // ~6 lines depending on line-height
+    el.style.height = 'auto'
+    const newHeight = Math.min(el.scrollHeight, maxHeight)
+    el.style.height = `${newHeight}px`
+    el.style.overflowY = el.scrollHeight > maxHeight ? 'auto' : 'hidden'
+  }, [])
+
+  useEffect(() => {
+    if (endRef.current) {
+      endRef.current.scrollIntoView({ behavior: 'smooth', block: 'end' })
+    } else if (listRef.current) {
+      listRef.current.scrollTop = listRef.current.scrollHeight
+    }
+  }, [messages])
+
+  // Resize textarea on mount and input changes
+  useEffect(() => {
+    resizeTextarea()
+  }, [inputValue, resizeTextarea])
+
+  const handleSend = useCallback(async () => {
+    const content = inputValue.trim()
+    if (!canSend || !content) return
+    if (MOCK_MODE) {
+      // Local-only optimistic flow without backend
+      addMessage({ type: 'user', content, timestamp: new Date() })
+      const assistantId = addMessage({
+        type: 'assistant',
+        content: 'Thinking…',
+        timestamp: new Date(),
+        isLoading: true,
+      })
+      updateInput('')
+      setTimeout(() => {
+        const mockAnswer = `Here is a mock response to: "${content}"\n\n- Point A\n- Point B\n\nThis is sample output while backend is disconnected.`
+        updateMessage(assistantId, {
+          content: mockAnswer,
+          isLoading: false,
+          sources: [
+            {
+              source: 'dataset/manuals/aircraft_mx_guide.pdf',
+              score: 0.83,
+              content:
+                'Hydraulic pressure drops during taxi often indicate minor leaks or entrained air. Inspect lines and fittings.',
+            },
+            {
+              source: 'dataset/bulletins/bulletin-2024-17.md',
+              score: 0.71,
+              content:
+                'Pressure sensor calibration drifts were reported in batch 24B. Verify calibration if readings fluctuate.',
+            },
+          ],
+        })
+      }, 350)
+      return
+    }
+
+    const ok = await sendMessage(content)
+    if (ok) updateInput('')
+  }, [canSend, inputValue, sendMessage, updateInput])
+
+  const handleKeyDown: React.KeyboardEventHandler<HTMLTextAreaElement> = e => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      handleSend()
+    }
+  }
+
+  // Wire lightweight global events for Retry and Use-as-prompt
+  useEffect(() => {
+    const onRetry = (e: Event) => {
+      const detail = (e as CustomEvent).detail as { id: string }
+      // For now, simply re-send the last user message
+      const lastUser = [...messages].reverse().find(m => m.type === 'user')
+      if (lastUser) {
+        updateInput(lastUser.content)
+        setTimeout(() => handleSend(), 0)
+      }
+    }
+    const onUse = (e: Event) => {
+      const detail = (e as CustomEvent).detail as { content: string }
+      updateInput(detail.content || '')
+    }
+    window.addEventListener('lf-chat-retry', onRetry as EventListener)
+    window.addEventListener('lf-chat-use-as-prompt', onUse as EventListener)
+    return () => {
+      window.removeEventListener('lf-chat-retry', onRetry as EventListener)
+      window.removeEventListener(
+        'lf-chat-use-as-prompt',
+        onUse as EventListener
+      )
+    }
+  }, [messages, updateInput, handleSend])
+
+  return (
+    <div className={containerClasses}>
+      {/* Header row actions */}
+      <div className="flex items-center justify-between px-3 md:px-4 py-2 border-b border-border rounded-t-xl bg-background/50">
+        <div className="text-xs md:text-sm text-muted-foreground">Session</div>
+        <button
+          type="button"
+          onClick={() => clearChat()}
+          disabled={isClearing}
+          className="text-xs px-2 py-1 rounded bg-secondary hover:bg-secondary/80 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {isClearing ? 'Clearing…' : 'Clear'}
+        </button>
+      </div>
+
+      {/* Error */}
+      {error && (
+        <div className="mx-4 mt-3 p-2 bg-red-100 border border-red-400 text-red-700 rounded text-xs">
+          {error}
+        </div>
+      )}
+
+      {/* Messages */}
+      <div ref={listRef} className="flex-1 overflow-y-auto p-3 md:p-4">
+        <div className="flex flex-col gap-4">
+          {!hasMessages ? (
+            <EmptyState />
+          ) : (
+            messages.map((m: ChatboxMessage) => (
+              <TestChatMessage
+                key={m.id}
+                message={m}
+                showReferences={showReferences}
+                allowRanking={allowRanking}
+              />
+            ))
+          )}
+          <div ref={endRef} />
+        </div>
+      </div>
+
+      {/* Input */}
+      <div className={inputContainerClasses}>
+        <textarea
+          ref={inputRef}
+          value={inputValue}
+          onChange={e => updateInput(e.target.value)}
+          onKeyDown={handleKeyDown}
+          disabled={isSending}
+          placeholder={
+            isSending
+              ? 'Waiting for response…'
+              : 'Type a message and press Enter'
+          }
+          className={textareaClasses}
+          aria-label="Message input"
+        />
+        <div className="flex items-center justify-between">
+          {isSending && (
+            <span className="text-xs text-muted-foreground">Sending…</span>
+          )}
+          <FontIcon
+            isButton
+            type="arrow-filled"
+            className={`w-8 h-8 self-end ${!canSend ? 'text-muted-foreground opacity-50' : 'text-primary'}`}
+            handleOnClick={handleSend}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+interface TestChatMessageProps {
+  message: ChatboxMessage
+  showReferences: boolean
+  allowRanking: boolean
+}
+
+function TestChatMessage({
+  message,
+  showReferences,
+  allowRanking,
+}: TestChatMessageProps) {
+  const isUser = message.type === 'user'
+  const isAssistant = message.type === 'assistant'
+  const [thumb, setThumb] = useState<null | 'up' | 'down'>(null)
+
+  // Load persisted thumb for this message
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    try {
+      const key = `lf_thumb_${message.id}`
+      const saved = localStorage.getItem(key)
+      if (saved === 'up' || saved === 'down') setThumb(saved)
+    } catch {}
+  }, [message.id])
+
+  const onThumb = useCallback(
+    (kind: 'up' | 'down') => {
+      setThumb(prev => {
+        const next = prev === kind ? null : kind
+        try {
+          const key = `lf_thumb_${message.id}`
+          if (next) localStorage.setItem(key, next)
+          else localStorage.removeItem(key)
+        } catch {}
+        return next
+      })
+    },
+    [message.id]
+  )
+
+  return (
+    <div
+      className={`flex flex-col ${isUser ? 'self-end' : ''}`}
+      style={{ maxWidth: isUser ? 'min(88%, 900px)' : 'min(92%, 900px)' }}
+    >
+      <div
+        className={
+          isUser
+            ? 'px-4 py-3 md:px-4 md:py-3 rounded-lg bg-primary/10 text-foreground'
+            : isAssistant
+              ? 'px-0 md:px-0 text-[15px] md:text-base leading-relaxed text-foreground/90'
+              : 'px-4 py-3 rounded-lg bg-muted text-foreground'
+        }
+      >
+        {message.isLoading && isAssistant ? (
+          <TypingDots label="Thinking" />
+        ) : (
+          message.content
+        )}
+      </div>
+
+      {/* Assistant footer actions */}
+      {isAssistant && (
+        <div className="mt-2 flex items-center gap-2 text-muted-foreground">
+          {allowRanking && (
+            <>
+              <ThumbButton
+                kind="up"
+                active={thumb === 'up'}
+                onClick={() => onThumb('up')}
+              />
+              <ThumbButton
+                kind="down"
+                active={thumb === 'down'}
+                onClick={() => onThumb('down')}
+              />
+              <span className="mx-1 opacity-40">•</span>
+            </>
+          )}
+          {/* Copy button removed */}
+          <span className="opacity-40">•</span>
+          <ActionLink
+            label="Retry"
+            onClick={() =>
+              window.dispatchEvent(
+                new CustomEvent('lf-chat-retry', { detail: { id: message.id } })
+              )
+            }
+          />
+          <span className="opacity-40">/</span>
+          <ActionLink
+            label="Use as prompt"
+            onClick={() =>
+              window.dispatchEvent(
+                new CustomEvent('lf-chat-use-as-prompt', {
+                  detail: { content: message.content },
+                })
+              )
+            }
+          />
+        </div>
+      )}
+
+      {/* References */}
+      {showReferences &&
+        isAssistant &&
+        Array.isArray(message.sources) &&
+        message.sources.length > 0 && <References sources={message.sources} />}
+    </div>
+  )
+}
+
+function ThumbButton({
+  kind,
+  active,
+  onClick,
+}: {
+  kind: 'up' | 'down'
+  active?: boolean
+  onClick?: () => void
+}) {
+  return (
+    <button onClick={onClick} className="flex items-center gap-1 group">
+      <FontIcon
+        isButton
+        type={
+          kind === 'up'
+            ? active
+              ? 'thumbs-up-filled'
+              : 'thumbs-up'
+            : active
+              ? 'thumbs-down-filled'
+              : 'thumbs-down'
+        }
+        className={`w-5 h-5 ${active ? 'text-teal-500' : 'text-muted-foreground group-hover:text-foreground'}`}
+      />
+    </button>
+  )
+}
+
+// Copy button removed
+
+function ActionLink({
+  label,
+  onClick,
+}: {
+  label: string
+  onClick: () => void
+}) {
+  return (
+    <button onClick={onClick} className="text-xs hover:underline">
+      {label}
+    </button>
+  )
+}
+
+function References({ sources }: { sources: any[] }) {
+  const [open, setOpen] = useState<boolean>(true)
+  const count = sources.length
+  return (
+    <div className="mt-2 rounded-md border border-border bg-card/40">
+      <button
+        type="button"
+        onClick={() => setOpen(o => !o)}
+        className="w-full flex items-center justify-between px-3 py-2 text-xs text-muted-foreground hover:bg-accent/40 rounded-t-md focus:outline-none focus:ring-2 focus:ring-primary/60"
+        aria-expanded={open}
+        aria-controls={`references-panel`}
+      >
+        <span className="font-medium">References ({count})</span>
+        <span className="text-[11px]">{open ? 'Hide' : 'Show'}</span>
+      </button>
+      {open && (
+        <div id="references-panel" className="divide-y divide-border">
+          {sources.map((s, idx) => (
+            <div key={idx} className="px-3 py-2">
+              {s.content && (
+                <div className="text-sm text-foreground whitespace-pre-wrap line-clamp-2">
+                  {s.content}
+                </div>
+              )}
+              <div className="mt-1 flex items-center justify-between text-xs text-muted-foreground">
+                <div className="truncate">
+                  {s.source || s.metadata?.source || 'source'}
+                </div>
+                {typeof s.score === 'number' && (
+                  <span className="ml-2 text-[11px]">
+                    {(s.score * 100).toFixed(1)}%
+                  </span>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function TypingDots({ label = 'Thinking' }: { label?: string }) {
+  return (
+    <span className="inline-flex items-center gap-1 opacity-80">
+      <span>{label}</span>
+      <span className="animate-pulse">.</span>
+      <span className="animate-pulse [animation-delay:150ms]">.</span>
+      <span className="animate-pulse [animation-delay:300ms]">.</span>
+    </span>
+  )
+}

--- a/designer/src/components/TestChat/TestChat.tsx
+++ b/designer/src/components/TestChat/TestChat.tsx
@@ -495,7 +495,15 @@ function TestChatMessage({
           <span className="opacity-40">•</span>
           <ActionLink
             label="Diagnose"
-            onClick={() =>
+            className={
+              thumb === 'down'
+                ? 'text-xs text-teal-500 hover:text-teal-400 hover:underline font-medium'
+                : undefined
+            }
+            onClick={() => {
+              // brief local visual loading cue by dimming text
+              const el = document.activeElement as HTMLElement | null
+              if (el) el.blur()
               window.dispatchEvent(
                 new CustomEvent('lf-diagnose', {
                   detail: {
@@ -504,7 +512,7 @@ function TestChatMessage({
                   },
                 })
               )
-            }
+            }}
           />
           <span className="opacity-40">/</span>
           <ActionLink
@@ -721,12 +729,17 @@ function ThumbButton({
 function ActionLink({
   label,
   onClick,
+  className,
 }: {
   label: string
   onClick: () => void
+  className?: string
 }) {
   return (
-    <button onClick={onClick} className="text-xs hover:underline">
+    <button
+      onClick={onClick}
+      className={className || 'text-xs hover:underline'}
+    >
       {label}
     </button>
   )

--- a/designer/src/components/TestChat/TestChat.tsx
+++ b/designer/src/components/TestChat/TestChat.tsx
@@ -178,8 +178,7 @@ export default function TestChat({
 
   // Wire lightweight global events for Retry and Use-as-prompt
   useEffect(() => {
-    const onRetry = (e: Event) => {
-      const detail = (e as CustomEvent).detail as { id: string }
+    const onRetry = () => {
       // For now, simply re-send the last user message
       const lastUser = [...messages].reverse().find(m => m.type === 'user')
       if (lastUser) {
@@ -582,6 +581,12 @@ function TestChatMessage({
               <Badge className="bg-teal-500/20 text-teal-400 border border-teal-500/30">
                 Test result
               </Badge>
+              <span
+                className="text-[11px] text-muted-foreground"
+                title="This is a simple lexical overlap metric and may not reflect semantic correctness."
+              >
+                experimental
+              </span>
               <span
                 className={`px-2 py-0.5 rounded-2xl text-xs ${
                   (message.metadata.testResult.score ?? 0) >= 95

--- a/designer/src/components/TestChat/TestChat.tsx
+++ b/designer/src/components/TestChat/TestChat.tsx
@@ -25,8 +25,21 @@ const textareaClasses =
 
 function EmptyState() {
   return (
-    <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
-      Start testing your tuned model by sending a message…
+    <div className="flex items-center justify-center h-full">
+      <div className="text-center px-6 py-10 rounded-xl border border-border bg-card/40">
+        <div className="mx-auto mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-teal-500/20 border border-teal-500/30">
+          <FontIcon type="test" className="w-5 h-5 text-teal-400" />
+        </div>
+        <div className="text-lg font-medium text-foreground">
+          Start testing your model
+        </div>
+        <div className="mt-1 text-sm text-muted-foreground">
+          Send a message to evaluate responses and run diagnostics.
+        </div>
+        <div className="mt-3 text-xs text-muted-foreground">
+          Tip: Press Enter to send
+        </div>
+      </div>
     </div>
   )
 }
@@ -330,7 +343,7 @@ export default function TestChat({
 
       {/* Messages */}
       <div ref={listRef} className="flex-1 overflow-y-auto p-3 md:p-4">
-        <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-4 h-full">
           {!hasMessages ? (
             <EmptyState />
           ) : (

--- a/designer/src/components/ui/checkbox.tsx
+++ b/designer/src/components/ui/checkbox.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react'
+import * as CheckboxPrimitive from '@radix-ui/react-checkbox'
+import { Check } from 'lucide-react'
+
+import { cn } from '@/lib/utils'
+
+const Checkbox = React.forwardRef<
+  React.ElementRef<typeof CheckboxPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <CheckboxPrimitive.Root
+    ref={ref}
+    className={cn(
+      'peer h-4 w-4 shrink-0 rounded-sm border border-input shadow focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground',
+      className
+    )}
+    {...props}
+  >
+    <CheckboxPrimitive.Indicator
+      className={cn('flex items-center justify-center text-current')}
+    >
+      <Check className="h-3.5 w-3.5" />
+    </CheckboxPrimitive.Indicator>
+  </CheckboxPrimitive.Root>
+))
+Checkbox.displayName = CheckboxPrimitive.Root.displayName
+
+export { Checkbox }

--- a/designer/src/components/ui/switch.tsx
+++ b/designer/src/components/ui/switch.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react'
+import * as SwitchPrimitives from '@radix-ui/react-switch'
+
+import { cn } from '@/lib/utils'
+
+const Switch = React.forwardRef<
+  React.ElementRef<typeof SwitchPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
+>(({ className, ...props }, ref) => (
+  <SwitchPrimitives.Root
+    className={cn(
+      'peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input',
+      className
+    )}
+    {...props}
+    ref={ref}
+  >
+    <SwitchPrimitives.Thumb
+      className={cn(
+        'pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0'
+      )}
+    />
+  </SwitchPrimitives.Root>
+))
+Switch.displayName = SwitchPrimitives.Root.displayName
+
+export { Switch }

--- a/designer/src/hooks/useChatSession.ts
+++ b/designer/src/hooks/useChatSession.ts
@@ -10,8 +10,6 @@ const SESSION_STORAGE_KEYS = {
   SESSION_LIST: 'chatbox_sessions',
 } as const
 
-
-
 /**
  * Custom hook for managing chat session persistence and restoration
  * Provides session management with localStorage persistence
@@ -28,8 +26,29 @@ export function useChatSession(initialSessionId?: string) {
     return initialSessionId || ''
   })
 
+  // Ensure a local session exists if none is set (for immediate persistence)
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    if (!currentSessionId) {
+      const localId = `local_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`
+      setCurrentSessionId(localId)
+      localStorage.setItem(SESSION_STORAGE_KEYS.CURRENT_SESSION, localId)
+      // Initialize empty storage for messages to avoid null reads
+      try {
+        localStorage.setItem(
+          SESSION_STORAGE_KEYS.SESSION_MESSAGES(localId),
+          JSON.stringify([])
+        )
+      } catch {}
+    }
+  }, [currentSessionId])
+
   // Query for current session messages
-  const { data: messages = [], isLoading, error } = useQuery({
+  const {
+    data: messages = [],
+    isLoading,
+    error,
+  } = useQuery({
     queryKey: chatKeys.session(currentSessionId),
     queryFn: () => loadSessionMessages(currentSessionId),
     staleTime: 1000 * 60 * 5, // 5 minutes
@@ -45,38 +64,43 @@ export function useChatSession(initialSessionId?: string) {
   })
 
   // Load messages from localStorage
-  const loadSessionMessages = useCallback((sessionId: string): ChatboxMessage[] => {
-    if (typeof window === 'undefined') return []
-    
-    try {
-      const stored = localStorage.getItem(SESSION_STORAGE_KEYS.SESSION_MESSAGES(sessionId))
-      if (!stored) return []
-      
-      const parsed = JSON.parse(stored)
-      // Convert timestamp strings back to Date objects
-      return parsed.map((msg: any) => ({
-        ...msg,
-        timestamp: new Date(msg.timestamp)
-      }))
-    } catch (error) {
-      console.warn(`Failed to load messages for session ${sessionId}:`, error)
-      return []
-    }
-  }, [])
+  const loadSessionMessages = useCallback(
+    (sessionId: string): ChatboxMessage[] => {
+      if (typeof window === 'undefined') return []
+
+      try {
+        const stored = localStorage.getItem(
+          SESSION_STORAGE_KEYS.SESSION_MESSAGES(sessionId)
+        )
+        if (!stored) return []
+
+        const parsed = JSON.parse(stored)
+        // Convert timestamp strings back to Date objects
+        return parsed.map((msg: any) => ({
+          ...msg,
+          timestamp: new Date(msg.timestamp),
+        }))
+      } catch (error) {
+        console.warn(`Failed to load messages for session ${sessionId}:`, error)
+        return []
+      }
+    },
+    []
+  )
 
   // Load all sessions from localStorage
   const loadAllSessions = useCallback((): ChatSession[] => {
     if (typeof window === 'undefined') return []
-    
+
     try {
       const stored = localStorage.getItem(SESSION_STORAGE_KEYS.SESSION_LIST)
       if (!stored) return []
-      
+
       const parsed = JSON.parse(stored)
       return parsed.map((session: any) => ({
         ...session,
         createdAt: new Date(session.createdAt),
-        lastActivity: new Date(session.lastActivity)
+        lastActivity: new Date(session.lastActivity),
       }))
     } catch (error) {
       console.warn('Failed to load session list:', error)
@@ -85,139 +109,168 @@ export function useChatSession(initialSessionId?: string) {
   }, [])
 
   // Save messages to localStorage
-  const saveSessionMessages = useCallback((sessionId: string, messages: ChatboxMessage[]) => {
-    if (typeof window === 'undefined') return
-    
-    try {
-      localStorage.setItem(
-        SESSION_STORAGE_KEYS.SESSION_MESSAGES(sessionId),
-        JSON.stringify(messages)
-      )
-      
-      // Update session metadata
-      updateSessionMetadata(sessionId, messages)
-    } catch (error) {
-      console.warn(`Failed to save messages for session ${sessionId}:`, error)
-    }
-  }, [])
+  const saveSessionMessages = useCallback(
+    (sessionId: string, messages: ChatboxMessage[]) => {
+      if (typeof window === 'undefined') return
+
+      try {
+        localStorage.setItem(
+          SESSION_STORAGE_KEYS.SESSION_MESSAGES(sessionId),
+          JSON.stringify(messages)
+        )
+
+        // Update session metadata
+        updateSessionMetadata(sessionId, messages)
+      } catch (error) {
+        console.warn(`Failed to save messages for session ${sessionId}:`, error)
+      }
+    },
+    []
+  )
 
   // Update session metadata
-  const updateSessionMetadata = useCallback((sessionId: string, messages: ChatboxMessage[]) => {
-    if (typeof window === 'undefined') return
-    
-    try {
-      const sessions = loadAllSessions()
-      const existingIndex = sessions.findIndex(s => s.id === sessionId)
-      
-      const sessionData: ChatSession = {
-        id: sessionId,
-        createdAt: existingIndex >= 0 ? sessions[existingIndex].createdAt : new Date(),
-        lastActivity: new Date(),
-        messageCount: messages.length,
-        title: messages.length > 0 && messages[0].content
-          ? messages[0].content.length > 50
-            ? messages[0].content.substring(0, 50) + '...'
-            : messages[0].content
-          : 'New Chat'
+  const updateSessionMetadata = useCallback(
+    (sessionId: string, messages: ChatboxMessage[]) => {
+      if (typeof window === 'undefined') return
+
+      try {
+        const sessions = loadAllSessions()
+        const existingIndex = sessions.findIndex(s => s.id === sessionId)
+
+        const sessionData: ChatSession = {
+          id: sessionId,
+          createdAt:
+            existingIndex >= 0 ? sessions[existingIndex].createdAt : new Date(),
+          lastActivity: new Date(),
+          messageCount: messages.length,
+          title:
+            messages.length > 0 && messages[0].content
+              ? messages[0].content.length > 50
+                ? messages[0].content.substring(0, 50) + '...'
+                : messages[0].content
+              : 'New Chat',
+        }
+
+        if (existingIndex >= 0) {
+          sessions[existingIndex] = sessionData
+        } else {
+          sessions.push(sessionData)
+        }
+
+        // Keep only the last 10 sessions
+        const sortedSessions = sessions
+          .sort((a, b) => b.lastActivity.getTime() - a.lastActivity.getTime())
+          .slice(0, 10)
+
+        localStorage.setItem(
+          SESSION_STORAGE_KEYS.SESSION_LIST,
+          JSON.stringify(sortedSessions)
+        )
+
+        // Invalidate sessions query to trigger refetch
+        queryClient.invalidateQueries({ queryKey: chatKeys.sessions() })
+      } catch (error) {
+        console.warn('Failed to update session metadata:', error)
       }
-      
-      if (existingIndex >= 0) {
-        sessions[existingIndex] = sessionData
-      } else {
-        sessions.push(sessionData)
-      }
-      
-      // Keep only the last 10 sessions
-      const sortedSessions = sessions
-        .sort((a, b) => b.lastActivity.getTime() - a.lastActivity.getTime())
-        .slice(0, 10)
-      
-      localStorage.setItem(SESSION_STORAGE_KEYS.SESSION_LIST, JSON.stringify(sortedSessions))
-      
-      // Invalidate sessions query to trigger refetch
-      queryClient.invalidateQueries({ queryKey: chatKeys.sessions() })
-    } catch (error) {
-      console.warn('Failed to update session metadata:', error)
-    }
-  }, [loadAllSessions, queryClient])
+    },
+    [loadAllSessions, queryClient]
+  )
 
   // Create new session (will get ID from server on first message)
   const createNewSession = useCallback(() => {
-    const newSessionId = '' // Empty until server provides ID
+    // Create a local session immediately for persistence; can be migrated later
+    const newSessionId = `local_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`
     setCurrentSessionId(newSessionId)
-    
-    // Clear current session from localStorage - will be set when server provides ID
+
     if (typeof window !== 'undefined') {
-      localStorage.removeItem(SESSION_STORAGE_KEYS.CURRENT_SESSION)
+      localStorage.setItem(SESSION_STORAGE_KEYS.CURRENT_SESSION, newSessionId)
+      // Initialize empty messages array for this session
+      try {
+        localStorage.setItem(
+          SESSION_STORAGE_KEYS.SESSION_MESSAGES(newSessionId),
+          JSON.stringify([])
+        )
+      } catch {}
     }
-    
+
     // Invalidate queries to refresh data
-    if (newSessionId) {
-      queryClient.invalidateQueries({ queryKey: chatKeys.session(newSessionId) })
-    }
-    
+    queryClient.invalidateQueries({ queryKey: chatKeys.session(newSessionId) })
+
     return newSessionId
   }, [queryClient])
 
   // Switch to existing session
-  const switchToSession = useCallback((sessionId: string) => {
-    setCurrentSessionId(sessionId)
-    
-    // Save to localStorage
-    if (typeof window !== 'undefined') {
-      localStorage.setItem(SESSION_STORAGE_KEYS.CURRENT_SESSION, sessionId)
-    }
-    
-    // Invalidate queries to refresh data
-    queryClient.invalidateQueries({ queryKey: chatKeys.session(sessionId) })
-  }, [queryClient])
+  const switchToSession = useCallback(
+    (sessionId: string) => {
+      setCurrentSessionId(sessionId)
+
+      // Save to localStorage
+      if (typeof window !== 'undefined') {
+        localStorage.setItem(SESSION_STORAGE_KEYS.CURRENT_SESSION, sessionId)
+      }
+
+      // Invalidate queries to refresh data
+      queryClient.invalidateQueries({ queryKey: chatKeys.session(sessionId) })
+    },
+    [queryClient]
+  )
 
   // Delete session
-  const deleteSession = useCallback((sessionId: string) => {
-    if (typeof window === 'undefined') return
-    
-    try {
-      // Remove messages
-      localStorage.removeItem(SESSION_STORAGE_KEYS.SESSION_MESSAGES(sessionId))
-      
-      // Update session list
-      const sessions = loadAllSessions().filter(s => s.id !== sessionId)
-      localStorage.setItem(SESSION_STORAGE_KEYS.SESSION_LIST, JSON.stringify(sessions))
-      
-      // If deleting current session, create a new one
-      if (sessionId === currentSessionId) {
-        createNewSession()
+  const deleteSession = useCallback(
+    (sessionId: string) => {
+      if (typeof window === 'undefined') return
+
+      try {
+        // Remove messages
+        localStorage.removeItem(
+          SESSION_STORAGE_KEYS.SESSION_MESSAGES(sessionId)
+        )
+
+        // Update session list
+        const sessions = loadAllSessions().filter(s => s.id !== sessionId)
+        localStorage.setItem(
+          SESSION_STORAGE_KEYS.SESSION_LIST,
+          JSON.stringify(sessions)
+        )
+
+        // If deleting current session, create a new one
+        if (sessionId === currentSessionId) {
+          createNewSession()
+        }
+
+        // Invalidate queries
+        queryClient.invalidateQueries({ queryKey: chatKeys.session(sessionId) })
+        queryClient.invalidateQueries({ queryKey: chatKeys.sessions() })
+      } catch (error) {
+        console.warn(`Failed to delete session ${sessionId}:`, error)
       }
-      
-      // Invalidate queries
-      queryClient.invalidateQueries({ queryKey: chatKeys.session(sessionId) })
-      queryClient.invalidateQueries({ queryKey: chatKeys.sessions() })
-    } catch (error) {
-      console.warn(`Failed to delete session ${sessionId}:`, error)
-    }
-  }, [currentSessionId, loadAllSessions, createNewSession, queryClient])
+    },
+    [currentSessionId, loadAllSessions, createNewSession, queryClient]
+  )
 
   // Clear all sessions
   const clearAllSessions = useCallback(() => {
     if (typeof window === 'undefined') return
-    
+
     try {
       // Remove all session data
       const sessions = loadAllSessions()
       sessions.forEach(session => {
-        localStorage.removeItem(SESSION_STORAGE_KEYS.SESSION_MESSAGES(session.id))
+        localStorage.removeItem(
+          SESSION_STORAGE_KEYS.SESSION_MESSAGES(session.id)
+        )
       })
-      
+
       localStorage.removeItem(SESSION_STORAGE_KEYS.SESSION_LIST)
       localStorage.removeItem(SESSION_STORAGE_KEYS.CURRENT_SESSION)
-      
+
       // Create new session (server will provide ID)
       createNewSession()
-      
+
       // Invalidate all queries
       queryClient.invalidateQueries({ queryKey: chatKeys.all })
       queryClient.invalidateQueries({ queryKey: chatKeys.sessions() })
-      
+
       return '' // Session ID will be provided by server on first message
     } catch (error) {
       console.warn('Failed to clear all sessions:', error)
@@ -225,22 +278,63 @@ export function useChatSession(initialSessionId?: string) {
   }, [loadAllSessions, createNewSession, queryClient])
 
   // Set session ID when received from server
-  const setSessionId = useCallback((sessionId: string) => {
-    setCurrentSessionId(sessionId)
-    
-    // Save to localStorage
-    if (typeof window !== 'undefined') {
-      localStorage.setItem(SESSION_STORAGE_KEYS.CURRENT_SESSION, sessionId)
-    }
-    
-    // Invalidate queries to refresh data
-    queryClient.invalidateQueries({ queryKey: chatKeys.session(sessionId) })
-  }, [queryClient, currentSessionId])
+  const setSessionId = useCallback(
+    (sessionId: string) => {
+      // If we had a local session, migrate its stored messages and session list
+      if (
+        typeof window !== 'undefined' &&
+        currentSessionId &&
+        currentSessionId.startsWith('local_')
+      ) {
+        try {
+          const oldKey = SESSION_STORAGE_KEYS.SESSION_MESSAGES(currentSessionId)
+          const newKey = SESSION_STORAGE_KEYS.SESSION_MESSAGES(sessionId)
+          const stored = localStorage.getItem(oldKey)
+          if (stored && !localStorage.getItem(newKey)) {
+            localStorage.setItem(newKey, stored)
+          }
+          // Update session list entries to reflect the new ID
+          const sessionsRaw = localStorage.getItem(
+            SESSION_STORAGE_KEYS.SESSION_LIST
+          )
+          if (sessionsRaw) {
+            const list = JSON.parse(sessionsRaw)
+            const idx = Array.isArray(list)
+              ? list.findIndex((s: any) => s.id === currentSessionId)
+              : -1
+            if (idx >= 0) {
+              list[idx].id = sessionId
+              localStorage.setItem(
+                SESSION_STORAGE_KEYS.SESSION_LIST,
+                JSON.stringify(list)
+              )
+            }
+          }
+          // Remove old local storage key
+          localStorage.removeItem(oldKey)
+        } catch {}
+      }
+
+      setCurrentSessionId(sessionId)
+
+      // Save to localStorage
+      if (typeof window !== 'undefined') {
+        localStorage.setItem(SESSION_STORAGE_KEYS.CURRENT_SESSION, sessionId)
+      }
+
+      // Invalidate queries to refresh data
+      queryClient.invalidateQueries({ queryKey: chatKeys.session(sessionId) })
+    },
+    [queryClient, currentSessionId]
+  )
 
   // Save current session ID to localStorage when it changes
   useEffect(() => {
     if (typeof window !== 'undefined' && currentSessionId) {
-      localStorage.setItem(SESSION_STORAGE_KEYS.CURRENT_SESSION, currentSessionId)
+      localStorage.setItem(
+        SESSION_STORAGE_KEYS.CURRENT_SESSION,
+        currentSessionId
+      )
     }
   }, [currentSessionId])
 
@@ -250,7 +344,7 @@ export function useChatSession(initialSessionId?: string) {
     messages,
     isLoading,
     error,
-    
+
     // Session management
     sessions,
     createNewSession,
@@ -258,10 +352,10 @@ export function useChatSession(initialSessionId?: string) {
     deleteSession,
     clearAllSessions,
     setSessionId, // New function to set session ID from server
-    
+
     // Message persistence
     saveSessionMessages,
-    
+
     // Computed values
     hasMessages: messages.length > 0,
     currentSession: sessions.find(s => s.id === currentSessionId),

--- a/designer/src/hooks/useChatbox.ts
+++ b/designer/src/hooks/useChatbox.ts
@@ -19,35 +19,38 @@ export function useChatbox(initialSessionId?: string) {
     saveSessionMessages,
     createNewSession,
     setSessionId,
-    isLoading: isLoadingSession
+    isLoading: isLoadingSession,
   } = useChatSession(initialSessionId)
-  
+
   // Local state
   const [messages, setMessages] = useState<ChatboxMessage[]>([])
   const [inputValue, setInputValue] = useState('')
   const [error, setError] = useState<string | null>(null)
   const [hasInitialSync, setHasInitialSync] = useState(false)
-  
+
   // Ref for debounced save timeout
   const saveTimeoutRef = useRef<NodeJS.Timeout | null>(null)
-  
+
   // API hooks
   const queryClient = useQueryClient()
   const chatMutation = useChatInference()
   const deleteSessionMutation = useDeleteChatSession()
-  
+
   // Debounced save function to avoid blocking on every message change
-  const debouncedSave = useCallback((sessionId: string, messages: ChatboxMessage[]) => {
-    // Clear existing timeout
-    if (saveTimeoutRef.current) {
-      clearTimeout(saveTimeoutRef.current)
-    }
-    
-    // Set new timeout for debounced save
-    saveTimeoutRef.current = setTimeout(() => {
-      saveSessionMessages(sessionId, messages)
-    }, 500) // 500ms delay
-  }, [saveSessionMessages])
+  const debouncedSave = useCallback(
+    (sessionId: string, messages: ChatboxMessage[]) => {
+      // Clear existing timeout
+      if (saveTimeoutRef.current) {
+        clearTimeout(saveTimeoutRef.current)
+      }
+
+      // Set new timeout for debounced save
+      saveTimeoutRef.current = setTimeout(() => {
+        saveSessionMessages(sessionId, messages)
+      }, 500) // 500ms delay
+    },
+    [saveSessionMessages]
+  )
 
   // Sync persisted messages with local state ONLY on true initial load
   useEffect(() => {
@@ -60,7 +63,7 @@ export function useChatbox(initialSessionId?: string) {
       setHasInitialSync(true)
     }
   }, [persistedMessages, hasInitialSync, messages.length, sessionId])
-  
+
   // Save messages to persistence when they change (with debouncing)
   useEffect(() => {
     // Save if we have a valid session ID and either:
@@ -68,7 +71,7 @@ export function useChatbox(initialSessionId?: string) {
     // 2. We have messages to save (new session with messages)
     if (sessionId && (hasInitialSync || messages.length > 0)) {
       debouncedSave(sessionId, messages)
-      
+
       // IMMEDIATELY update React Query cache for cross-component access
       queryClient.setQueryData(chatKeys.session(sessionId), messages)
     }
@@ -82,117 +85,129 @@ export function useChatbox(initialSessionId?: string) {
       }
     }
   }, [])
-  
+
   // Add message to state
   const addMessage = useCallback((message: Omit<ChatboxMessage, 'id'>) => {
     const newMessage: ChatboxMessage = {
       ...message,
-      id: generateMessageId()
+      id: generateMessageId(),
     }
-    
+
     setMessages(prev => [...prev, newMessage])
     return newMessage.id
   }, [])
 
   // Update message by ID
-  const updateMessage = useCallback((id: string, updates: Partial<ChatboxMessage>) => {
-    setMessages(prev => {
-      const updated = prev.map(msg => 
-        msg.id === id ? { ...msg, ...updates } : msg
-      )
-      return updated
-    })
-  }, [])
+  const updateMessage = useCallback(
+    (id: string, updates: Partial<ChatboxMessage>) => {
+      setMessages(prev => {
+        const updated = prev.map(msg =>
+          msg.id === id ? { ...msg, ...updates } : msg
+        )
+        return updated
+      })
+    },
+    []
+  )
 
   // Handle sending message with API integration
-  const sendMessage = useCallback(async (messageContent: string) => {
-    if (!messageContent.trim() || chatMutation.isPending) return false
+  const sendMessage = useCallback(
+    async (messageContent: string) => {
+      if (!messageContent.trim() || chatMutation.isPending) return false
 
-    // Clear any previous errors
-    setError(null)
+      // Clear any previous errors
+      setError(null)
 
-    // Add user message immediately (optimistic update)
-    addMessage({
-      type: 'user',
-      content: messageContent,
-      timestamp: new Date()
-    })
-
-    // Add loading assistant message
-    const assistantMessageId = addMessage({
-      type: 'assistant',
-      content: 'Thinking...',
-      timestamp: new Date(),
-      isLoading: true
-    })
-
-    try {
-      // Create chat request
-      const chatRequest = createChatRequest(messageContent)
-
-      // Send to API
-      const response = await chatMutation.mutateAsync({
-        chatRequest,
-        sessionId
-      })
-
-      // Set session ID if received from server (for new sessions)
-      if (response.sessionId && response.sessionId !== sessionId) {
-        setSessionId(response.sessionId)
-        // Mark as having initial sync since this is a new session with messages
-        if (!hasInitialSync) {
-          setHasInitialSync(true)
-        }
-      }
-
-      // Update assistant message with response
-      if (response.data.choices && response.data.choices.length > 0) {
-        const assistantResponse = response.data.choices[0].message.content
-        
-        updateMessage(assistantMessageId, {
-          content: assistantResponse,
-          isLoading: false
-        })
-      } else {
-        updateMessage(assistantMessageId, {
-          content: 'Sorry, I didn\'t receive a proper response.',
-          isLoading: false
-        })
-      }
-
-      return true
-    } catch (error) {
-      console.error('Chat error:', error)
-
-      // Remove loading message
-      setMessages(prev => prev.filter(msg => msg.id !== assistantMessageId))
-
-      // Set error message
-      const errorMessage = error instanceof Error ? error.message : 'An unexpected error occurred'
-      setError(errorMessage)
-
-      // Add error message to chat
+      // Add user message immediately (optimistic update)
       addMessage({
-        type: 'error',
-        content: `Error: ${errorMessage}`,
-        timestamp: new Date()
+        type: 'user',
+        content: messageContent,
+        timestamp: new Date(),
       })
 
-      return false
-    }
-  }, [chatMutation, sessionId, setSessionId, addMessage, updateMessage])
+      // Add loading assistant message
+      const assistantMessageId = addMessage({
+        type: 'assistant',
+        content: 'Thinking...',
+        timestamp: new Date(),
+        isLoading: true,
+      })
+
+      try {
+        // Create chat request
+        const chatRequest = createChatRequest(messageContent)
+
+        // Send to API
+        const response = await chatMutation.mutateAsync({
+          chatRequest,
+          sessionId,
+        })
+
+        // Set session ID if received from server (for new sessions)
+        if (response.sessionId && response.sessionId !== sessionId) {
+          setSessionId(response.sessionId)
+          // Mark as having initial sync since this is a new session with messages
+          if (!hasInitialSync) {
+            setHasInitialSync(true)
+          }
+        }
+
+        // Update assistant message with response
+        if (response.data.choices && response.data.choices.length > 0) {
+          const assistantResponse = response.data.choices[0].message.content
+
+          updateMessage(assistantMessageId, {
+            content: assistantResponse,
+            isLoading: false,
+          })
+        } else {
+          updateMessage(assistantMessageId, {
+            content: "Sorry, I didn't receive a proper response.",
+            isLoading: false,
+          })
+        }
+
+        return true
+      } catch (error) {
+        console.error('Chat error:', error)
+
+        // Remove loading message
+        setMessages(prev => prev.filter(msg => msg.id !== assistantMessageId))
+
+        // Set error message
+        const errorMessage =
+          error instanceof Error
+            ? error.message
+            : 'An unexpected error occurred'
+        setError(errorMessage)
+
+        // Add error message to chat
+        addMessage({
+          type: 'error',
+          content: `Error: ${errorMessage}`,
+          timestamp: new Date(),
+        })
+
+        return false
+      }
+    },
+    [chatMutation, sessionId, setSessionId, addMessage, updateMessage]
+  )
 
   // Handle clear chat
   const clearChat = useCallback(async () => {
     if (deleteSessionMutation.isPending) return false
 
     try {
-      await deleteSessionMutation.mutateAsync(sessionId)
+      // If we don't have a valid sessionId (e.g., mock/test mode), skip server deletion
+      if (sessionId) {
+        await deleteSessionMutation.mutateAsync(sessionId)
+      }
 
       // Clear local messages and errors
       setMessages([])
       setError(null)
-      
+
       // Reset initial sync flag to allow fresh sync with new session
       setHasInitialSync(false)
 
@@ -202,7 +217,8 @@ export function useChatbox(initialSessionId?: string) {
       return true
     } catch (error) {
       console.error('Delete session error:', error)
-      const errorMessage = error instanceof Error ? error.message : 'Failed to clear chat'
+      const errorMessage =
+        error instanceof Error ? error.message : 'Failed to clear chat'
       setError(errorMessage)
       return false
     }
@@ -224,10 +240,10 @@ export function useChatbox(initialSessionId?: string) {
     setMessages([])
     setError(null)
     setInputValue('')
-    
+
     // Reset initial sync flag to allow fresh sync with new session
     setHasInitialSync(false)
-    
+
     return newSessionId
   }, [createNewSession])
 
@@ -237,12 +253,12 @@ export function useChatbox(initialSessionId?: string) {
     messages,
     inputValue,
     error,
-    
+
     // Loading states
     isSending: chatMutation.isPending,
     isClearing: deleteSessionMutation.isPending,
     isLoadingSession,
-    
+
     // Actions
     sendMessage,
     clearChat,
@@ -251,7 +267,7 @@ export function useChatbox(initialSessionId?: string) {
     resetSession,
     addMessage,
     updateMessage,
-    
+
     // Computed values
     hasMessages: messages.length > 0,
     canSend: !chatMutation.isPending && inputValue.trim().length > 0,

--- a/designer/src/hooks/useChatbox.ts
+++ b/designer/src/hooks/useChatbox.ts
@@ -200,7 +200,7 @@ export function useChatbox(initialSessionId?: string) {
 
     try {
       // If we don't have a valid sessionId (e.g., mock/test mode), skip server deletion
-      if (sessionId) {
+      if (sessionId && !sessionId.startsWith('local_')) {
         await deleteSessionMutation.mutateAsync(sessionId)
       }
 


### PR DESCRIPTION
## Summary by Sourcery

Revamp the Test view into a fully integrated, chat-driven testing experience by adding the TestChat component, reorganizing test case management into drawers and modals, and strengthening session and persistence logic across chat and testing hooks

New Features:
- Introduce TestChat component for interactive, chat-based testing of models within the Test view
- Add collapsible Tests and Generation Settings panels with toggles and drawers for streamlined workflow
- Implement modal dialogs for creating and editing test cases instead of inline forms and tables

Enhancements:
- Dispatch custom events (lf-test-run and lf-diagnose) to integrate test runs and diagnostics between the Test panel and chat area
- Persist user preferences (references, prompts, thinking steps, ranking, test data) and generation defaults in localStorage
- Refactor useChatSession hook to auto-initialize local sessions, migrate to server IDs, and maintain session metadata with React Query invalidation
- Improve useChatbox hook with debounced message persistence, enhanced error handling, and session management hooks exposure
- Enhance Chatbox component with global diagnose listener, diagnostic indicator, thumbs up/down feedback, retry and use-as-prompt actions

Chores:
- Add new Checkbox and Switch UI primitives
- Automatically close the chat panel when navigating to the Test page route

<!-- CLI_COVERAGE_START -->

### CLI Coverage

| File | Lines (cov/total) | Functions (cov/total) | Statements (cov/total) |
|---|---:|---:|---:|
| llamafarm-cli/cmd/chat_client.go | 138/220 (62.7%) | 0/7 (0.0%) | 97/306 (31.7%) |
| llamafarm-cli/cmd/config/config.go | 109/162 (67.3%) | 0/12 (0.0%) | 62/190 (32.6%) |
| llamafarm-cli/cmd/config/schema.go | 0/62 (0.0%) | 0/2 (0.0%) | 0/76 (0.0%) |
| llamafarm-cli/cmd/datasets.go | 20/239 (8.4%) | 0/3 (0.0%) | 10/360 (2.8%) |
| llamafarm-cli/cmd/designer.go | 7/51 (13.7%) | 0/1 (0.0%) | 2/56 (3.6%) |
| llamafarm-cli/cmd/dev.go | 7/34 (20.6%) | 0/1 (0.0%) | 2/42 (4.8%) |
| llamafarm-cli/cmd/docker_utils.go | 64/70 (91.4%) | 0/7 (0.0%) | 44/94 (46.8%) |
| llamafarm-cli/cmd/httpclient.go | 54/78 (69.2%) | 0/5 (0.0%) | 35/100 (35.0%) |
| llamafarm-cli/cmd/init.go | 5/96 (5.2%) | 0/1 (0.0%) | 3/134 (2.2%) |
| llamafarm-cli/cmd/log.go | 33/43 (76.7%) | 0/3 (0.0%) | 20/54 (37.0%) |
| llamafarm-cli/cmd/models.go | 3/7 (42.9%) | 0/1 (0.0%) | 1/6 (16.7%) |
| llamafarm-cli/cmd/projects.go | 10/69 (14.5%) | 0/1 (0.0%) | 3/78 (3.8%) |
| llamafarm-cli/cmd/rag.go | 3/7 (42.9%) | 0/1 (0.0%) | 1/6 (16.7%) |
| llamafarm-cli/cmd/root.go | 13/41 (31.7%) | 0/3 (0.0%) | 9/50 (18.0%) |
| llamafarm-cli/cmd/run.go | 4/94 (4.3%) | 0/1 (0.0%) | 2/102 (2.0%) |
| llamafarm-cli/cmd/server_utils.go | 57/222 (25.7%) | 0/9 (0.0%) | 44/300 (14.7%) |
| llamafarm-cli/cmd/tui_chat.go | 0/255 (0.0%) | 0/10 (0.0%) | 0/368 (0.0%) |
| llamafarm-cli/cmd/url_utils.go | 9/9 (100.0%) | 0/1 (0.0%) | 6/12 (50.0%) |
| llamafarm-cli/cmd/version.go | 3/6 (50.0%) | 0/1 (0.0%) | 1/4 (25.0%) |
| llamafarm-cli/cmd/watcher.go | 0/157 (0.0%) | 0/2 (0.0%) | 0/212 (0.0%) |
| llamafarm-cli/main.go | 0/3 (0.0%) | 0/1 (0.0%) | 0/3 (0.0%) |
| llamafarm-cli/tools/copy/main.go | 0/22 (0.0%) | 0/1 (0.0%) | 0/42 (0.0%) |
| llamafarm-cli/tools/cover2lcov/main.go | 0/86 (0.0%) | 0/1 (0.0%) | 0/204 (0.0%) |
| llamafarm-cli/tools/coverreport/main.go | 0/177 (0.0%) | 0/2 (0.0%) | 0/381 (0.0%) |
| total | 539/2210 (24.4%) | 0/77 (0.0%) | 342/3180 (10.8%) |

<!-- CLI_COVERAGE_END -->