### PR TITLE
fix(cli): show failures when failed count is greater than zero

### DIFF
--- a/cli/cmd/datasets.go
+++ b/cli/cmd/datasets.go
@@ -376,7 +376,9 @@ Examples:
 		fmt.Printf("\n📊 Final Summary:\n")
 		fmt.Printf("   Total files: %d\n", len(files))
 		fmt.Printf("   ✅ Successful: %d\n", uploaded)
-		fmt.Printf("   ❌ Failed: %d\n", failed)
+		if failed > 0 {
+			fmt.Printf("   ❌ Failed: %d\n", failed)
+		}
 	},
 }
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Only display the failure count line if the failed count is greater than zero