### PR TITLE
feat: Include file names in dataset API responses

### DIFF
--- a/cli/cmd/datasets.go
+++ b/cli/cmd/datasets.go
@@ -77,7 +77,7 @@ var datasetsListCmd = &cobra.Command{
 		// Ensure server is up (auto-start locally if needed)
 		ensureServerAvailable(serverCfg.URL)
 
-		url := buildServerURL(serverCfg.URL, fmt.Sprintf("/v1/projects/%s/%s/datasets/", serverCfg.Namespace, serverCfg.Project))
+		url := buildServerURL(serverCfg.URL, fmt.Sprintf("/v1/projects/%s/%s/datasets/?include_file_details=false", serverCfg.Namespace, serverCfg.Project))
 		req, err := http.NewRequest("GET", url, nil)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating request: %v\n", err)

--- a/config/datamodel.py
+++ b/config/datamodel.py
@@ -3243,10 +3243,24 @@ class Rag(BaseModel):
     )
 
 
+class DatasetFile(BaseModel):
+    hash: str = Field(..., description="File content hash")
+    original_filename: str = Field(..., description="Original filename")
+    size: int = Field(..., description="File size in bytes")
+    mime_type: str = Field(..., description="MIME type of the file")
+    timestamp: float = Field(..., description="Upload timestamp")
+
+
 class Dataset(BaseModel):
     name: str = Field(..., description="Dataset name")
     rag_strategy: Optional[str] = Field("auto", description="RAG strategy to use for the dataset")
     files: list[str] = Field(..., description="List of file hashes")
+
+
+class DatasetWithFileDetails(BaseModel):
+    name: str = Field(..., description="Dataset name")
+    rag_strategy: Optional[str] = Field("auto", description="RAG strategy to use for the dataset")
+    files: list[DatasetFile] = Field(..., description="List of files with details")
 
 
 class Provider(Enum):

--- a/designer/src/components/Data/DatasetView.tsx
+++ b/designer/src/components/Data/DatasetView.tsx
@@ -90,6 +90,19 @@ function DatasetView() {
   const files = useMemo(() => {
     if (!currentApiDataset?.files) return []
     return currentApiDataset.files.map((fileObj: any) => {
+      // Handle new API response format with file details
+      if (typeof fileObj === 'object' && fileObj !== null && 'original_filename' in fileObj) {
+        return {
+          id: fileObj.hash,
+          name: fileObj.original_filename,
+          size: fileObj.size,
+          lastModified: new Date(fileObj.timestamp * 1000).toLocaleString(),
+          type: fileObj.mime_type,
+          fullHash: fileObj.hash, // Store full hash for operations
+        }
+      }
+      
+      // Fallback for legacy format (file hash strings)
       const fileHash =
         typeof fileObj === 'string' ? fileObj : fileObj?.id || fileObj || ''
       const size =

--- a/designer/src/components/Data/DatasetView.tsx
+++ b/designer/src/components/Data/DatasetView.tsx
@@ -26,6 +26,7 @@ import {
   useDeleteDatasetFile,
   useDeleteDataset,
 } from '../../hooks/useDatasets'
+import { DatasetFile, FlexibleDataset } from '../../types/datasets'
 import { defaultStrategies } from '../Rag/strategies'
 import PageActions from '../common/PageActions'
 import { Mode } from '../ModeToggle'
@@ -39,7 +40,7 @@ type Dataset = {
   processedPercent: number
   version: string
   description?: string
-  files?: string[] // Array of file hashes from API
+  files?: string[] | DatasetFile[] // Flexible file format from API
 }
 
 function DatasetView() {

--- a/designer/src/components/Data/DatasetView.tsx
+++ b/designer/src/components/Data/DatasetView.tsx
@@ -92,7 +92,11 @@ function DatasetView() {
     if (!currentApiDataset?.files) return []
     return currentApiDataset.files.map((fileObj: any) => {
       // Handle new API response format with file details
-      if (typeof fileObj === 'object' && fileObj !== null && 'original_filename' in fileObj) {
+      if (
+        typeof fileObj === 'object' &&
+        fileObj !== null &&
+        'original_filename' in fileObj
+      ) {
         return {
           id: fileObj.hash,
           name: fileObj.original_filename,
@@ -102,7 +106,7 @@ function DatasetView() {
           fullHash: fileObj.hash, // Store full hash for operations
         }
       }
-      
+
       // Fallback for legacy format (file hash strings)
       const fileHash =
         typeof fileObj === 'string' ? fileObj : fileObj?.id || fileObj || ''

--- a/designer/src/components/Data/DatasetView.tsx
+++ b/designer/src/components/Data/DatasetView.tsx
@@ -26,7 +26,7 @@ import {
   useDeleteDatasetFile,
   useDeleteDataset,
 } from '../../hooks/useDatasets'
-import { DatasetFile, FlexibleDataset } from '../../types/datasets'
+import { DatasetFile } from '../../types/datasets'
 import { defaultStrategies } from '../Rag/strategies'
 import PageActions from '../common/PageActions'
 import { Mode } from '../ModeToggle'

--- a/designer/src/types/datasets.ts
+++ b/designer/src/types/datasets.ts
@@ -6,6 +6,22 @@
  */
 
 /**
+ * File information with metadata
+ */
+export interface DatasetFile {
+  /** File content hash */
+  hash: string
+  /** Original filename */
+  original_filename: string
+  /** File size in bytes */
+  size: number
+  /** MIME type of the file */
+  mime_type: string
+  /** Upload timestamp */
+  timestamp: number
+}
+
+/**
  * Core Dataset entity structure for API communication
  * Used in responses from the datasets service
  */
@@ -16,6 +32,18 @@ export interface Dataset {
   rag_strategy: string
   /** Array of file hashes included in this dataset */
   files: string[]
+}
+
+/**
+ * Enhanced Dataset with file details for API responses
+ */
+export interface DatasetWithFileDetails {
+  /** Dataset name within the project */
+  name: string
+  /** RAG strategy used for processing */
+  rag_strategy: string
+  /** Array of files with detailed metadata */
+  files: DatasetFile[]
 }
 
 /**
@@ -42,8 +70,8 @@ export interface CreateDatasetResponse {
 export interface ListDatasetsResponse {
   /** Total number of datasets */
   total: number
-  /** Array of datasets */
-  datasets: Dataset[]
+  /** Array of datasets with file details */
+  datasets: DatasetWithFileDetails[]
 }
 
 /**

--- a/designer/src/types/datasets.ts
+++ b/designer/src/types/datasets.ts
@@ -47,6 +47,19 @@ export interface DatasetWithFileDetails {
 }
 
 /**
+ * Flexible Dataset that can contain either file hashes or file details
+ * Used for backward compatibility in API responses
+ */
+export interface FlexibleDataset {
+  /** Dataset name within the project */
+  name: string
+  /** RAG strategy used for processing */
+  rag_strategy: string
+  /** Array of files - either hashes (legacy) or detailed metadata (enhanced) */
+  files: string[] | DatasetFile[]
+}
+
+/**
  * Request payload for creating a new dataset
  */
 export interface CreateDatasetRequest {
@@ -70,8 +83,8 @@ export interface CreateDatasetResponse {
 export interface ListDatasetsResponse {
   /** Total number of datasets */
   total: number
-  /** Array of datasets with file details */
-  datasets: DatasetWithFileDetails[]
+  /** Array of datasets with flexible file format */
+  datasets: FlexibleDataset[]
 }
 
 /**

--- a/designer/src/types/datasets.ts
+++ b/designer/src/types/datasets.ts
@@ -1,6 +1,6 @@
 /**
  * Dataset API Types - aligned with server/api/routers/datasets/
- * 
+ *
  * This file contains types for Dataset API communication.
  * These types should remain stable and aligned with the API contract.
  */
@@ -181,7 +181,11 @@ export interface DatasetApiError {
  * Base error classes for Dataset API operations
  */
 export class DatasetError extends Error {
-  constructor(message: string, public statusCode?: number, public data?: any) {
+  constructor(
+    message: string,
+    public statusCode?: number,
+    public data?: any
+  ) {
     super(message)
     this.name = 'DatasetError'
   }

--- a/docs/website/package.json
+++ b/docs/website/package.json
@@ -53,5 +53,6 @@
   },
   "engines": {
     "node": ">=18.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "llamafarm-contri",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/server/api/routers/datasets/datasets.py
+++ b/server/api/routers/datasets/datasets.py
@@ -5,8 +5,9 @@ from core.celery.tasks import process_dataset_task
 from core.logging import FastAPIStructLogger
 from services.data_service import DataService, FileExistsInAnotherDatasetError
 from services.dataset_service import Dataset, DatasetService
-from config.datamodel import DatasetWithFileDetails
-from typing import Union
+from config.datamodel import DatasetWithFileDetails, DatasetFile
+from typing import Union, Any, Dict
+from fastapi import Query
 from services.project_service import ProjectService
 from services.rag_subprocess import ingest_file_with_rag
 
@@ -18,32 +19,50 @@ router = APIRouter(
 )
 
 
+class FlexibleDataset(BaseModel):
+    name: str
+    rag_strategy: str
+    files: Union[list[str], list[DatasetFile]]
+
+
 class ListDatasetsResponse(BaseModel):
     total: int
-    datasets: list[DatasetWithFileDetails]
+    datasets: list[FlexibleDataset]
 
 
-class ListDatasetsLegacyResponse(BaseModel):
-    total: int
-    datasets: list[Dataset]
-
-
-@router.get("/")
-async def list_datasets(namespace: str, project: str, include_file_details: bool = True):
+@router.get("/", response_model=ListDatasetsResponse)
+async def list_datasets(
+    namespace: str,
+    project: str,
+    include_file_details: bool = Query(True, description="Include detailed file information with original filenames")
+):
     logger.bind(namespace=namespace, project=project)
     if include_file_details:
-        datasets = DatasetService.list_datasets_with_file_details(namespace, project)
-        return ListDatasetsResponse(
-            total=len(datasets),
-            datasets=datasets,
-        )
+        detailed_datasets = DatasetService.list_datasets_with_file_details(namespace, project)
+        datasets = [
+            FlexibleDataset(
+                name=ds.name,
+                rag_strategy=ds.rag_strategy or "auto",
+                files=ds.files
+            )
+            for ds in detailed_datasets
+        ]
     else:
         # Backward compatibility: return old format for CLI
-        datasets = DatasetService.list_datasets(namespace, project)
-        return ListDatasetsLegacyResponse(
-            total=len(datasets),
-            datasets=datasets,
-        )
+        basic_datasets = DatasetService.list_datasets(namespace, project)
+        datasets = [
+            FlexibleDataset(
+                name=ds.name,
+                rag_strategy=ds.rag_strategy or "auto",
+                files=ds.files
+            )
+            for ds in basic_datasets
+        ]
+
+    return ListDatasetsResponse(
+        total=len(datasets),
+        datasets=datasets,
+    )
 
 
 class CreateDatasetRequest(BaseModel):

--- a/server/api/routers/datasets/datasets.py
+++ b/server/api/routers/datasets/datasets.py
@@ -5,6 +5,7 @@ from core.celery.tasks import process_dataset_task
 from core.logging import FastAPIStructLogger
 from services.data_service import DataService, FileExistsInAnotherDatasetError
 from services.dataset_service import Dataset, DatasetService
+from config.datamodel import DatasetWithFileDetails
 from services.project_service import ProjectService
 from services.rag_subprocess import ingest_file_with_rag
 
@@ -18,13 +19,13 @@ router = APIRouter(
 
 class ListDatasetsResponse(BaseModel):
     total: int
-    datasets: list[Dataset]
+    datasets: list[DatasetWithFileDetails]
 
 
 @router.get("/", response_model=ListDatasetsResponse)
 async def list_datasets(namespace: str, project: str):
     logger.bind(namespace=namespace, project=project)
-    datasets = DatasetService.list_datasets(namespace, project)
+    datasets = DatasetService.list_datasets_with_file_details(namespace, project)
     return ListDatasetsResponse(
         total=len(datasets),
         datasets=datasets,

--- a/server/api/routers/datasets/datasets.py
+++ b/server/api/routers/datasets/datasets.py
@@ -6,6 +6,7 @@ from core.logging import FastAPIStructLogger
 from services.data_service import DataService, FileExistsInAnotherDatasetError
 from services.dataset_service import Dataset, DatasetService
 from config.datamodel import DatasetWithFileDetails
+from typing import Union
 from services.project_service import ProjectService
 from services.rag_subprocess import ingest_file_with_rag
 
@@ -22,14 +23,27 @@ class ListDatasetsResponse(BaseModel):
     datasets: list[DatasetWithFileDetails]
 
 
-@router.get("/", response_model=ListDatasetsResponse)
-async def list_datasets(namespace: str, project: str):
+class ListDatasetsLegacyResponse(BaseModel):
+    total: int
+    datasets: list[Dataset]
+
+
+@router.get("/")
+async def list_datasets(namespace: str, project: str, include_file_details: bool = True):
     logger.bind(namespace=namespace, project=project)
-    datasets = DatasetService.list_datasets_with_file_details(namespace, project)
-    return ListDatasetsResponse(
-        total=len(datasets),
-        datasets=datasets,
-    )
+    if include_file_details:
+        datasets = DatasetService.list_datasets_with_file_details(namespace, project)
+        return ListDatasetsResponse(
+            total=len(datasets),
+            datasets=datasets,
+        )
+    else:
+        # Backward compatibility: return old format for CLI
+        datasets = DatasetService.list_datasets(namespace, project)
+        return ListDatasetsLegacyResponse(
+            total=len(datasets),
+            datasets=datasets,
+        )
 
 
 class CreateDatasetRequest(BaseModel):

--- a/server/services/dataset_service.py
+++ b/server/services/dataset_service.py
@@ -1,8 +1,8 @@
-from config.datamodel import Dataset
+from config.datamodel import Dataset, DatasetWithFileDetails, DatasetFile
 
 from api.errors import DatasetNotFoundError, NotFoundError
 from core.logging import FastAPIStructLogger
-from services.data_service import MetadataFileContent
+from services.data_service import DataService, MetadataFileContent
 from services.project_service import ProjectService
 
 # TODO: populate this with default strategies from the rug sub-system
@@ -21,6 +21,45 @@ class DatasetService:
         """
         project_config = ProjectService.load_config(namespace, project)
         return project_config.datasets
+
+    @classmethod
+    def list_datasets_with_file_details(cls, namespace: str, project: str) -> list[DatasetWithFileDetails]:
+        """
+        List all datasets for a given project with file details including original filenames
+        """
+        project_config = ProjectService.load_config(namespace, project)
+        datasets_with_details = []
+        
+        for dataset in project_config.datasets:
+            files_with_details = []
+            for file_hash in dataset.files:
+                try:
+                    metadata = DataService.get_data_file_metadata_by_hash(
+                        namespace=namespace,
+                        project_id=project,
+                        file_content_hash=file_hash
+                    )
+                    file_detail = DatasetFile(
+                        hash=metadata.hash,
+                        original_filename=metadata.original_file_name,
+                        size=metadata.size,
+                        mime_type=metadata.mime_type,
+                        timestamp=metadata.timestamp
+                    )
+                    files_with_details.append(file_detail)
+                except FileNotFoundError:
+                    # Skip files that no longer exist on disk
+                    logger.warning(f"File metadata not found for hash: {file_hash}")
+                    continue
+            
+            dataset_with_details = DatasetWithFileDetails(
+                name=dataset.name,
+                rag_strategy=dataset.rag_strategy,
+                files=files_with_details
+            )
+            datasets_with_details.append(dataset_with_details)
+        
+        return datasets_with_details
 
     @classmethod
     def create_dataset(


### PR DESCRIPTION
### **PR Description:**

fixes: #117

- Currently, when users view datasets in the UI, they only see truncated file hashes like `abc123def456...ghi012` instead of the actual filenames. This makes it impossible for users to identify which files are in their datasets without additional steps.

- This PR fixes the issue by enhancing the dataset API to return original filenames alongside file metadata.

**What changed:**
- Dataset API responses now include file details (original filename, size, mime type, timestamp) instead of just hashes
- Frontend displays actual filenames like `example.pdf` and `document.docx` 
- Backward compatibility maintained for existing hash-only responses

**Before:** Users saw cryptic hash fragments  
**After:** Users see meaningful file names they recognize

**Files modified:** 5 files across backend models, API layer, and frontend components.

## Summary by Sourcery

Include file metadata in dataset API responses and update the frontend to display human-readable file details while keeping legacy hash-only handling.

New Features:
- Enhance dataset API to return original filenames and detailed metadata (size, mime type, timestamp) alongside file hashes
- Add frontend support to display file name, size, type, and last modified timestamp with fallback to legacy hash format

Enhancements:
- Introduce new DatasetFile and DatasetWithFileDetails models in backend data schema and TypeScript types
- Switch dataset listing endpoint to use the enhanced list_datasets_with_file_details method