### PR TITLE
fix(rag): remove unnecessary properties from schema

### DIFF
--- a/rag/schema.yaml
+++ b/rag/schema.yaml
@@ -1936,29 +1936,12 @@ definitions:
                 - ["*.pdf", "*.PDF"]  # All PDF files
                 - ["report_*.csv"]  # CSV files starting with report_
                 - ["README*", "*.md"]  # README files and markdown
-            file_exclude_patterns:
-              type: array
-              items:
-                type: string
-              description: Glob patterns for files to exclude (e.g., ["*_draft.pdf", "*.tmp"])
-              examples:
-                - ["*_draft.pdf", "*.tmp.pdf"]  # Draft and temp PDFs
-                - ["~$*", "*.bak"]  # Temp and backup files
             priority:
               type: integer
               description: Parser priority (higher = try first)
               default: 50
               minimum: 0
               maximum: 1000
-            mime_types:
-              type: ["array", "null"]
-              items:
-                type: string
-              description: MIME types this parser handles (e.g., ["application/pdf"])
-              examples:
-                - ["application/pdf"]  # PDF parser
-                - ["text/csv", "text/tab-separated-values"]  # CSV parser
-                - ["text/markdown", "text/x-markdown"]  # Markdown parser
             fallback_parser:
               type: ["string", "null"]
               description: Parser to use if this one fails
@@ -1998,13 +1981,6 @@ definitions:
               examples:
                 - ["*.pdf", "*.PDF"]  # PDF files only
                 - ["*"]  # All files
-            file_exclude_patterns:
-              type: array
-              items:
-                type: string
-              description: Glob patterns for files to exclude from this extractor
-              examples:
-                - ["*.tmp", "*.bak"]  # Skip temp/backup files
             priority:
               type: integer
               description: Extractor priority (higher = apply first)


### PR DESCRIPTION
### Changes Made
- Removed `file_exclude_patterns` from parsers and extractors in the RAG schema
- Removed `mime_types` property from parsers 
- Rationale: Eliminated anti-pattern of having both inclusion and exclusion properties
- Benefit: Cleaner schema design that relies on inclusion patterns instead of redundant exclusion properties

fixes: #190

### Technical Details
- Updated `dataProcessingStrategyDefinition` in `rag/schema.yaml`
- Removed `file_exclude_patterns` from both parser and extractor configurations  
- Removed `mime_types` array property from parser configuration
- Maintained all essential functionality while removing superfluous options