### PR TITLE
fix: localhost url rewriting logic

### DIFF
--- a/server/seeds/project_seed/llamafarm.yaml
+++ b/server/seeds/project_seed/llamafarm.yaml
@@ -10,6 +10,7 @@ runtime:
     description: "Default Ollama model for LlamaFarm"
     provider: ollama
     model: gemma3:1b
+    base_url: http://localhost:11434/v1
     prompt_format: unstructured
 
 

--- a/server/services/health_service.py
+++ b/server/services/health_service.py
@@ -91,7 +91,7 @@ def _check_seed_project() -> dict:
 
     # Load seed project config for ModelService
     try:
-        import yaml
+        from config.helpers.loader import load_config
 
         seed_path = (
             Path(__file__).resolve().parents[1]
@@ -109,10 +109,8 @@ def _check_seed_project() -> dict:
                 "runtime": {"provider": None, "model": None},
             }
 
-        project_config_data = yaml.safe_load(seed_path.read_text(encoding="utf-8"))
-        from config.datamodel import LlamaFarmConfig
-
-        project_config = LlamaFarmConfig(**project_config_data)
+        # Use the proper config loader that includes URL rewriting for Docker
+        project_config = load_config(config_path=seed_path, validate=False)
 
         # Use ModelService to get the correct model config
         model_config = ModelService.get_model(project_config, model_name=None)


### PR DESCRIPTION
### **User description**
## Summary by Sourcery

Fix URL rewriting logic by migrating health_service to the shared load_config helper and add a base_url override in the seed project configuration for localhost support.

New Features:
- Add base_url field to seed project YAML for localhost Ollama access

Bug Fixes:
- Use centralized config loader in health_service to fix URL rewriting for Docker environments


___

### **PR Type**
Bug fix


___

### **Description**
- Replace manual YAML loading with centralized config loader in health_service

- Apply Docker URL rewriting to seed project configuration

- Add base_url field to seed project for localhost access


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Manual YAML loading"] -->|"Replace with"| B["load_config helper"]
  B -->|"Applies URL rewriting"| C["Docker localhost support"]
  D["seed project YAML"] -->|"Add base_url"| C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>health_service.py</strong><dd><code>Use centralized config loader for URL rewriting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/services/health_service.py

<ul><li>Replace direct <code>yaml.safe_load()</code> with centralized <code>load_config()</code> <br>function<br> <li> Remove manual <code>LlamaFarmConfig</code> instantiation<br> <li> Enable automatic URL rewriting for Docker environments<br> <li> Add explanatory comment about config loader benefits</ul>


</details>


  </td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/342/files#diff-d6f75be96def2d0a1d5fa2ff053ee0b3d916bc707cac0e3b2e7c54167a92f56a">+3/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>llamafarm.yaml</strong><dd><code>Add base_url for localhost Ollama access</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/seeds/project_seed/llamafarm.yaml

<ul><li>Add <code>base_url: http://localhost:11434/v1</code> to default Ollama model <br>configuration<br> <li> Enable localhost access for seed project in Docker environments</ul>


</details>


  </td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/342/files#diff-8e94488f9fc35bac9a5f88c9cd1a682b0643cf7a1f26938718718f7ee5763771">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

