### PR TITLE
fix: OllamaEmbedder respects configured dimension from llamafarm.yaml

### DIFF
--- a/rag/components/embedders/ollama_embedder/ollama_embedder.py
+++ b/rag/components/embedders/ollama_embedder/ollama_embedder.py
@@ -32,6 +32,7 @@ class OllamaEmbedder(Embedder):
             "base_url", settings.OLLAMA_HOST
         )
         self.base_url = self.api_base  # Alias for compatibility
+        self.dimension = config.get("dimension", 768)  # Read from config
         self.batch_size = max(
             config.get("batch_size", 32), 1
         )  # Ensure positive batch size
@@ -106,18 +107,8 @@ class OllamaEmbedder(Embedder):
 
     def get_embedding_dimension(self) -> int:
         """Get the dimension of embeddings produced by this model."""
-        # Default dimensions for common models (avoid test embedding during tests)
-        dimension_map = {
-            "nomic-embed-text": 768,
-            "all-minilm": 384,
-            "sentence-transformers": 384,
-        }
-
-        for model_name, dim in dimension_map.items():
-            if model_name in self.model:
-                return dim
-
-        return 768  # Default
+        # Return the configured dimension from llamafarm.yaml
+        return self.dimension
 
     def _call_ollama_api(self, text: str) -> Dict[str, Any]:
         """Call Ollama API for a single text."""


### PR DESCRIPTION
## Critical Bug Fix

OllamaEmbedder was ignoring the `dimension` config parameter from llamafarm.yaml, causing dimension mismatches when using models other than nomic-embed-text.

## Root Cause

The `__init__` method was NOT reading `dimension` from config, and `get_embedding_dimension()` returned hardcoded values (768/384 based on model name pattern matching).

When embeddings failed, zero-filled vectors used the wrong dimension.

## Failure Pattern

With mxbai-embed-large @ 1024 dimensions:
- ✅ Successful embeddings → 1024 dims (from Ollama API)
- ❌ Failed embeddings → 768 dims (hardcoded fallback)
- ❌ ChromaDB rejects: "Collection expecting embedding with dimension of 1024, got 768"

## The Fix

1. Read dimension from config in `__init__`: `self.dimension = config.get('dimension', 768)`
2. Use configured dimension in `get_embedding_dimension()`: `return self.dimension`

## Impact

Now works correctly with ANY embedding model dimension specified in llamafarm.yaml:
- nomic-embed-text (768)
- mxbai-embed-large (1024)
- any-minilm (384)
- Custom models with any dimension

## Testing

Resolves dimension mismatch errors when processing documents with non-default embedding models.

## Files Changed

- `rag/components/embedders/ollama_embedder/ollama_embedder.py`: Added dimension config reading, simplified get_embedding_dimension()

## Summary by Sourcery

Fix OllamaEmbedder to read and use the 'dimension' setting from llamafarm.yaml and remove hardcoded fallback dimensions to prevent embedding dimension mismatches.

Bug Fixes:
- OllamaEmbedder now reads the 'dimension' parameter from config to ensure correct embedding dimensions

Enhancements:
- Simplify get_embedding_dimension to return the configured dimension instead of using hardcoded model-based defaults