### PR TITLE
fix: Clear Chat Button Input Field Issue During Streaming

### DIFF
--- a/designer/src/hooks/useChatbox.ts
+++ b/designer/src/hooks/useChatbox.ts
@@ -1209,7 +1209,7 @@ export function useChatbox(options: UseChatboxOptions = {}) {
       await classifyAndSetError(err)
       return false
     }
-  }, [isStreaming, streamingChat, nonStreamingChat, useProjectSessionMode, projectSession, simpleSession])
+  }, [isStreaming, cancelStreaming, streamingChat, nonStreamingChat, useProjectSessionMode, projectSession, simpleSession])
 
   // Handle input change
   const updateInput = useCallback((value: string) => {


### PR DESCRIPTION
### PR Description

fix: #443

### **Problem**
Input field stays disabled when clearing chat during streaming, requiring page refresh.

### **Root Cause**  
`clearChat()` didn't cancel streaming, leaving `isStreaming = true` → `isSending = true` → input disabled.

### **Solution**
Added `cancelStreaming()` call in `clearChat()` before clearing messages.

## Summary by Sourcery

Cancel active streaming when clearing chat to re-enable the input field

Bug Fixes:
- Call cancelStreaming in clearChat to prevent the input field from remaining disabled during an ongoing stream

Enhancements:
- Add isStreaming to clearChat’s dependency array to ensure proper effect updating

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Bug fix: clearing chat during an active stream now properly resets state**
> 
> - Call `cancelStreaming()` in `clearChat()` to stop active streams and clear `isStreaming`
> - Reset mutation state via `streamingChat.reset()` and `nonStreamingChat.reset()`
> - Update `clearChat` dependency array to include streaming and cancel/reset refs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d66b7febc32510f683514cce33d1d2d79cd14531. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->