### PR TITLE
docs: update README with local RAG worker setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,15 @@ cd llamafarm
 
 npm install -g nx
 nx init --useDotNxInstallation --interactive=false
+
+# Start both server and RAG worker (required for full functionality)
+# Option 1: Use the convenience script
+./start-local.sh
+
+# Option 2: Run in separate terminals
+# Terminal 1:
+nx start rag
+# Terminal 2:
 nx start server
 ```
 


### PR DESCRIPTION
## Summary
Updates the README to include proper instructions for running the RAG worker alongside the server when developing locally.

## Changes
- Added clear instructions for starting both server and RAG worker
- Provided two options: convenience script () or manual terminal setup  
- Clarified that both components are required for full functionality

## Context
This documentation update complements PR #219 which adds the local RAG worker support. Without these instructions, users following the README would only start the server and encounter RAG task timeouts.

## Related
- Fixes documentation gap introduced after PR #213
- Complements PR #219 (local RAG worker support)

## Summary by Sourcery

Documentation:
- Add instructions for starting both server and RAG worker locally via start-local.sh script or separate terminals