### PR TITLE
fix: hf progress bars can crash runtime

### DIFF
--- a/cli/cmd/orchestrator/services.go
+++ b/cli/cmd/orchestrator/services.go
@@ -115,6 +115,8 @@ func (e *HealthError) Error() string {
 	return fmt.Sprintf("server unhealthy: %s", e.Status)
 }
 
+const hfHubDisableProgressBars = "1" // Disable HF transfer progress bars, as they can cause headless services to crash
+
 // Service Graph Definition
 // Services are defined declaratively - just specify config, the framework handles the rest
 
@@ -137,7 +139,7 @@ var ServiceGraph = map[string]*ServiceDefinition{
 			"LF_RUNTIME_HOST":              "127.0.0.1",
 			"TRANSFORMERS_OUTPUT_DIR":      filepath.Join("${LF_DATA_DIR}", "outputs", "images"),
 			"TRANSFORMERS_CACHE_DIR":       filepath.Join("${HOME}", ".cache", "huggingface"),
-			"HF_HUB_DISABLE_PROGRESS_BARS": "1", // Disable tqdm progress bars to prevent broken pipe errors
+			"HF_HUB_DISABLE_PROGRESS_BARS": hfHubDisableProgressBars,
 			// Device control (empty = inherit from parent environment)
 			"TRANSFORMERS_SKIP_MPS":            "", // Set to "1" to skip MPS on macOS
 			"TRANSFORMERS_FORCE_CPU":           "", // Set to "1" to force CPU (useful in CI)
@@ -162,7 +164,7 @@ var ServiceGraph = map[string]*ServiceDefinition{
 		Args:            []string{"run", "--managed-python", "uvicorn", "main:app", "--host", "0.0.0.0"},
 		Env: map[string]string{
 			"OLLAMA_HOST":                  "http://localhost:11434",
-			"HF_HUB_DISABLE_PROGRESS_BARS": "1", // Disable tqdm progress bars to prevent broken pipe errors
+			"HF_HUB_DISABLE_PROGRESS_BARS": hfHubDisableProgressBars,
 		},
 		HealthComponent: "server",
 	},
@@ -175,7 +177,7 @@ var ServiceGraph = map[string]*ServiceDefinition{
 		Command:         "uv",
 		Args:            []string{"run", "--managed-python", "python", "main.py"},
 		Env: map[string]string{
-			"HF_HUB_DISABLE_PROGRESS_BARS": "1", // Disable tqdm progress bars to prevent broken pipe errors
+			"HF_HUB_DISABLE_PROGRESS_BARS": hfHubDisableProgressBars,
 		},
 		HealthComponent: "rag-service",
 	},


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Disable Hugging Face tqdm progress bars across services

- Prevents broken pipe errors during runtime execution

- Adds environment variable to universal-runtime, server, and rag services

- Aligns environment variable formatting for consistency


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Services Configuration"] -->|Add HF_HUB_DISABLE_PROGRESS_BARS| B["universal-runtime"]
  A -->|Add HF_HUB_DISABLE_PROGRESS_BARS| C["server"]
  A -->|Add HF_HUB_DISABLE_PROGRESS_BARS| D["rag"]
  B -->|Prevent tqdm crashes| E["Stable Execution"]
  C -->|Prevent tqdm crashes| E
  D -->|Prevent tqdm crashes| E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>services.go</strong><dd><code>Disable Hugging Face progress bars in services</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/cmd/orchestrator/services.go

<ul><li>Added <code>HF_HUB_DISABLE_PROGRESS_BARS</code> environment variable set to "1" in <br>universal-runtime service configuration<br> <li> Added <code>HF_HUB_DISABLE_PROGRESS_BARS</code> environment variable set to "1" in <br>server service configuration<br> <li> Added new <code>Env</code> map with <code>HF_HUB_DISABLE_PROGRESS_BARS</code> environment <br>variable to rag service<br> <li> Reformatted environment variable key alignment for improved <br>readability across all service definitions</ul>


</details>


  </td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/499/files#diff-9d524758560b8c261cebc0fd9b2ad7db069c192dd8a1e3eaf48205b72ac76ad5">+10/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

