### PR TITLE
fix(cli): set user directive in container

### DIFF
--- a/cli/cmd/docker_orchestrator.go
+++ b/cli/cmd/docker_orchestrator.go
@@ -173,6 +173,7 @@ func (co *ContainerOrchestrator) startServerContainer(serverURL string) error {
 			"llamafarm.component": "server",
 			"llamafarm.managed":   "true",
 		},
+		User: getCurrentUserGroup(),
 	}
 
 	// Mount effective working directory into the container at the same path
@@ -248,6 +249,7 @@ func (co *ContainerOrchestrator) startRAGContainer() error {
 			"llamafarm.component": "rag",
 			"llamafarm.managed":   "true",
 		},
+		User: getCurrentUserGroup(),
 	}
 
 	logDebug(fmt.Sprintf("Starting RAG container with network: %s", networkName))

--- a/cli/cmd/server_utils.go
+++ b/cli/cmd/server_utils.go
@@ -220,6 +220,7 @@ func startLocalServerViaDocker(serverURL string) error {
 			"llamafarm.component": "server",
 			"llamafarm.managed":   "true",
 		},
+		User: getCurrentUserGroup(),
 	}
 
 	// Mount effective working directory into the container at the same path


### PR DESCRIPTION
## Summary by Sourcery

Add support for running Docker containers under the host user's UID:GID in CLI commands

Enhancements:
- Introduce User field in ContainerRunSpec and propagate it to container start calls
- Implement getCurrentUserGroup to retrieve the current user's UID:GID string
- Set the container User field to the host user in orchestrator and local server start functions