### PR TITLE
Fix(designer): delete projects from designer

### DIFF
--- a/designer/src/Home.tsx
+++ b/designer/src/Home.tsx
@@ -286,14 +286,26 @@ function Home() {
 
   // React to project deletions fired from the modal to update UI immediately
   useEffect(() => {
-    const onDeleted = () => {
-      // Invalidate local derived list by forcing a refilter
-      setSearch(s => s + '')
+    const onDeleted = (event: Event) => {
+      const deletedProjectName = (event as CustomEvent<string>).detail
+      // Force refetch of projects list to ensure UI is updated
+      queryClient.invalidateQueries({ queryKey: projectKeys.list(namespace) })
+      
+      // Clear active project if it was the one deleted
+      try {
+        const active = localStorage.getItem('activeProject')
+        if (active === deletedProjectName) {
+          localStorage.removeItem('activeProject')
+          window.dispatchEvent(
+            new CustomEvent<string>('lf-active-project', { detail: '' })
+          )
+        }
+      } catch {}
     }
     window.addEventListener('lf-project-deleted' as any, onDeleted as any)
     return () =>
       window.removeEventListener('lf-project-deleted' as any, onDeleted as any)
-  }, [])
+  }, [namespace, queryClient])
 
   return (
     <div className="min-h-screen flex flex-col items-stretch px-4 sm:px-6 lg:px-8 pt-24 md:pt-28 pb-8 bg-background">

--- a/designer/src/components/Dashboard/Dashboard.tsx
+++ b/designer/src/components/Dashboard/Dashboard.tsx
@@ -100,6 +100,26 @@ const Dashboard = () => {
       window.removeEventListener('lf-active-project', handler as EventListener)
   }, [])
 
+  // Listen for project deletions and redirect to home if current project was deleted
+  useEffect(() => {
+    const handleProjectDeleted = (event: Event) => {
+      const deletedProjectName = (event as CustomEvent<string>).detail
+      if (deletedProjectName === projectName) {
+        // Current project was deleted, redirect to home
+        navigate('/')
+      }
+    }
+    window.addEventListener(
+      'lf-project-deleted',
+      handleProjectDeleted as EventListener
+    )
+    return () =>
+      window.removeEventListener(
+        'lf-project-deleted',
+        handleProjectDeleted as EventListener
+      )
+  }, [projectName, navigate])
+
   // Get default model name from config
   const defaultModelName = useMemo(() => {
     const config = projectDetail?.project?.config

--- a/designer/src/components/Project/ProjectModal.tsx
+++ b/designer/src/components/Project/ProjectModal.tsx
@@ -172,7 +172,7 @@ const ProjectModal: React.FC<ProjectModalProps> = ({
                   disabled={isLoading}
                   type="button"
                 >
-                  Confirm delete
+                  {isLoading ? 'Deleting...' : 'Confirm delete'}
                 </button>
               </div>
             ) : (


### PR DESCRIPTION
## Summary by Sourcery

Fix project deletion flow by invalidating cache, clearing active project state, redirecting when the current project is deleted, and updating the delete button label

Bug Fixes:
- Invalidate project list query on deletion to refresh the UI
- Clear active project from localStorage and emit an empty active-project event when it’s deleted
- Redirect to home in the dashboard if the currently open project is deleted
- Show “Deleting…” on the confirmation button while a project is being deleted