### PR TITLE
Fix .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,8 @@
 # Python
-__pycache__/
-*.pyc
-*.pyo
-*.pyd
+**/__pycache__/
+**/*.pyc
+**/*.pyo
+**/*.pyd
 .Python
 *.so
 .pytest_cache/
@@ -26,12 +26,12 @@ env/
 # IDE
 .vscode/
 .idea/
-*.swp
-*.swo
+**/*.swp
+**/*.swo
 
 # OS
-.DS_Store
-Thumbs.db
+**/.DS_Store
+**/Thumbs.db
 
 # Build artifacts
 build/


### PR DESCRIPTION
Fixes #284

This PR fixes minor .dockerignore misconfigurations (#284). I added `**/` at the beginning of the patterns I thought should match recursively. However, since I am not very familiar with this project, I might have missed patterns that also need `**/`. Please let me know (or directly update my PR) if any other lines should include `**/` as well!

## Summary by Sourcery

Bug Fixes:
- Prefix applicable ignore patterns with '**/' to ensure they exclude files in all subdirectories