### PR TITLE
fix(cli): Windows Docker volume mount path conversion

### DIFF
--- a/cli/cmd/docker_orchestrator.go
+++ b/cli/cmd/docker_orchestrator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 )
@@ -157,6 +158,7 @@ func (co *ContainerOrchestrator) startServerContainer(serverURL string) error {
 	}
 
 	// Prepare container specification
+	homeDir, _ := os.UserHomeDir()
 	spec := ContainerRunSpec{
 		Name:  co.serverContainerName,
 		Image: image,
@@ -165,7 +167,7 @@ func (co *ContainerOrchestrator) startServerContainer(serverURL string) error {
 		},
 		Env: make(map[string]string),
 		Volumes: []string{
-			fmt.Sprintf("%s:%s", os.ExpandEnv("$HOME/.llamafarm"), "/var/lib/llamafarm"),
+			fmt.Sprintf("%s:%s", convertToDockerPath(filepath.Join(homeDir, ".llamafarm")), "/var/lib/llamafarm"),
 		},
 		Labels: map[string]string{
 			"llamafarm.component": "server",
@@ -174,11 +176,7 @@ func (co *ContainerOrchestrator) startServerContainer(serverURL string) error {
 	}
 
 	// Mount effective working directory into the container at the same path
-	if cwd := getEffectiveCWD(); strings.TrimSpace(cwd) != "" {
-		spec.Volumes = append(spec.Volumes, fmt.Sprintf("%s:%s", cwd, cwd))
-	} else {
-		fmt.Fprintln(os.Stderr, "Warning: could not determine current directory; continuing without volume mount")
-	}
+	setupWorkdirVolumeMount(&spec)
 
 	// Pass through or configure Ollama access inside the container
 	if isLocalhost(ollamaHost) {

--- a/cli/cmd/docker_orchestrator.go
+++ b/cli/cmd/docker_orchestrator.go
@@ -176,7 +176,9 @@ func (co *ContainerOrchestrator) startServerContainer(serverURL string) error {
 	}
 
 	// Mount effective working directory into the container at the same path
-	setupWorkdirVolumeMount(&spec)
+	if err := setupWorkdirVolumeMount(&spec); err != nil {
+		return fmt.Errorf("failed to configure working directory volume: %v", err)
+	}
 
 	// Pass through or configure Ollama access inside the container
 	if isLocalhost(ollamaHost) {

--- a/cli/cmd/server_utils.go
+++ b/cli/cmd/server_utils.go
@@ -452,9 +452,7 @@ func setupWorkdirVolumeMount(spec *ContainerRunSpec) error {
 	volumeMount := fmt.Sprintf("%s:%s", dockerPath, dockerPath)
 	spec.Volumes = append(spec.Volumes, volumeMount)
 
-	if debug {
-		fmt.Fprintf(os.Stderr, "Debug: Mounting volume: %s\n", volumeMount)
-	}
+	OutputDebug("Mounting volume: %s\n", volumeMount)
 
 	return nil
 }

--- a/cli/cmd/server_utils.go
+++ b/cli/cmd/server_utils.go
@@ -10,7 +10,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"time"
 )
@@ -224,7 +223,9 @@ func startLocalServerViaDocker(serverURL string) error {
 	}
 
 	// Mount effective working directory into the container at the same path
-	setupWorkdirVolumeMount(&spec)
+	if err := setupWorkdirVolumeMount(&spec); err != nil {
+		return fmt.Errorf("failed to configure working directory volume: %v", err)
+	}
 
 	// Pass through or configure Ollama access inside the container
 	if isLocalhost(ollamaHostVar) {
@@ -414,16 +415,9 @@ func isUnhealthyOnlyDueToRAG(hr *HealthPayload) bool {
 	return hasUnhealthyRAG && !hasUnhealthyNonRAG
 }
 
-// convertToDockerPath converts Windows paths to Docker-compatible format
+// convertToDockerPath normalizes a host path to use forward slashes which Docker accepts across platforms.
 func convertToDockerPath(hostPath string) string {
-	if runtime.GOOS == "windows" {
-		hostPath = strings.ReplaceAll(hostPath, `\`, `/`)
-		if len(hostPath) >= 2 && hostPath[1] == ':' {
-			drive := strings.ToLower(string(hostPath[0]))
-			hostPath = "/" + drive + hostPath[2:]
-		}
-	}
-	return hostPath
+	return filepath.ToSlash(hostPath)
 }
 
 // validateDockerVolumePath checks if a path can be safely mounted as a Docker volume
@@ -441,17 +435,16 @@ func validateDockerVolumePath(hostPath string) error {
 }
 
 // setupWorkdirVolumeMount safely sets up the working directory volume mount
-func setupWorkdirVolumeMount(spec *ContainerRunSpec) {
+// Returns an error if the working directory cannot be determined or validated
+func setupWorkdirVolumeMount(spec *ContainerRunSpec) error {
 	cwd := getEffectiveCWD()
 	if strings.TrimSpace(cwd) == "" {
-		fmt.Fprintln(os.Stderr, "Warning: could not determine current directory; continuing without volume mount")
-		return
+		return fmt.Errorf("could not determine current directory")
 	}
 
 	// Simple validation - check if path is accessible
 	if err := validateDockerVolumePath(cwd); err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: working directory not accessible (%s): %v; continuing without volume mount\n", cwd, err)
-		return
+		return fmt.Errorf("working directory not accessible (%s): %v", cwd, err)
 	}
 
 	// Convert to Docker-compatible path
@@ -462,4 +455,6 @@ func setupWorkdirVolumeMount(spec *ContainerRunSpec) {
 	if debug {
 		fmt.Fprintf(os.Stderr, "Debug: Mounting volume: %s\n", volumeMount)
 	}
+
+	return nil
 }

--- a/cli/cmd/server_utils.go
+++ b/cli/cmd/server_utils.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 )
@@ -204,6 +206,7 @@ func startLocalServerViaDocker(serverURL string) error {
 	}
 
 	// Prepare container specification
+	homeDir, _ := os.UserHomeDir()
 	spec := ContainerRunSpec{
 		Name:  containerName,
 		Image: image,
@@ -212,7 +215,7 @@ func startLocalServerViaDocker(serverURL string) error {
 		},
 		Env: make(map[string]string),
 		Volumes: []string{
-			fmt.Sprintf("%s:%s", os.ExpandEnv("$HOME/.llamafarm"), "/var/lib/llamafarm"),
+			fmt.Sprintf("%s:%s", convertToDockerPath(filepath.Join(homeDir, ".llamafarm")), "/var/lib/llamafarm"),
 		},
 		Labels: map[string]string{
 			"llamafarm.component": "server",
@@ -221,11 +224,7 @@ func startLocalServerViaDocker(serverURL string) error {
 	}
 
 	// Mount effective working directory into the container at the same path
-	if cwd := getEffectiveCWD(); strings.TrimSpace(cwd) != "" {
-		spec.Volumes = append(spec.Volumes, fmt.Sprintf("%s:%s", cwd, cwd))
-	} else {
-		fmt.Fprintln(os.Stderr, "Warning: could not determine current directory; continuing without volume mount")
-	}
+	setupWorkdirVolumeMount(&spec)
 
 	// Pass through or configure Ollama access inside the container
 	if isLocalhost(ollamaHostVar) {
@@ -413,4 +412,54 @@ func isUnhealthyOnlyDueToRAG(hr *HealthPayload) bool {
 	// 1. There are unhealthy RAG components, AND
 	// 2. There are NO unhealthy non-RAG components
 	return hasUnhealthyRAG && !hasUnhealthyNonRAG
+}
+
+// convertToDockerPath converts Windows paths to Docker-compatible format
+func convertToDockerPath(hostPath string) string {
+	if runtime.GOOS == "windows" {
+		hostPath = strings.ReplaceAll(hostPath, `\`, `/`)
+		if len(hostPath) >= 2 && hostPath[1] == ':' {
+			drive := strings.ToLower(string(hostPath[0]))
+			hostPath = "/" + drive + hostPath[2:]
+		}
+	}
+	return hostPath
+}
+
+// validateDockerVolumePath checks if a path can be safely mounted as a Docker volume
+func validateDockerVolumePath(hostPath string) error {
+	if strings.TrimSpace(hostPath) == "" {
+		return fmt.Errorf("empty path")
+	}
+
+	// Check if the path is accessible
+	if _, err := os.Stat(hostPath); err != nil {
+		return fmt.Errorf("path not accessible: %v", err)
+	}
+
+	return nil
+}
+
+// setupWorkdirVolumeMount safely sets up the working directory volume mount
+func setupWorkdirVolumeMount(spec *ContainerRunSpec) {
+	cwd := getEffectiveCWD()
+	if strings.TrimSpace(cwd) == "" {
+		fmt.Fprintln(os.Stderr, "Warning: could not determine current directory; continuing without volume mount")
+		return
+	}
+
+	// Simple validation - check if path is accessible
+	if err := validateDockerVolumePath(cwd); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: working directory not accessible (%s): %v; continuing without volume mount\n", cwd, err)
+		return
+	}
+
+	// Convert to Docker-compatible path
+	dockerPath := convertToDockerPath(cwd)
+	volumeMount := fmt.Sprintf("%s:%s", dockerPath, dockerPath)
+	spec.Volumes = append(spec.Volumes, volumeMount)
+
+	if debug {
+		fmt.Fprintf(os.Stderr, "Debug: Mounting volume: %s\n", volumeMount)
+	}
 }


### PR DESCRIPTION
## Summary by Sourcery

Add Windows-compatible path conversion and centralized volume-mount setup to improve Docker host path handling and validation

New Features:
- Convert Windows host paths to Docker-compatible format for volume mounts
- Introduce helper functions convertToDockerPath, validateDockerVolumePath, and setupWorkdirVolumeMount to manage and validate volume mounts

Enhancements:
- Replace inline working directory mount logic with setupWorkdirVolumeMount in server_utils.go and docker_orchestrator.go
- Switch home directory volume mount to use os.UserHomeDir and convertToDockerPath for consistent path resolution on all platforms