### PR TITLE
fix: Add GH_TOKEN to desktop app workflows

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -112,6 +112,8 @@ jobs:
       - name: Build Electron app (unsigned for PR testing)
         working-directory: electron-app
         env:
+          # GitHub token for electron-builder
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # SECURITY: Disable signing for PR builds to prevent exposing secrets to forks
           # Only release workflow (release-desktop.yml) should sign builds
           CSC_IDENTITY_AUTO_DISCOVERY: false

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -87,6 +87,8 @@ jobs:
       - name: Build and Sign Electron app
         working-directory: electron-app
         env:
+          # GitHub token for electron-builder to publish artifacts
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Certificate (same as CLI workflow)
           CSC_LINK: ${{ secrets.APPLE_CERT_DATA }}
           CSC_KEY_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}


### PR DESCRIPTION
### **User description**
## Summary

Fixes electron-builder failure in desktop app workflows by adding the required GH_TOKEN environment variable.

## Problem

Both desktop app workflows were failing with:
```
Error: GitHub Personal Access Token is not set, neither programmatically, nor using env "GH_TOKEN"
```

## Solution

- Added `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` to the build step in both workflows:
  - `.github/workflows/desktop.yml` (unsigned PR builds)
  - `.github/workflows/release-desktop.yml` (signed release builds)

## Changes

- ✅ Maps GitHub Actions' `GITHUB_TOKEN` to `GH_TOKEN` for electron-builder
- ✅ Fixes build failures in both release and PR workflows
- ✅ No changes to signing behavior or security model

## Testing

This change allows electron-builder to authenticate with GitHub during the build process, which is required for the publish step even when artifacts are uploaded separately.


___

### **PR Type**
Bug fix


___

### **Description**
- Add GH_TOKEN environment variable to desktop workflows

- Maps GitHub Actions GITHUB_TOKEN to electron-builder requirement

- Fixes build failures in both PR and release workflows

- Enables electron-builder artifact publishing authentication


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitHub Actions"] -- "GITHUB_TOKEN secret" --> B["GH_TOKEN env var"]
  B --> C["electron-builder"]
  C --> D["Artifact publishing"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>desktop.yml</strong><dd><code>Add GH_TOKEN to unsigned PR build step</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/desktop.yml

<ul><li>Added <code>GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}</code> environment variable to <br>build step<br> <li> Included explanatory comment about electron-builder requirement<br> <li> Maintains existing security settings for unsigned PR builds</ul>


</details>


  </td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/480/files#diff-cc0ad60f02c62cee29c07f15d6e7d39332ac4e281f8f993c85dfbaa069f6627c">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>release-desktop.yml</strong><dd><code>Add GH_TOKEN to signed release build step</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release-desktop.yml

<ul><li>Added <code>GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}</code> environment variable to <br>build step<br> <li> Included explanatory comment about artifact publishing requirement<br> <li> Preserves existing signing and notarization configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/480/files#diff-7a42dc8739297053550b8882b7bf3fcc770725f51365f7b273ed5a7d9d91c329">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

