### PR TITLE
fix: health check

### DIFF
--- a/server/services/health_service.py
+++ b/server/services/health_service.py
@@ -244,8 +244,15 @@ def _check_rag_service() -> dict:
 def compute_overall_status(components: list[dict], seeds: list[dict]) -> str:
     order = {"healthy": 0, "degraded": 1, "unhealthy": 2}
     worst = 0
+    
+    # Only consider non-RAG components for overall status
+    # RAG service status is included in response but doesn't affect overall health
     for c in components + seeds:
+        # Skip RAG service when computing overall status
+        if c.get("name") == "rag-service":
+            continue
         worst = max(worst, order.get(c.get("status", "unhealthy"), 2))
+    
     return next((k for k, v in order.items() if v == worst), "unhealthy")
 
 


### PR DESCRIPTION
## Summary by Sourcery

Improve health check logic by auto-starting unhealthy RAG services locally and decoupling RAG status from the overall server health calculation.

Bug Fixes:
- Exclude RAG service from overall health computation in compute_overall_status in health_service.py

Enhancements:
- Introduce handleRAGServiceInBackground to detect unhealthy RAG components and asynchronously start the RAG container on localhost
- Add findRAGComponent utility and update RAG detection logic in server_utils.go to match explicit name patterns
- Refine isUnhealthyOnlyDueToRAG to leverage the new RAG component matching logic