### PR TITLE
fix(cli): don't show seed status errors in project chat mode

### DIFF
--- a/cli/cmd/chat.go
+++ b/cli/cmd/chat.go
@@ -173,6 +173,7 @@ Examples:
 		} else {
 			config = RAGCommandConfig(serverURL) // Wait for both server and RAG
 		}
+		// Ensure health checks reflect project context before contacting server
 		EnsureServicesWithConfig(config)
 		resp, err := sendChatRequest(messages, ctx)
 		if err != nil {

--- a/cli/cmd/dev.go
+++ b/cli/cmd/dev.go
@@ -9,11 +9,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// startCmd launches the chat quickly for development at the top level.
-var startCmd = &cobra.Command{
-	Use:   "start",
-	Short: "Start working with your project locally",
-	Long:  "Start your LlamaFarm project locally and open an interactive chat session for development and testing.",
+// devCmd launches the chat quickly for development at the top level.
+var devCmd = &cobra.Command{
+	Use:     "dev",
+	Short:   "Start working with your project locally",
+	Aliases: []string{"start"},
+	Long:    "Start your LlamaFarm project locally and open an interactive chat session for development and testing.",
 	Run: func(cmd *cobra.Command, args []string) {
 		if strings.TrimSpace(serverURL) == "" {
 			serverURL = "http://localhost:8000"
@@ -66,7 +67,7 @@ func start(mode SessionMode) {
 	// Filter health status to avoid alarming messages for optional services (like RAG)
 	// that are starting in the background
 	if serverHealth != nil {
-		serverHealth = FilterHealthForOptionalServices(serverHealth, config)
+		serverHealth = FilterHealthForOptionalServices(serverHealth, config, mode)
 	}
 
 	runChatSessionTUI(mode, projectInfo, serverHealth)
@@ -74,8 +75,8 @@ func start(mode SessionMode) {
 
 func init() {
 	// Attach to root
-	rootCmd.AddCommand(startCmd)
+	rootCmd.AddCommand(devCmd)
 
 	// Add start-only flags
-	startCmd.Flags().StringVar(&ollamaHost, "ollama-host", ollamaHost, "Ollama host URL")
+	devCmd.Flags().StringVar(&ollamaHost, "ollama-host", ollamaHost, "Ollama host URL")
 }

--- a/server/services/health_service.py
+++ b/server/services/health_service.py
@@ -167,7 +167,7 @@ def _check_seed_project() -> dict:
             else f"Model '{model}' not found; run: ollama pull {model}"
         )
         return {
-            "name": "project",
+            "name": "seed:project",
             "status": status,
             "message": message,
             "latency_ms": _now_ms() - start,
@@ -181,8 +181,6 @@ def _check_seed_project() -> dict:
             "latency_ms": _now_ms() - start,
             "runtime": {"host": base, "model": model},
         }
-
-
 
 
 def _check_rag_service() -> dict:
@@ -244,15 +242,15 @@ def _check_rag_service() -> dict:
 def compute_overall_status(components: list[dict], seeds: list[dict]) -> str:
     order = {"healthy": 0, "degraded": 1, "unhealthy": 2}
     worst = 0
-    
+
     # Only consider non-RAG components for overall status
     # RAG service status is included in response but doesn't affect overall health
     for c in components + seeds:
-        # Skip RAG service when computing overall status
-        if c.get("name") == "rag-service":
+        # Skip RAG service and Project seed when computing overall status
+        if c.get("name", "") in ["rag-service", "seed:project"]:
             continue
         worst = max(worst, order.get(c.get("status", "unhealthy"), 2))
-    
+
     return next((k for k, v in order.items() if v == worst), "unhealthy")
 
 


### PR DESCRIPTION
## Summary by Sourcery

Filter out seed status errors in project chat mode, streamline TUI chat mode switching and health checks, rename the CLI startup command, and introduce a comprehensive Production Deployment guide.

New Features:
- Add PRODUCTION.md as a detailed Production Deployment guide for single-VM environments.

Bug Fixes:
- Suppress unhealthy seed status messages in project chat mode to prevent alarming errors.
- Prevent duplicate mode-switch notifications in the TUI chat interface.
- Ensure checkServerHealth returns the actual health payload even when the server reports non-healthy status.

Enhancements:
- Refactor TUI chat switchMode logic to handle message appending internally and unify switch commands.
- Extend FilterHealthForOptionalServices to consider session mode and include seeds only in Dev mode.
- Rename the CLI 'start' command to 'dev' (with alias) and update related flags and descriptions.

Documentation:
- Add comprehensive production deployment instructions in PRODUCTION.md.