### PR TITLE
chore: add local RAG worker support for nx

### DIFF
--- a/rag/project.json
+++ b/rag/project.json
@@ -1,0 +1,24 @@
+{
+    "root": "rag/",
+    "targets": {
+        "start": {
+            "executor": "nx:run-commands",
+            "options": {
+                "cwd": "{workspaceRoot}/rag",
+                "command": "uv run python main.py",
+                "output": "inherit"
+            }
+        },
+        "build": {
+            "cwd": "..",
+            "command": "docker build -t llamafarm-rag -f rag/Dockerfile ."
+        },
+        "test": {
+            "executor": "nx:run-commands",
+            "options": {
+                "cwd": "{workspaceRoot}/rag",
+                "command": "uv run pytest -v --cov=. --cov-report=term-missing"
+            }
+        }
+    }
+}

--- a/start-local.sh
+++ b/start-local.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Script to start both server and RAG worker locally for development
+
+echo "Starting LlamaFarm services locally..."
+
+# Kill any existing processes
+echo "Stopping any existing services..."
+pkill -f "nx start server" 2>/dev/null
+pkill -f "nx start rag" 2>/dev/null
+pkill -f "celery.*LlamaFarm" 2>/dev/null
+sleep 2
+
+# Start RAG worker in background
+echo "Starting RAG worker..."
+nx start rag &
+RAG_PID=$!
+
+# Give RAG worker time to start
+sleep 3
+
+# Start server (foreground)
+echo "Starting server..."
+nx start server
+
+# Cleanup on exit
+trap "kill $RAG_PID 2>/dev/null; pkill -f 'celery.*LlamaFarm' 2>/dev/null" EXIT


### PR DESCRIPTION
## Problem
After PR #213 separated RAG into its own container for Docker deployment, the RAG worker doesn't start when running the server locally with `nx start server`. This causes RAG health checks and tasks to timeout with errors like:
```
Exception: Task timed out or failed: PENDING
```

## Solution
- Add `rag/project.json` to enable running the RAG worker with nx
- Add `start-local.sh` convenience script to start both services together

## Usage
### Option 1: Run in separate terminals
```bash
# Terminal 1
nx start rag

# Terminal 2  
nx start server
```

### Option 2: Use convenience script
```bash
./start-local.sh
```

This ensures RAG tasks can be processed locally just like in the Docker environment.

## Testing
- Run `nx start rag` - RAG worker should start successfully
- Run `nx start server` in another terminal - Server should connect to RAG worker
- RAG health checks should now pass instead of timing out