### PR TITLE
feat(designer): Hook up prompts from config 

### DIFF
--- a/designer/src/components/Prompt/GeneratedOutput/PromptModal.tsx
+++ b/designer/src/components/Prompt/GeneratedOutput/PromptModal.tsx
@@ -43,7 +43,7 @@ const PromptModal: React.FC<PromptModalProps> = ({
       setText(initialText)
       setRole(initialRole)
     }
-  }, [isOpen, initialText, initialRole])
+  }, [isOpen, mode, initialText, initialRole])
 
   const title = mode === 'create' ? 'Create prompt' : 'Edit prompt'
   const cta = mode === 'create' ? 'Create' : 'Save'
@@ -140,7 +140,8 @@ const PromptModal: React.FC<PromptModalProps> = ({
                   ? 'bg-primary text-primary-foreground hover:opacity-90'
                   : 'opacity-50 cursor-not-allowed bg-primary text-primary-foreground'
               }`}
-              onClick={() => isValid && onSave(text.trim(), role)}
+              disabled={!isValid}
+              onClick={() => onSave(text.trim(), role)}
             >
               {cta}
             </button>


### PR DESCRIPTION
## Summary by Sourcery

Fetch prompts from the project config, display them in a simplified table with role and preview, and support creating, editing, and deleting prompts through modal dialogs that update the backend via the projectService API.

New Features:
- Fetch and display prompts from project configuration instead of localStorage defaults
- Enable creating, editing, and deleting prompts by persisting changes via projectService API calls

Enhancements:
- Revamp prompts table to show role and preview columns with inline edit and delete actions
- Replace version field in PromptModal with role selector and include contextual helper text and docs link
- Show empty state when no prompts are defined