### PR TITLE
fix(cli): use correct version number

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -99,7 +99,7 @@ jobs:
           fi
 
           # Build with version info (schema compilation and type generation already done by generate-types)
-          go build -ldflags "-s -w -X llamafarm-cli/cmd.Version=${VERSION}" -o ../dist/${{ matrix.output }} .
+          go build -ldflags "-s -w -X 'github.com/llamafarm/cli/cmd/version.CurrentVersion=${VERSION}'" -o ../dist/${{ matrix.output }} .
 
       - name: Upload CLI artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -87,7 +87,7 @@ jobs:
           fi
 
           # Build the binary
-          go build -ldflags="-s -w -X 'llamafarm-cli/cmd.Version=${{ steps.version.outputs.version }}'" -o "${BINARY_NAME}" .
+          go build -ldflags="-s -w -X 'github.com/llamafarm/cli/cmd/version.CurrentVersion=${{ steps.version.outputs.version }}'" -o "${BINARY_NAME}" .
 
           # SHA the binary
           sha256sum "${BINARY_NAME}" > "${BINARY_NAME}.sha256"

--- a/cli/README.md
+++ b/cli/README.md
@@ -121,4 +121,4 @@ LF_VERSION_REF=abc123def456... lf start
 - Commands live under `cmd/` as Cobra subcommands.
 - Shared helpers (HTTP clients, config resolution) live in `cmd/*` modules.
 - Regenerate Go config types after schema updates via `config/generate-types.sh`.
-- The CLI's `Version` variable is set via `-ldflags` during build: `-X 'llamafarm-cli/cmd.Version=v1.2.3'`
+- The CLI's `CurrentVersion` variable is set via `-ldflags` during build: `-X 'github.com/llamafarm/cli/cmd/version.CurrentVersion=v1.2.3'`

--- a/cli/hack/test-install.sh
+++ b/cli/hack/test-install.sh
@@ -57,7 +57,7 @@ test_local_build() {
 
     # Build the CLI locally
     info "Building CLI locally..."
-    go build -ldflags="-X 'llamafarm-cli/cmd.Version=test-1.0.0'" -o lf . || error "Failed to build CLI"
+    go build -ldflags="-X 'github.com/llamafarm/cli/cmd/version.CurrentVersion=test-1.0.0'" -o lf . || error "Failed to build CLI"
 
     # Test the binary
     info "Testing built binary..."
@@ -85,15 +85,15 @@ test_cross_compile() {
 
     # Test Linux build
     info "Testing Linux amd64 build..."
-    GOOS=linux GOARCH=amd64 go build -ldflags="-s -w -X 'llamafarm-cli/cmd.Version=test-1.0.0'" -o lf-linux . || error "Linux build failed"
+    GOOS=linux GOARCH=amd64 go build -ldflags="-s -w -X 'github.com/llamafarm/cli/cmd/version.CurrentVersion=test-1.0.0'" -o lf-linux . || error "Linux build failed"
 
     # Test macOS build
     info "Testing macOS amd64 build..."
-    GOOS=darwin GOARCH=amd64 go build -ldflags="-s -w -X 'llamafarm-cli/cmd.Version=test-1.0.0'" -o lf-macos . || error "macOS build failed"
+    GOOS=darwin GOARCH=amd64 go build -ldflags="-s -w -X 'github.com/llamafarm/cli/cmd/version.CurrentVersion=test-1.0.0'" -o lf-macos . || error "macOS build failed"
 
     # Test Windows build
     info "Testing Windows amd64 build..."
-    GOOS=windows GOARCH=amd64 go build -ldflags="-s -w -X 'llamafarm-cli/cmd.Version=test-1.0.0'" -o lf-windows.exe . || error "Windows build failed"
+    GOOS=windows GOARCH=amd64 go build -ldflags="-s -w -X 'github.com/llamafarm/cli/cmd/version.CurrentVersion=test-1.0.0'" -o lf-windows.exe . || error "Windows build failed"
 
     success "Cross-compilation test passed"
 

--- a/cli/hack/test-installer-comprehensive.sh
+++ b/cli/hack/test-installer-comprehensive.sh
@@ -111,7 +111,7 @@ build_test_binaries() {
         local out_name="lf-${goos}-${goarch}"
 
         GOOS=$goos GOARCH=$goarch CGO_ENABLED=0 go build \
-            -ldflags="-s -w -X 'llamafarm-cli/cmd.Version=${TEST_VERSION}'" \
+            -ldflags="-s -w -X 'github.com/llamafarm/cli/cmd/version.CurrentVersion=${TEST_VERSION}'" \
             -o "../$test_dir/${out_name}" .
 
         chmod +x "../$test_dir/${out_name}"

--- a/cli/hack/test-installer-docker.sh
+++ b/cli/hack/test-installer-docker.sh
@@ -212,7 +212,7 @@ test_cli_build() {
             go mod tidy
 
             # Test basic build
-            go build -buildvcs=false -ldflags='-X llamafarm-cli/cmd.Version=docker-test-1.0.0' -o ../dist/lf-test .
+            go build -buildvcs=false -ldflags='-X github.com/llamafarm/cli/cmd/version.CurrentVersion=docker-test-1.0.0' -o ../dist/lf-test .
 
             # Test binary execution
             ./../dist/lf-test version

--- a/cli/hack/test-installer-local.sh
+++ b/cli/hack/test-installer-local.sh
@@ -91,7 +91,7 @@ create_test_artifacts() {
         fi
 
         GOOS=$goos GOARCH=$goarch CGO_ENABLED=0 go build \
-            -ldflags="-s -w -X 'llamafarm-cli/cmd.Version=$TEST_VERSION'" \
+            -ldflags="-s -w -X 'github.com/llamafarm/cli/cmd/version.CurrentVersion=$TEST_VERSION'" \
             -o "$binary_name" .
 
         # Create archive

--- a/cli/hack/test-installer-quick.sh
+++ b/cli/hack/test-installer-quick.sh
@@ -93,7 +93,7 @@ test_cli_build() {
 
     # Test basic build
     go generate -v ./...
-    if go build -ldflags="-X 'llamafarm-cli/cmd.Version=test-quick-1.0.0'" -o ../dist/lf-test .; then
+    if go build -ldflags="-X 'github.com/llamafarm/cli/cmd/version.CurrentVersion=test-quick-1.0.0'" -o ../dist/lf-test .; then
         success "CLI build successful"
     else
         error "CLI build failed"
@@ -115,13 +115,13 @@ test_cli_build() {
     # Test cross-compilation (quick test)
     info "Testing cross-compilation..."
 
-    if GOOS=linux GOARCH=amd64 go build -ldflags="-X 'llamafarm-cli/cmd.Version=test-cross'" -o ../dist/lf-linux .; then
+    if GOOS=linux GOARCH=amd64 go build -ldflags="-X 'github.com/llamafarm/cli/cmd/version.CurrentVersion=test-cross'" -o ../dist/lf-linux .; then
         success "Linux cross-compilation works"
     else
         error "Linux cross-compilation failed"
     fi
 
-    if GOOS=windows GOARCH=amd64 go build -ldflags="-X 'llamafarm-cli/cmd.Version=test-cross'" -o ../dist/lf-windows.exe .; then
+    if GOOS=windows GOARCH=amd64 go build -ldflags="-X 'github.com/llamafarm/cli/cmd/version.CurrentVersion=test-cross'" -o ../dist/lf-windows.exe .; then
         success "Windows cross-compilation works"
     else
         error "Windows cross-compilation failed"


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Update CLI version flag path from incorrect to correct Go package path

- Change ldflags from `llamafarm-cli/cmd.Version` to `github.com/llamafarm/cli/cmd/version.CurrentVersion`

- Update all build scripts and workflows to use corrected version variable

- Update documentation to reflect new version variable naming


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old Path: llamafarm-cli/cmd.Version"] -->|"Update to correct path"| B["New Path: github.com/llamafarm/cli/cmd/version.CurrentVersion"]
  B --> C["Build Scripts"]
  B --> D["CI/CD Workflows"]
  B --> E["Documentation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test-install.sh</strong><dd><code>Fix version flag in local and cross-compile tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/hack/test-install.sh

<ul><li>Updated ldflags in local build test from <code>llamafarm-cli/cmd.Version</code> to <br><code>github.com/llamafarm/cli/cmd/version.CurrentVersion</code><br> <li> Updated ldflags in cross-compilation tests for Linux, macOS, and <br>Windows builds</ul>


</details>


  </td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/440/files#diff-2f3afdad427ac9c65830d43fb5c727393ae3c598af380c0dd431ec77d72539c7">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test-installer-comprehensive.sh</strong><dd><code>Fix version flag in comprehensive installer tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/hack/test-installer-comprehensive.sh

<ul><li>Updated ldflags in build_test_binaries function to use correct version <br>variable path</ul>


</details>


  </td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/440/files#diff-d28b2f6aa36727615d6fa698817ee3a6894b0372432c8c91f1343eb3b5eb1946">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test-installer-docker.sh</strong><dd><code>Fix version flag in Docker installer tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/hack/test-installer-docker.sh

<ul><li>Updated ldflags in test_cli_build function to use correct version <br>variable path</ul>


</details>


  </td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/440/files#diff-e903cdc1bf69e189926e141885121601d0383000f66e438daaa36fba91929380">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test-installer-local.sh</strong><dd><code>Fix version flag in local installer tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/hack/test-installer-local.sh

<ul><li>Updated ldflags in create_test_artifacts function to use correct <br>version variable path</ul>


</details>


  </td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/440/files#diff-51c6c7c0cfa356b1cdc28381fa1c1c9513701533d86ca6cca0c72b3bd6770fc0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test-installer-quick.sh</strong><dd><code>Fix version flag in quick installer tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/hack/test-installer-quick.sh

<ul><li>Updated ldflags in test_cli_build function for basic build test<br> <li> Updated ldflags in cross-compilation tests for Linux and Windows</ul>


</details>


  </td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/440/files#diff-22ecd659a09ac35a3396328c47c9fee6508c4d032ceccd327dbec6308c3ffbdf">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cli.yml</strong><dd><code>Fix version flag in CLI workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/cli.yml

<ul><li>Updated ldflags in build step to use correct version variable path<br> <li> Added quotes around ldflags value for proper shell escaping</ul>


</details>


  </td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/440/files#diff-302cf6f60da3e4f2ef11792a8bcf7b39c384c4c0e4e065b575e0aaf7d5fa5c79">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>release-cli.yml</strong><dd><code>Fix version flag in release workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release-cli.yml

<ul><li>Updated ldflags in binary build step to use correct version variable <br>path</ul>


</details>


  </td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/440/files#diff-6ba0eeeb9cdfe6d2493769e2c1b9d3b249ab70bf3d9f1e9d0dc28296446f5a46">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update version flag documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/README.md

<ul><li>Updated documentation example to reflect new version variable path and <br>name<br> <li> Changed from <code>llamafarm-cli/cmd.Version</code> to <br><code>github.com/llamafarm/cli/cmd/version.CurrentVersion</code></ul>


</details>


  </td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/440/files#diff-a60fd8fcc968f85dd50305193d1af8e94118afb7439f90c07bb434acd3490fab">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

