### PR TITLE
fix(mcp): handle missing mcp config section gracefully

### DIFF
--- a/server/services/mcp_service.py
+++ b/server/services/mcp_service.py
@@ -55,6 +55,11 @@ class MCPService:
     def _resolve_servers(self) -> list[Server]:
         """Resolve the list of MCP servers to use for the model."""
         servers_to_use: list[Server] = []
+
+        # If no MCP config exists, return empty list
+        if self._config.mcp is None:
+            return servers_to_use
+
         if self._model_config.mcp_servers is not None:
             servers_to_use.extend(
                 [
@@ -64,9 +69,7 @@ class MCPService:
                 ]
             )
         else:
-            servers_to_use.extend(
-                self._config.mcp.servers if self._config.mcp is not None else []
-            )
+            servers_to_use.extend(self._config.mcp.servers)
         return servers_to_use
 
     def list_servers(self) -> list[str]:


### PR DESCRIPTION
### **User description**
## Problem

When a project config has `mcp_servers` defined on models but no top-level `mcp` section, the server crashes with:

```
AttributeError: 'NoneType' object has no attribute 'servers'
  File "server/services/mcp_service.py", line 62, in _resolve_servers
    for s in self._config.mcp.servers
```

## Root Cause

`MCPService._resolve_servers()` checks if `mcp_servers` is not None, but doesn't check if `self._config.mcp` exists before accessing `self._config.mcp.servers`:

```python
if self._model_config.mcp_servers is not None:
    servers_to_use.extend(
        [
            s
            for s in self._config.mcp.servers  # ❌ mcp is None
            if s.name in self._model_config.mcp_servers
        ]
    )
```

When `mcp_servers: []` (empty list, not None), the check passes but `self._config.mcp` is None.

## Solution

Added an early return if `mcp` config is None:

```python
def _resolve_servers(self) -> list[Server]:
    servers_to_use: list[Server] = []
    
    # If no MCP config exists, return empty list
    if self._config.mcp is None:
        return servers_to_use
    
    # ... rest of logic
```

## Testing

1. Create a config with models that have `mcp_servers: []` but no `mcp:` section
2. Make a chat request
3. Verify it works without AttributeError

## Impact

- Allows projects to use `mcp_servers: []` on models without requiring an `mcp` section in config
- No breaking changes - existing configs with MCP section work as before


___

### **PR Type**
Bug fix


___

### **Description**
- Handle missing MCP config section gracefully with early return

- Prevent AttributeError when models have mcp_servers but no mcp section

- Simplify null check logic by consolidating at function start


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["_resolve_servers called"] --> B{"mcp config exists?"}
  B -->|No| C["Return empty list"]
  B -->|Yes| D{"mcp_servers defined?"}
  D -->|Yes| E["Filter servers by name"]
  D -->|No| F["Use all servers"]
  E --> G["Return servers list"]
  F --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mcp_service.py</strong><dd><code>Add early null check for MCP config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/services/mcp_service.py

<ul><li>Added early return check if <code>self._config.mcp</code> is None at start of <br><code>_resolve_servers()</code><br> <li> Removed redundant null check from else branch that was accessing <br><code>self._config.mcp.servers</code><br> <li> Simplified logic by consolidating MCP existence validation in one <br>place</ul>


</details>


  </td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/485/files#diff-8c949652553ee56000b5170f57040b259321366ff7e63681bcc84c94be69c11f">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

