### PR TITLE
Implement rag self-health check and server cache

### DIFF
--- a/rag/celery_app.py
+++ b/rag/celery_app.py
@@ -1,0 +1,103 @@
+"""
+RAG Celery App Configuration
+
+This module configures the Celery application for the RAG service worker.
+It sets up the broker connection, task routing, and imports all RAG tasks.
+"""
+
+import logging
+import os
+from pathlib import Path
+
+from celery import Celery, signals
+
+logger = logging.getLogger(__name__)
+
+# Create Celery app instance
+app = Celery("LlamaFarm-RAG-Worker")
+
+# Get data directory from environment - use same default as server
+lf_data_dir = os.environ.get("LF_DATA_DIR", str(Path.home() / ".llamafarm"))
+
+# Create necessary broker directories
+_folders = [
+    f"{lf_data_dir}/broker/in",
+    f"{lf_data_dir}/broker/processed",
+    f"{lf_data_dir}/broker/results",
+]
+
+for folder in _folders:
+    os.makedirs(folder, exist_ok=True)
+
+# Configure broker based on environment variables
+celery_broker_url = os.environ.get("CELERY_BROKER_URL", "")
+celery_result_backend = os.environ.get("CELERY_RESULT_BACKEND", "")
+
+if celery_broker_url and celery_result_backend:
+    # Use external broker (Redis, RabbitMQ, etc.)
+    app.conf.update(
+        broker_url=celery_broker_url,
+        result_backend=celery_result_backend,
+        result_persistent=True,
+        task_serializer="json",
+        accept_content=["json"],
+        result_serializer="json",
+        timezone="UTC",
+        enable_utc=True,
+        # Task routing - only handle rag.* tasks
+        task_routes={
+            "rag.*": {"queue": "rag"},
+        },
+    )
+else:
+    # Use default filesystem broker (same as server)
+    app.conf.update(
+        broker_url="filesystem://",
+        broker_transport_options={
+            "data_folder_in": f"{lf_data_dir}/broker/in",
+            "data_folder_out": f"{lf_data_dir}/broker/in",  # Must be same as data_folder_in
+            "data_folder_processed": f"{lf_data_dir}/broker/processed",
+        },
+        result_backend=f"file://{lf_data_dir}/broker/results",
+        result_persistent=True,
+        task_serializer="json",
+        accept_content=["json"],
+        result_serializer="json",
+        timezone="UTC",
+        enable_utc=True,
+        # Task routing - only handle rag.* tasks
+        task_routes={
+            "rag.*": {"queue": "rag"},
+        },
+    )
+
+
+# Intentionally empty function to prevent Celery from overriding root logger config
+@signals.setup_logging.connect
+def setup_celery_logging(**kwargs):
+    pass
+
+
+# Import and register health tasks
+try:
+    from tasks.health_tasks import create_health_tasks
+    rag_health_check_task, rag_ping_task = create_health_tasks(app)
+    logger.info("RAG health tasks registered successfully")
+except Exception as e:
+    logger.warning(f"Failed to import RAG health tasks: {e}")
+
+
+def run_worker():
+    try:
+        # Only consume from the 'rag' queue, not the 'celery' queue
+        app.worker_main(argv=["worker", "-P", "solo", "--uid", "0", "-Q", "rag"])
+    except KeyboardInterrupt:
+        logger.info("RAG worker shutting down due to keyboard interrupt")
+    except Exception as e:
+        logger.error("RAG worker failed to start", extra={"error": str(e)})
+        raise
+
+
+# Only run worker if this module is the main entry point
+if __name__ == "__main__":
+    run_worker()

--- a/rag/main.py
+++ b/rag/main.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""
+RAG Service Celery Worker Entry Point
+
+This module serves as the main entry point for the RAG container when running
+as a Celery worker service. It connects to the Celery broker and handles
+RAG-related tasks from the server.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+# Add the current directory to Python path for imports
+sys.path.insert(0, str(Path(__file__).parent))
+
+from celery_app import app, run_worker
+
+
+def main():
+    """Main entry point for RAG Celery worker."""
+    print("Starting RAG Celery worker service")
+    
+    # Log environment info
+    print(f"Data directory: {os.environ.get('LF_DATA_DIR', str(Path.home() / '.llamafarm'))}")
+    print(f"Python path: {sys.path[:3]}")  # First few paths for debugging
+    
+    # Log registered tasks for debugging
+    try:
+        registered_tasks = list(app.tasks.keys())
+        rag_tasks = [task for task in registered_tasks if task.startswith("rag.")]
+        print(f"Total registered tasks: {len(registered_tasks)}")
+        print(f"RAG tasks found: {len(rag_tasks)}")
+        
+        if rag_tasks:
+            print("RAG tasks:")
+            for task in sorted(rag_tasks):
+                print(f"  - {task}")
+    except Exception as e:
+        print(f"Could not list registered tasks: {e}")
+    
+    # Start the worker
+    run_worker()
+
+
+if __name__ == "__main__":
+    main()

--- a/rag/tasks/__init__.py
+++ b/rag/tasks/__init__.py
@@ -1,0 +1,17 @@
+"""
+RAG Celery Tasks Package
+
+This package contains all Celery task implementations for the RAG service.
+Tasks are organized by functionality:
+- search_tasks: RAG search and database queries
+- ingest_tasks: File ingestion and processing
+- query_tasks: Complex RAG query operations
+- health_tasks: Health monitoring and diagnostics
+"""
+
+from .health_tasks import rag_health_check_task, rag_ping_task
+
+__all__ = [
+    "rag_health_check_task",
+    "rag_ping_task",
+]

--- a/rag/tasks/health_tasks.py
+++ b/rag/tasks/health_tasks.py
@@ -1,0 +1,208 @@
+"""
+RAG Health Check Tasks
+
+Celery tasks for RAG service health monitoring and diagnostics.
+"""
+
+import logging
+import time
+from typing import Any, Dict
+
+from celery import Task
+
+logger = logging.getLogger(__name__)
+
+
+class HealthTask(Task):
+    """Base task class for health check operations."""
+
+    def on_failure(self, exc, task_id, args, kwargs, einfo):
+        """Log task failure details."""
+        logger.error(
+            "RAG health task failed",
+            extra={
+                "task_id": task_id,
+                "task_name": self.name,
+                "error": str(exc),
+                "args": args,
+                "kwargs": kwargs,
+            },
+        )
+
+
+def create_health_tasks(app):
+    """Create health check tasks bound to the given Celery app."""
+    
+    @app.task(bind=True, base=HealthTask, name="rag.health_check")
+    def rag_health_check_task(self) -> Dict[str, Any]:
+        """
+        Perform a comprehensive health check of the RAG service.
+        
+        This task tests core RAG functionality and returns detailed health status.
+        It's designed to be called by the server to check RAG service availability.
+        
+        Returns:
+            Dict containing health status, metrics, and diagnostic information
+        """
+        start_time = time.time()
+        
+        logger.info(
+            "Starting RAG health check",
+            extra={"task_id": self.request.id}
+        )
+        
+        health_data = {
+            "status": "healthy",
+            "timestamp": int(start_time),
+            "task_id": self.request.id,
+            "worker_id": getattr(self.request, 'hostname', 'unknown'),
+            "checks": {},
+            "metrics": {},
+            "errors": []
+        }
+        
+        try:
+            # Check 1: Task system is working (we're already here, so this passes)
+            health_data["checks"]["task_system"] = {
+                "status": "healthy",
+                "message": "RAG worker processing tasks"
+            }
+            
+            # Check 2: Import system - verify we can import core RAG modules
+            try:
+                from api import DatabaseSearchAPI
+                from core.ingest_handler import IngestHandler
+                health_data["checks"]["imports"] = {
+                    "status": "healthy", 
+                    "message": "Core RAG modules importable"
+                }
+            except Exception as e:
+                health_data["checks"]["imports"] = {
+                    "status": "degraded",
+                    "message": f"Import issues: {str(e)}"
+                }
+                health_data["errors"].append(f"Import error: {e}")
+            
+            # Check 3: Configuration system - verify we can load config templates
+            try:
+                import yaml
+                
+                # Try to load a basic YAML to test the system
+                test_yaml = "test: value"
+                yaml.safe_load(test_yaml)
+                
+                health_data["checks"]["config_system"] = {
+                    "status": "healthy",
+                    "message": "Configuration system functional"
+                }
+            except Exception as e:
+                health_data["checks"]["config_system"] = {
+                    "status": "degraded", 
+                    "message": f"Config system issues: {str(e)}"
+                }
+                health_data["errors"].append(f"Config error: {e}")
+            
+            # Check 4: Memory and performance metrics
+            try:
+                import psutil
+                import os
+                
+                process = psutil.Process(os.getpid())
+                memory_mb = process.memory_info().rss / 1024 / 1024
+                cpu_percent = process.cpu_percent()
+                
+                health_data["metrics"]["memory_mb"] = round(memory_mb, 2)
+                health_data["metrics"]["cpu_percent"] = cpu_percent
+                
+                # Flag if resource usage is high
+                if memory_mb > 1000:  # > 1GB
+                    health_data["checks"]["memory"] = {
+                        "status": "degraded",
+                        "message": f"High memory usage: {memory_mb:.1f}MB"
+                    }
+                else:
+                    health_data["checks"]["memory"] = {
+                        "status": "healthy",
+                        "message": f"Memory usage normal: {memory_mb:.1f}MB"
+                    }
+                    
+            except Exception as e:
+                health_data["checks"]["performance"] = {
+                    "status": "degraded",
+                    "message": f"Cannot collect metrics: {str(e)}"
+                }
+            
+            # Determine overall status based on individual checks
+            check_statuses = [check["status"] for check in health_data["checks"].values()]
+            
+            if "unhealthy" in check_statuses:
+                health_data["status"] = "unhealthy"
+            elif "degraded" in check_statuses:
+                health_data["status"] = "degraded"
+            else:
+                health_data["status"] = "healthy"
+            
+            # Add timing metrics
+            duration_ms = int((time.time() - start_time) * 1000)
+            health_data["metrics"]["check_duration_ms"] = duration_ms
+            
+            logger.info(
+                "RAG health check completed",
+                extra={
+                    "task_id": self.request.id,
+                    "status": health_data["status"],
+                    "duration_ms": duration_ms,
+                    "checks_passed": len([c for c in check_statuses if c == "healthy"]),
+                    "total_checks": len(check_statuses)
+                }
+            )
+            
+            return health_data
+            
+        except Exception as e:
+            logger.error(
+                "RAG health check failed",
+                extra={
+                    "task_id": self.request.id,
+                    "error": str(e)
+                },
+                exc_info=True
+            )
+            
+            # Return failure status
+            return {
+                "status": "unhealthy",
+                "timestamp": int(start_time),
+                "task_id": self.request.id,
+                "worker_id": getattr(self.request, 'hostname', 'unknown'),
+                "checks": {},
+                "metrics": {"check_duration_ms": int((time.time() - start_time) * 1000)},
+                "errors": [f"Health check exception: {str(e)}"],
+                "message": f"Health check failed: {str(e)}"
+            }
+
+    @app.task(bind=True, base=HealthTask, name="rag.ping")
+    def rag_ping_task(self) -> Dict[str, Any]:
+        """
+        Simple ping task for basic connectivity testing.
+        
+        Returns:
+            Dict with basic ping response and timing
+        """
+        start_time = time.time()
+        
+        return {
+            "status": "healthy",
+            "message": "RAG worker responding",
+            "timestamp": int(start_time),
+            "task_id": self.request.id,
+            "worker_id": getattr(self.request, 'hostname', 'unknown'),
+            "latency_ms": int((time.time() - start_time) * 1000)
+        }
+    
+    return rag_health_check_task, rag_ping_task
+
+
+# Global variables to store the tasks once created
+rag_health_check_task = None
+rag_ping_task = None

--- a/server/services/health_service.py
+++ b/server/services/health_service.py
@@ -219,6 +219,62 @@ def _check_celery() -> dict:
         }
 
 
+def _check_rag_service() -> dict:
+    """Check RAG service health using cached status with background updates."""
+    start = _now_ms()
+    try:
+        from services.rag_health_cache import get_rag_health_cache
+        
+        # Get cached health status (non-blocking)
+        cache = get_rag_health_cache()
+        health_data = cache.get_cached_health()
+        
+        # Convert to health service format
+        status = health_data.get("status", "unhealthy")
+        message = health_data.get("message", "Unknown RAG status")
+        
+        # Add cache metadata to message if available
+        cache_age = health_data.get("cache_age_seconds", -1)
+        source = health_data.get("source", "unknown")
+        
+        if source == "cache" and cache_age >= 0:
+            if cache_age < 60:
+                message += f" (cached: {cache_age}s ago)"
+            else:
+                message += f" (cached: {cache_age//60}m ago)"
+        elif source == "immediate_check":
+            message += " (immediate check)"
+            
+        # Add detailed information if available
+        details = {}
+        if "worker_id" in health_data:
+            details["worker_id"] = health_data["worker_id"]
+        if "checks" in health_data:
+            details["checks"] = health_data["checks"]
+        if "metrics" in health_data:
+            details["metrics"] = health_data["metrics"]
+            
+        result = {
+            "name": "rag-service",
+            "status": status,
+            "message": message,
+            "latency_ms": _now_ms() - start,
+        }
+        
+        if details:
+            result["details"] = details
+            
+        return result
+        
+    except Exception as e:
+        return {
+            "name": "rag-service",
+            "status": "unhealthy",
+            "message": f"RAG health cache error: {e}",
+            "latency_ms": _now_ms() - start,
+        }
+
+
 def compute_overall_status(components: list[dict], seeds: list[dict]) -> str:
     order = {"healthy": 0, "degraded": 1, "unhealthy": 2}
     worst = 0
@@ -236,6 +292,7 @@ def health_summary() -> dict[str, Any]:
     components.append(_check_storage())
     components.append(_check_ollama())
     components.append(_check_celery())
+    components.append(_check_rag_service())
 
     seeds.append(_check_seed_project())
 

--- a/server/services/rag_health_cache.py
+++ b/server/services/rag_health_cache.py
@@ -1,0 +1,235 @@
+"""
+RAG Health Cache Service
+
+This service manages cached health status for the RAG service to avoid blocking
+health checks while still providing up-to-date information.
+"""
+
+import asyncio
+import logging
+import time
+from typing import Any, Dict, Optional
+from threading import Lock, Thread
+
+from celery import signature
+
+logger = logging.getLogger(__name__)
+
+
+class RAGHealthCache:
+    """
+    Manages cached RAG health status with periodic background updates.
+    
+    This class provides non-blocking access to RAG health information by:
+    1. Maintaining a cache of the last known health status
+    2. Periodically updating the cache in the background
+    3. Falling back to fast ping checks when needed
+    """
+    
+    def __init__(self, update_interval: int = 30, timeout: float = 5.0):
+        """
+        Initialize the RAG health cache.
+        
+        Args:
+            update_interval: Seconds between background health checks
+            timeout: Timeout for health check tasks in seconds
+        """
+        self.update_interval = update_interval
+        self.timeout = timeout
+        self.cache: Optional[Dict[str, Any]] = None
+        self.cache_timestamp: float = 0
+        self.lock = Lock()
+        self.background_thread: Optional[Thread] = None
+        self.running = False
+        
+    def start_background_updates(self):
+        """Start the background thread that periodically updates health status."""
+        if self.background_thread and self.background_thread.is_alive():
+            return
+            
+        self.running = True
+        self.background_thread = Thread(target=self._background_update_loop, daemon=True)
+        self.background_thread.start()
+        logger.info("RAG health cache background updates started")
+        
+    def stop_background_updates(self):
+        """Stop the background update thread."""
+        self.running = False
+        if self.background_thread:
+            self.background_thread.join(timeout=1.0)
+        logger.info("RAG health cache background updates stopped")
+        
+    def _background_update_loop(self):
+        """Background thread loop that periodically updates the cache."""
+        while self.running:
+            try:
+                # Perform health check
+                health_data = self._perform_health_check()
+                
+                # Update cache
+                with self.lock:
+                    self.cache = health_data
+                    self.cache_timestamp = time.time()
+                    
+                logger.debug(
+                    "RAG health cache updated",
+                    extra={
+                        "status": health_data.get("status", "unknown") if health_data else "failed",
+                        "cache_age": 0
+                    }
+                )
+                
+            except Exception as e:
+                logger.warning(f"Background RAG health check failed: {e}")
+                
+            # Wait for next update
+            for _ in range(self.update_interval):
+                if not self.running:
+                    break
+                time.sleep(1)
+                
+    def _perform_health_check(self) -> Optional[Dict[str, Any]]:
+        """
+        Perform the actual health check by calling the RAG health task.
+        
+        Returns:
+            Health data dict or None if check failed
+        """
+        try:
+            from core.celery.celery import app as celery_app  # type: ignore
+            
+            # Try comprehensive health check first
+            health_task = signature("rag.health_check", app=celery_app)
+            result = health_task.apply_async()
+            
+            try:
+                health_data = result.get(timeout=self.timeout)
+                if isinstance(health_data, dict):
+                    return health_data
+            except Exception:
+                # Comprehensive check failed, try simple ping
+                ping_task = signature("rag.ping", app=celery_app)
+                ping_result = ping_task.apply_async()
+                
+                try:
+                    ping_data = ping_result.get(timeout=2.0)  # Shorter timeout for ping
+                    if isinstance(ping_data, dict):
+                        # Convert ping response to health format
+                        return {
+                            "status": ping_data.get("status", "degraded"),
+                            "timestamp": ping_data.get("timestamp", int(time.time())),
+                            "message": "RAG worker responding (ping only)",
+                            "worker_id": ping_data.get("worker_id", "unknown"),
+                            "checks": {
+                                "connectivity": {
+                                    "status": "healthy",
+                                    "message": "RAG worker reachable"
+                                }
+                            },
+                            "metrics": {
+                                "latency_ms": ping_data.get("latency_ms", 0)
+                            },
+                            "errors": [],
+                            "ping_only": True
+                        }
+                except Exception:
+                    pass
+                    
+            return None
+            
+        except Exception as e:
+            logger.warning(f"RAG health check failed: {e}")
+            return None
+            
+    def get_cached_health(self) -> Dict[str, Any]:
+        """
+        Get the current cached health status.
+        
+        Returns:
+            Health status dict with cache metadata
+        """
+        with self.lock:
+            now = time.time()
+            cache_age = int(now - self.cache_timestamp) if self.cache_timestamp > 0 else -1
+            
+            if self.cache is None:
+                # No cache yet, try immediate check with short timeout
+                immediate_health = self._perform_quick_check()
+                return {
+                    "status": "degraded" if immediate_health else "unhealthy",
+                    "message": "RAG worker responding" if immediate_health else "RAG worker not responding",
+                    "timestamp": int(now),
+                    "cache_age_seconds": 0,
+                    "source": "immediate_check"
+                }
+                
+            # Return cached data with metadata
+            cached_health = self.cache.copy()
+            cached_health["cache_age_seconds"] = cache_age
+            cached_health["source"] = "cache"
+            
+            # Mark as stale if cache is too old
+            if cache_age > self.update_interval * 2:
+                cached_health["status"] = "degraded"
+                cached_health["message"] = f"Cached status (stale: {cache_age}s old)"
+                
+            return cached_health
+            
+    def _perform_quick_check(self) -> bool:
+        """
+        Perform a quick connectivity check.
+        
+        Returns:
+            True if RAG worker is reachable, False otherwise
+        """
+        try:
+            from core.celery.celery import app as celery_app  # type: ignore
+            
+            ping_task = signature("rag.ping", app=celery_app)
+            result = ping_task.apply_async()
+            ping_data = result.get(timeout=1.0)  # Very short timeout
+            
+            return isinstance(ping_data, dict) and ping_data.get("status") == "healthy"
+            
+        except Exception:
+            return False
+            
+    def force_update(self) -> Dict[str, Any]:
+        """
+        Force an immediate health check update.
+        
+        Returns:
+            Updated health status
+        """
+        health_data = self._perform_health_check()
+        
+        with self.lock:
+            if health_data:
+                self.cache = health_data
+                self.cache_timestamp = time.time()
+            
+        return self.get_cached_health()
+
+
+# Global cache instance
+_rag_health_cache: Optional[RAGHealthCache] = None
+
+
+def get_rag_health_cache() -> RAGHealthCache:
+    """Get the global RAG health cache instance."""
+    global _rag_health_cache
+    
+    if _rag_health_cache is None:
+        _rag_health_cache = RAGHealthCache()
+        _rag_health_cache.start_background_updates()
+        
+    return _rag_health_cache
+
+
+def shutdown_rag_health_cache():
+    """Shutdown the global RAG health cache."""
+    global _rag_health_cache
+    
+    if _rag_health_cache:
+        _rag_health_cache.stop_background_updates()
+        _rag_health_cache = None


### PR DESCRIPTION
Implement a robust, non-blocking RAG service health check by introducing dedicated RAG health tasks and a server-side caching mechanism.

The previous RAG health check was unreliable and could block the server's `/health` endpoint. This PR moves the health check logic to the RAG service itself, allowing it to report its own status. The server then periodically fetches and caches this status, ensuring the `/health` endpoint remains responsive while providing detailed, up-to-date RAG service diagnostics.

---
<a href="https://cursor.com/background-agent?bcId=bc-584cfca4-d9c7-48b2-b947-af618348a35b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-584cfca4-d9c7-48b2-b947-af618348a35b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

## Summary by Sourcery

Add a non-blocking self-health check for the RAG service by moving health logic into Celery tasks, caching results server-side, and integrating the cache into the main `/health` endpoint.

New Features:
- Introduce Celery tasks (`rag.health_check` and `rag.ping`) for detailed RAG service health probes
- Add a RAGHealthCache service that periodically updates and stores health status in the background
- Configure a dedicated Celery app and entrypoint for the RAG worker with health tasks registration
- Extend the server’s health service to fetch and report cached RAG health data asynchronously

Enhancements:
- Ensure the `/health` endpoint remains responsive by using cached RAG health status with immediate fallback checks
- Include cache metadata (age, source) and detailed diagnostics in reported RAG health