### PR TITLE
fix: lf run project path + jsonschema validation error output

### DIFF
--- a/cli/cmd/config/types_test.go
+++ b/cli/cmd/config/types_test.go
@@ -218,6 +218,19 @@ func TestInvalidJSONConfig(t *testing.T) {
 	}
 }
 
+func TestInvalidYAMLConfig(t *testing.T) {
+	// Test error handling for invalid YAML
+	invalidYAML := `version: v1
+name: test
+invalid yaml: [ unclosed bracket`
+	dir := writeTempConfigDir(t, invalidYAML)
+
+	_, err := LoadConfig(dir)
+	if err == nil {
+		t.Fatal("expected error for invalid YAML, but got none")
+	}
+}
+
 func TestIsConfigFile(t *testing.T) {
 	// Test that IsConfigFile correctly identifies config files
 	tests := []struct {

--- a/cli/cmd/dev.go
+++ b/cli/cmd/dev.go
@@ -34,7 +34,7 @@ var devCmd = &cobra.Command{
 		cwd := getEffectiveCWD()
 		cfg, err := config.LoadConfig(cwd)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "No config file found in target directory. Run `lf init` to create a new project.\n")
+			fmt.Fprintf(os.Stderr, "Error loading config: %v\nRun `lf init` to create a new project if none exists.\n", err)
 			os.Exit(1)
 		}
 

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -15,7 +15,7 @@ var (
 	runRAGDatabase       string
 	runRetrievalStrategy string
 	runRAGTopK           int
-	runNoRAG             bool // Changed: now we track if RAG is disabled
+	runNoRAG             bool
 	runRAGScoreThreshold float64
 )
 
@@ -161,7 +161,7 @@ Examples:
 			MaxTokens:   maxTokens,
 			HTTPClient:  getHTTPClient(),
 			// RAG settings - RAG is enabled by default unless --no-rag is used
-			RAGEnabled:           !runNoRAG, // Changed: RAG is on by default
+			RAGEnabled:           !runNoRAG,
 			RAGDatabase:          runRAGDatabase,
 			RAGRetrievalStrategy: runRetrievalStrategy,
 			RAGTopK:              runRAGTopK,
@@ -185,7 +185,6 @@ Examples:
 func init() {
 	runCmd.Flags().StringVarP(&runInputFile, "file", "f", "", "path to file containing input text")
 
-	// RAG flags - RAG is enabled by default now
 	runCmd.Flags().BoolVar(&runNoRAG, "no-rag", false, "Disable RAG (use LLM only without document retrieval)")
 	runCmd.Flags().StringVar(&runRAGDatabase, "database", "", "Database to use for RAG (default: from config)")
 	runCmd.Flags().StringVar(&runRetrievalStrategy, "retrieval-strategy", "", "Retrieval strategy to use (default: from database config)")

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -11,11 +11,11 @@ import (
 )
 
 var (
-	runInputFile        string
-	runRAGDatabase      string
+	runInputFile         string
+	runRAGDatabase       string
 	runRetrievalStrategy string
-	runRAGTopK          int
-	runNoRAG            bool  // Changed: now we track if RAG is disabled
+	runRAGTopK           int
+	runNoRAG             bool // Changed: now we track if RAG is disabled
 	runRAGScoreThreshold float64
 )
 
@@ -37,16 +37,16 @@ Examples:
 
   # Project inferred from llamafarm.yaml, input file
   lf run -f ./prompt.txt
-  
+
   # Run with RAG (default behavior)
   lf run "What is transformer architecture?"
-  
+
   # Run with specific database
   lf run --database main_database "Explain attention mechanism"
-  
+
   # Run with custom retrieval strategy and top-k
   lf run --retrieval-strategy filtered_search --rag-top-k 10 "How do neural networks work?"
-  
+
   # Run WITHOUT RAG (LLM only)
   lf run --no-rag "What is machine learning?"`,
 	Args: func(cmd *cobra.Command, args []string) error {
@@ -119,8 +119,28 @@ Examples:
 			proj = strings.TrimSpace(parts[1])
 		}
 
+		cwd := getEffectiveCWD()
+
+		if ns == "" || proj == "" {
+			cfg, err := config.LoadConfig(cwd)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "No config file found in target directory.\n")
+				os.Exit(1)
+			}
+
+			projectInfo, err := cfg.GetProjectInfo()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: Could not extract project info for watcher: %v\n", err)
+			} else {
+				// Start the config file watcher in background
+				if err := StartConfigWatcher(projectInfo.Namespace, projectInfo.Project); err != nil {
+					fmt.Fprintf(os.Stderr, "Warning: Failed to start config watcher: %v\n", err)
+				}
+			}
+		}
+
 		// Resolve server configuration (strict): if ns/proj are absent, require from llamafarm.yaml
-		serverCfg, err := config.GetServerConfig("", serverURL, ns, proj)
+		serverCfg, err := config.GetServerConfig(cwd, serverURL, ns, proj)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
@@ -141,11 +161,11 @@ Examples:
 			MaxTokens:   maxTokens,
 			HTTPClient:  getHTTPClient(),
 			// RAG settings - RAG is enabled by default unless --no-rag is used
-			RAGEnabled:          !runNoRAG,  // Changed: RAG is on by default
-			RAGDatabase:         runRAGDatabase,
+			RAGEnabled:           !runNoRAG, // Changed: RAG is on by default
+			RAGDatabase:          runRAGDatabase,
 			RAGRetrievalStrategy: runRetrievalStrategy,
-			RAGTopK:             runRAGTopK,
-			RAGScoreThreshold:   runRAGScoreThreshold,
+			RAGTopK:              runRAGTopK,
+			RAGScoreThreshold:    runRAGScoreThreshold,
 		}
 
 		messages := []ChatMessage{{Role: "user", Content: input}}
@@ -164,13 +184,13 @@ Examples:
 
 func init() {
 	runCmd.Flags().StringVarP(&runInputFile, "file", "f", "", "path to file containing input text")
-	
+
 	// RAG flags - RAG is enabled by default now
 	runCmd.Flags().BoolVar(&runNoRAG, "no-rag", false, "Disable RAG (use LLM only without document retrieval)")
 	runCmd.Flags().StringVar(&runRAGDatabase, "database", "", "Database to use for RAG (default: from config)")
 	runCmd.Flags().StringVar(&runRetrievalStrategy, "retrieval-strategy", "", "Retrieval strategy to use (default: from database config)")
 	runCmd.Flags().IntVar(&runRAGTopK, "rag-top-k", 5, "Number of RAG results to retrieve")
 	runCmd.Flags().Float64Var(&runRAGScoreThreshold, "rag-score-threshold", 0.0, "Minimum score threshold for RAG results")
-	
+
 	rootCmd.AddCommand(runCmd)
 }

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -124,7 +124,7 @@ Examples:
 		if ns == "" || proj == "" {
 			cfg, err := config.LoadConfig(cwd)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "No config file found in target directory.\n")
+				fmt.Fprintf(os.Stderr, "Error loading config: %v\n", err)
 				os.Exit(1)
 			}
 

--- a/config/helpers/loader.py
+++ b/config/helpers/loader.py
@@ -92,7 +92,8 @@ def _validate_config(config: dict, schema: dict) -> None:
         # Simple validation since schema is already fully dereferenced by compile_schema.py
         jsonschema.validate(config, schema)
     except jsonschema.ValidationError as e:
-        raise ConfigError(f"Configuration validation error: {e.message}") from e
+        path_str = ".".join(str(p) for p in e.path) if hasattr(e, "path") else ""
+        raise ConfigError(f"Configuration validation error: {e.message} at path {path_str}") from e
     except Exception as e:
         raise ConfigError(f"Error during validation: {e}") from e
 

--- a/config/helpers/loader.py
+++ b/config/helpers/loader.py
@@ -93,7 +93,7 @@ def _validate_config(config: dict, schema: dict) -> None:
         jsonschema.validate(config, schema)
     except jsonschema.ValidationError as e:
         path_str = ".".join(str(p) for p in e.path) if hasattr(e, "path") else ""
-        raise ConfigError(f"Configuration validation error: {e.message} at path {path_str}") from e
+        raise ConfigError(f"Configuration validation error: {e.message}" + (f" at path {path_str}" if path_str else "")) from e
     except Exception as e:
         raise ConfigError(f"Error during validation: {e}") from e
 


### PR DESCRIPTION
## Summary by Sourcery

Enhance the CLI run command to better infer project context and launch a config watcher, switch RAG on by default, and provide more detailed JSON schema validation errors.

New Features:
- Start a background config file watcher when namespace or project is not specified

Bug Fixes:
- Include JSON path in configuration validation error messages

Enhancements:
- Infer project path from the current working directory when flags are omitted
- Pass working directory to server configuration loader in run command
- Enable RAG by default and allow disabling it with the --no-rag flag