### PR TITLE
fix(designer): clean up Prompts page to avoid repetition in new test

### DIFF
--- a/designer/src/components/Header.tsx
+++ b/designer/src/components/Header.tsx
@@ -278,7 +278,7 @@ function Header() {
                 onClick={() => navigate('/chat/prompt')}
               >
                 <FontIcon type="prompt" className="w-6 h-6" />
-                <span>Prompt</span>
+                <span>Prompts</span>
               </button>
               <button
                 className={`w-full flex items-center justify-center gap-2 transition-colors rounded-lg p-2 ${

--- a/designer/src/components/Prompt/GeneratedOutput/PromptModal.tsx
+++ b/designer/src/components/Prompt/GeneratedOutput/PromptModal.tsx
@@ -77,7 +77,7 @@ const PromptModal: React.FC<PromptModalProps> = ({
           </div>
         </div>
 
-        <DialogFooter className="flex items-center justify-between gap-2">
+        <DialogFooter className="flex flex-row items-center justify-between sm:justify-between gap-2">
           {mode === 'edit' ? (
             <button
               className="px-3 py-2 rounded-md bg-destructive text-destructive-foreground hover:opacity-90 text-sm"

--- a/designer/src/components/Prompt/Prompt.tsx
+++ b/designer/src/components/Prompt/Prompt.tsx
@@ -2,22 +2,10 @@ import { useState } from 'react'
 import ModeToggle, { Mode } from '../ModeToggle'
 import { Button } from '../ui/button'
 import ConfigEditor from '../ConfigEditor/ConfigEditor'
-import GeneratedOutputs from './GeneratedOutput/GeneratedOutputs'
 import { usePackageModal } from '../../contexts/PackageModalContext'
+import Prompts from './GeneratedOutput/Prompts'
 
 const Prompt = () => {
-  // Persist onboarding state per active project
-  const [hasGeneratedOutputs, setHasGeneratedOutputs] = useState<boolean>(
-    () => {
-      try {
-        const project = localStorage.getItem('activeProject') || 'default'
-        const key = `prompt.onboarding.completed:${project}`
-        return localStorage.getItem(key) === '1'
-      } catch {
-        return false
-      }
-    }
-  )
   const [mode, setMode] = useState<Mode>('designer')
   const { openPackageModal } = usePackageModal()
 
@@ -25,7 +13,7 @@ const Prompt = () => {
     <div className="h-full w-full flex flex-col">
       <div className="flex items-center justify-between mb-4 flex-shrink-0">
         <h2 className="text-2xl ">
-          {mode === 'designer' ? 'Prompt' : 'Config editor'}
+          {mode === 'designer' ? 'Prompts' : 'Config editor'}
         </h2>
         <div className="flex items-center gap-3">
           <ModeToggle mode={mode} onToggle={setMode} />
@@ -35,69 +23,9 @@ const Prompt = () => {
         </div>
       </div>
       {mode === 'designer' ? (
-        hasGeneratedOutputs ? (
-          <GeneratedOutputs />
-        ) : (
-          <div className="flex-1 min-h-0 pb-6 overflow-auto">
-            <div className="bg-card rounded-lg p-4 flex flex-col">
-              <div className="mb-2">Expected outputs</div>
-              <div className="text-sm mb-6">
-                Help us generate better results, faster
-              </div>
-              <label className="text-sm mb-2">
-                What kind of output are you hoping for?
-              </label>
-              <textarea
-                className="w-full h-18 bg-secondary border-none rounded-lg px-4 py-2 text-lg mb-6 code-like text-foreground"
-                placeholder="e.g. “Summarize each entry,” “Generate a visual timeline,” “Classify logs,” “Extract sensor anomalies,” “Create a chart,” “Turn this into a checklist,” etc."
-              />
-              <label className="text-xs text-muted-foreground mb-2">
-                Example input
-              </label>
-              <input
-                className="w-full h-18 bg-secondary border-none rounded-lg px-4 py-2 mb-1 code-like text-foreground"
-                placeholder="Enter here"
-              />
-              <label className="text-xs text-muted-foreground mb-4">
-                Connect your projects to OpenAI
-              </label>
-              <div className="mb-3">
-                What are some expected outputs you'd hope to see?
-              </div>
-              <label className="text-xs text-muted-foreground mb-2">
-                Example ideal outputs
-              </label>
-              <div className="flex flex-col gap-2 mb-6">
-                <input
-                  className="w-full h-18 bg-secondary border-none rounded-lg px-4 py-2 code-like text-foreground"
-                  placeholder="Enter here"
-                />
-                <input
-                  className="w-full h-18 bg-secondary border-none rounded-lg px-4 py-2 code-like text-foreground"
-                  placeholder="Enter here"
-                />
-                <input
-                  className="w-full h-18 bg-secondary border-none rounded-lg px-4 py-2 code-like text-foreground"
-                  placeholder="Enter here"
-                />
-              </div>
-              <button
-                className="bg-primary text-primary-foreground rounded-lg px-4 py-2 w-fit self-end"
-                onClick={() => {
-                  setHasGeneratedOutputs(true)
-                  try {
-                    const project =
-                      localStorage.getItem('activeProject') || 'default'
-                    const key = `prompt.onboarding.completed:${project}`
-                    localStorage.setItem(key, '1')
-                  } catch {}
-                }}
-              >
-                Generate outputs
-              </button>
-            </div>
-          </div>
-        )
+        <div className="flex-1 min-h-0 pb-6 overflow-auto">
+          <Prompts />
+        </div>
       ) : (
         <div className="flex-1 min-h-0 overflow-hidden pb-6">
           <ConfigEditor className="h-full" />

--- a/designer/src/index.css
+++ b/designer/src/index.css
@@ -124,3 +124,11 @@ body,
     @apply bg-background text-foreground;
   }
 }
+
+/* Multi-line text clamp utilities */
+.line-clamp-6 {
+  display: -webkit-box;
+  -webkit-line-clamp: 6;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}


### PR DESCRIPTION
simple clean up - hides some stuff, fixes some bugs

## Summary by Sourcery

Replace the old Expected outputs onboarding flow on the Prompt page with a unified, project-scoped Prompts table that persists edits per active project and updates related UI labels.

Bug Fixes:
- Remove obsolete onboarding state logic and GeneratedOutputs component to prevent duplication
- Adjust PromptModal footer layout to maintain consistent spacing on small screens

Enhancements:
- Consolidate prompt management into a new Prompts component that loads default prompt rows and persists edits under a project-specific localStorage key
- Reload saved prompts when the active project changes and guard persistence to the correct storage key
- Add a multiline text clamp utility and apply it to limit preview column text to six lines
- Enhance the prompts table by updating header styles and adding descriptive guidance above the list

Chores:
- Rename “Prompt” labels in the header navigation and page title to “Prompts”

<!-- CLI_COVERAGE_START -->

### CLI Coverage

| File | Lines (cov/total) | Functions (cov/total) | Statements (cov/total) |
|---|---:|---:|---:|
| llamafarm-cli/cmd/chat_client.go | 138/220 (62.7%) | 0/7 (0.0%) | 97/306 (31.7%) |
| llamafarm-cli/cmd/config/config.go | 109/162 (67.3%) | 0/12 (0.0%) | 62/190 (32.6%) |
| llamafarm-cli/cmd/config/schema.go | 0/62 (0.0%) | 0/2 (0.0%) | 0/76 (0.0%) |
| llamafarm-cli/cmd/datasets.go | 20/239 (8.4%) | 0/3 (0.0%) | 10/360 (2.8%) |
| llamafarm-cli/cmd/designer.go | 7/51 (13.7%) | 0/1 (0.0%) | 2/56 (3.6%) |
| llamafarm-cli/cmd/dev.go | 7/34 (20.6%) | 0/1 (0.0%) | 2/42 (4.8%) |
| llamafarm-cli/cmd/docker_utils.go | 64/70 (91.4%) | 0/7 (0.0%) | 44/94 (46.8%) |
| llamafarm-cli/cmd/httpclient.go | 54/78 (69.2%) | 0/5 (0.0%) | 35/100 (35.0%) |
| llamafarm-cli/cmd/init.go | 5/96 (5.2%) | 0/1 (0.0%) | 3/134 (2.2%) |
| llamafarm-cli/cmd/log.go | 33/43 (76.7%) | 0/3 (0.0%) | 20/54 (37.0%) |
| llamafarm-cli/cmd/models.go | 3/7 (42.9%) | 0/1 (0.0%) | 1/6 (16.7%) |
| llamafarm-cli/cmd/projects.go | 10/69 (14.5%) | 0/1 (0.0%) | 3/78 (3.8%) |
| llamafarm-cli/cmd/rag.go | 3/7 (42.9%) | 0/1 (0.0%) | 1/6 (16.7%) |
| llamafarm-cli/cmd/root.go | 13/41 (31.7%) | 0/3 (0.0%) | 9/50 (18.0%) |
| llamafarm-cli/cmd/run.go | 4/94 (4.3%) | 0/1 (0.0%) | 2/102 (2.0%) |
| llamafarm-cli/cmd/server_utils.go | 57/222 (25.7%) | 0/9 (0.0%) | 44/300 (14.7%) |
| llamafarm-cli/cmd/tui_chat.go | 0/255 (0.0%) | 0/10 (0.0%) | 0/368 (0.0%) |
| llamafarm-cli/cmd/url_utils.go | 9/9 (100.0%) | 0/1 (0.0%) | 6/12 (50.0%) |
| llamafarm-cli/cmd/version.go | 3/6 (50.0%) | 0/1 (0.0%) | 1/4 (25.0%) |
| llamafarm-cli/cmd/watcher.go | 0/157 (0.0%) | 0/2 (0.0%) | 0/212 (0.0%) |
| llamafarm-cli/main.go | 0/3 (0.0%) | 0/1 (0.0%) | 0/3 (0.0%) |
| llamafarm-cli/tools/copy/main.go | 0/22 (0.0%) | 0/1 (0.0%) | 0/42 (0.0%) |
| llamafarm-cli/tools/cover2lcov/main.go | 0/86 (0.0%) | 0/1 (0.0%) | 0/204 (0.0%) |
| llamafarm-cli/tools/coverreport/main.go | 0/177 (0.0%) | 0/2 (0.0%) | 0/381 (0.0%) |
| total | 539/2210 (24.4%) | 0/77 (0.0%) | 342/3180 (10.8%) |

<!-- CLI_COVERAGE_END -->