### PR TITLE
chore: sign and notify macos cli binaries during release

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -15,7 +15,6 @@ permissions:
   contents: write
 
 env:
-  CLI_NAME: llamafarm-cli
   BINARY_NAME: lf
 
 jobs:
@@ -73,31 +72,73 @@ jobs:
           echo "SHA256: $(cat ${BINARY_NAME}.sha256)"
           echo "binary_name=${BINARY_NAME}" >> $GITHUB_OUTPUT
 
-          # # Create archive
-          # ARCHIVE_NAME="${{ env.CLI_NAME }}-${{ matrix.goos }}-${{ matrix.goarch }}"
-          # mkdir -p dist
-
-          # if [[ "${{ matrix.goos }}" == "windows" ]]; then
-          #   zip "dist/${ARCHIVE_NAME}.zip" "${BINARY_NAME}"
-          # else
-          #   tar -czf "dist/${ARCHIVE_NAME}.tar.gz" "${BINARY_NAME}"
-          # fi
-
-      - name: Upload assets to the Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ steps.version.outputs.version }}
-          files: |
-            cli/${{ steps.build.outputs.binary_name }}
-            cli/${{ steps.build.outputs.binary_name }}.sha256
-          fail_on_unmatched_files: true
-          append_body: true
-
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: "${{ steps.build.outputs.binary_name }}"
           path: cli/${{ steps.build.outputs.binary_name }}
+
+  # For each build, run the release upload as a separate job, pulling the built artifact from the previous job.
+
+  upload-cli-release:
+    name: Upload CLI Release Asset
+    needs: build-cli
+    runs-on: ${{ matrix.goos == 'darwin' && 'macos-latest' || matrix.goos == 'windows' && 'windows-latest' || 'ubuntu-latest' }}
+    # if: github.event_name == 'release'
+    strategy:
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+          - goos: darwin
+            goarch: amd64
+          - goos: darwin
+            goarch: arm64
+          - goos: windows
+            goarch: amd64
+          - goos: windows
+            goarch: arm64
+
+    steps:
+      - name: Download built binary artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: "${{ env.BINARY_NAME }}-${{ matrix.goos }}-${{ matrix.goarch }}"
+          path: cli/
+
+      - name: Set binary name
+        id: set-binary-name
+        run: |
+          BINARY_NAME="${{ env.BINARY_NAME }}-${{ matrix.goos }}-${{ matrix.goarch }}"
+          if [[ "${{ matrix.goos }}" == "windows" ]]; then
+            BINARY_NAME="${BINARY_NAME}-windows-${{ matrix.goarch }}.exe"
+          fi
+          echo "binary_name=${BINARY_NAME}" >> $GITHUB_OUTPUT
+
+      - name: Sign and Notarize macOS binary
+        if: matrix.goos == 'darwin'
+        uses: lando/code-sign-action@v2
+        with:
+          file: cli/${{ steps.set-binary-name.outputs.binary_name }}
+          certificate-data: ${{ secrets.APPLE_CERT_DATA }}
+          certificate-password: ${{ secrets.APPLE_CERT_PASSWORD }}
+          apple-notary-user: ${{ secrets.APPLE_ID }}
+          apple-notary-password: ${{ secrets.APPLE_ID_PASSWORD }}
+          apple-team-id: ${{ secrets.APPLE_TEAM_ID }}
+          apple-product-id: dev.llamafarm.cli
+          options: --options runtime
+
+      - name: Upload assets to the Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.release.tag_name }}
+          files: |
+            cli/${{ steps.set-binary-name.outputs.binary_name }}
+            cli/${{ steps.set-binary-name.outputs.binary_name }}.sha256
+          fail_on_unmatched_files: true
+          append_body: true
 
   test-cli-install:
     name: Test Installation Script

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -61,7 +61,7 @@ jobs:
           # Set binary name with .exe extension for Windows
           BINARY_NAME="${{ env.BINARY_NAME }}-${{ matrix.goos }}-${{ matrix.goarch }}"
           if [[ "${{ matrix.goos }}" == "windows" ]]; then
-            BINARY_NAME="${BINARY_NAME}-windows-${{ matrix.goarch }}.exe"
+            BINARY_NAME="${BINARY_NAME}.exe"
           fi
 
           # Build the binary
@@ -83,8 +83,7 @@ jobs:
   upload-cli-release:
     name: Upload CLI Release Asset
     needs: build-cli
-    runs-on: ${{ matrix.goos == 'darwin' && 'macos-latest' || matrix.goos == 'windows' && 'windows-latest' || 'ubuntu-latest' }}
-    # if: github.event_name == 'release'
+    runs-on: 'ubuntu-latest'
     strategy:
       matrix:
         include:
@@ -102,33 +101,31 @@ jobs:
             goarch: arm64
 
     steps:
-      - name: Download built binary artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: "${{ env.BINARY_NAME }}-${{ matrix.goos }}-${{ matrix.goarch }}"
-          path: cli/
-
       - name: Set binary name
         id: set-binary-name
         run: |
           BINARY_NAME="${{ env.BINARY_NAME }}-${{ matrix.goos }}-${{ matrix.goarch }}"
           if [[ "${{ matrix.goos }}" == "windows" ]]; then
-            BINARY_NAME="${BINARY_NAME}-windows-${{ matrix.goarch }}.exe"
+            BINARY_NAME="${BINARY_NAME}.exe"
           fi
           echo "binary_name=${BINARY_NAME}" >> $GITHUB_OUTPUT
 
+      - name: Download built binary artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: "${{ steps.set-binary-name.outputs.binary_name }}"
+          path: cli/
+
       - name: Sign and Notarize macOS binary
         if: matrix.goos == 'darwin'
-        uses: lando/code-sign-action@v2
-        with:
-          file: cli/${{ steps.set-binary-name.outputs.binary_name }}
-          certificate-data: ${{ secrets.APPLE_CERT_DATA }}
-          certificate-password: ${{ secrets.APPLE_CERT_PASSWORD }}
-          apple-notary-user: ${{ secrets.APPLE_ID }}
-          apple-notary-password: ${{ secrets.APPLE_ID_PASSWORD }}
-          apple-team-id: ${{ secrets.APPLE_TEAM_ID }}
-          apple-product-id: dev.llamafarm.cli
-          options: --options runtime
+        run: |
+          curl -sSfL https://get.anchore.io/quill | sudo sh -s -- -b /usr/local/bin
+          QUILL_SIGN_PASSWORD=${{ secrets.APPLE_CERT_PASSWORD }} quill sign-and-notarize cli/${{ steps.set-binary-name.outputs.binary_name }} \
+            --p12 ${{ secrets.APPLE_CERT_DATA }} \
+            --notary-key-id ${{ secrets.APPLE_NOTARY_KEY_ID }} \
+            --notary-key ${{ secrets.APPLE_NOTARY_KEY }} \
+            --notary-issuer ${{ secrets.APPLE_NOTARY_ISSUER }} \
+            --verbose
 
       - name: Upload assets to the Release
         uses: softprops/action-gh-release@v2
@@ -144,7 +141,6 @@ jobs:
     name: Test Installation Script
     needs: build-cli
     runs-on: ${{ matrix.os }}
-    if: github.event_name == 'release'
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -101,6 +101,14 @@ jobs:
             goarch: arm64
 
     steps:
+      - name: Get version
+        id: version
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+          else
+            echo "version=${{ github.event.release.tag_name}}" >> $GITHUB_OUTPUT
+          fi
       - name: Set binary name
         id: set-binary-name
         run: |
@@ -130,7 +138,7 @@ jobs:
       - name: Upload assets to the Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.event.release.tag_name }}
+          tag_name: ${{ steps.version.outputs.version }}
           files: |
             cli/${{ steps.set-binary-name.outputs.binary_name }}
             cli/${{ steps.set-binary-name.outputs.binary_name }}.sha256
@@ -146,6 +154,15 @@ jobs:
         os: [ubuntu-latest, macos-latest]
 
     steps:
+      - name: Get version
+        id: version
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+          else
+            echo "version=${{ github.event.release.tag_name}}" >> $GITHUB_OUTPUT
+          fi
+
       - name: Checkout code
         uses: actions/checkout@v4
 
@@ -156,7 +173,7 @@ jobs:
 
           # Test the install script
           chmod +x install.sh
-          VERSION=${{ github.event.release.tag_name }} INSTALL_DIR=$HOME/.local/bin ./install.sh
+          VERSION=${{ steps.version.outputs.version }} INSTALL_DIR=$HOME/.local/bin ./install.sh
 
           # Test the installed binary
           export PATH="$HOME/.local/bin:$PATH"

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -76,7 +76,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: "${{ steps.build.outputs.binary_name }}"
-          path: cli/${{ steps.build.outputs.binary_name }}
+          path: |
+            cli/${{ steps.build.outputs.binary_name }}
+            cli/${{ steps.build.outputs.binary_name }}.sha256
 
   # For each build, run the release upload as a separate job, pulling the built artifact from the previous job.
 


### PR DESCRIPTION
fixes: #227

## Summary by Sourcery

Revise the CLI release workflow to separate build and upload steps, streamline binary naming, and add signing and notarization for macOS CLI binaries during release.

New Features:
- Integrate Quill-based signing and notarization for macOS CLI binaries during release.

Enhancements:
- Split build and release upload into distinct GitHub Actions jobs using upload-artifact and download-artifact.
- Simplify Windows binary naming logic and remove unused CLI_NAME environment variable.
- Use the GitHub release event tag for asset uploads instead of a separate version step.

CI:
- Update the release-cli workflow to set binary names per matrix, handle artifact transfers, and append files to the GitHub release.

Tests:
- Remove release-only gating so the installation script tests run on both Linux and macOS for every build.