### PR TITLE
fix(api): Support datasets endpoint without trailing slash

### DIFF
--- a/server/api/routers/datasets/datasets.py
+++ b/server/api/routers/datasets/datasets.py
@@ -16,12 +16,14 @@ router = APIRouter(
 )
 
 
+# Support both with and without trailing slash to avoid proxy redirect issues
 @router.get(
     "/",
     operation_id="dataset_list",
     tags=["mcp"],
     responses={200: {"model": ListDatasetsResponse}},
 )
+@router.get("", include_in_schema=False)
 async def list_datasets(
     namespace: str,
     project: str,


### PR DESCRIPTION
### **User description**
## Summary

Fix datasets API returning HTML instead of JSON when called without trailing slash.

## Changes

- Add secondary route decorator `@router.get("")` to handle requests without trailing slash
- Follows the same pattern used in the examples router

## Testing

```bash
# Before fix - returns HTML
curl http://localhost:8000/v1/projects/default/my-project/datasets

# After fix - returns JSON
curl http://localhost:8000/v1/projects/default/my-project/datasets
# {"total":1,"datasets":[...]}

# With trailing slash still works
curl http://localhost:8000/v1/projects/default/my-project/datasets/
# {"total":1,"datasets":[...]}
```

Fixes #518


___

### **PR Type**
Bug fix


___

### **Description**
- Add secondary route decorator to handle datasets endpoint without trailing slash

- Prevents requests falling through to SPA catch-all returning HTML instead of JSON

- Follows existing pattern used in examples router for consistency


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Request to /datasets"] --> B{"Route Match"}
  B -->|"With @router.get('')"| C["Returns JSON"]
  B -->|"Without fix"| D["Falls to SPA catch-all"]
  D --> E["Returns HTML"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>datasets.py</strong><dd><code>Add trailing slash support to datasets endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/api/routers/datasets/datasets.py

<ul><li>Added comment explaining the dual route pattern for trailing slash <br>support<br> <li> Added secondary <code>@router.get("")</code> decorator to <code>list_datasets</code> function <br>with <code>include_in_schema=False</code><br> <li> Ensures both <code>/datasets</code> and <code>/datasets/</code> requests are properly handled by <br>the API</ul>


</details>


  </td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/519/files#diff-2a9ae7c4d14682581ee3ed7e03a2a56531d580c63939b236143b9968032cffdd">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

