### PR TITLE
feat(rag): report rag stats

### DIFF
--- a/cli/cmd/rag_stats.go
+++ b/cli/cmd/rag_stats.go
@@ -290,7 +290,7 @@ func fetchRAGStats(cfg *config.ServerConfig, database string) (*RAGStats, error)
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("server returned %d: %s", resp.StatusCode, string(body))
+		return nil, fmt.Errorf("%s", utils.PrettyServerError(resp, body))
 	}
 
 	var stats RAGStats
@@ -324,7 +324,7 @@ func fetchRAGHealth(cfg *config.ServerConfig, database string) (*RAGHealth, erro
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("server returned %d: %s", resp.StatusCode, string(body))
+		return nil, fmt.Errorf("%s", utils.PrettyServerError(resp, body))
 	}
 
 	var health RAGHealth
@@ -370,7 +370,7 @@ func fetchRAGDocuments(cfg *config.ServerConfig, database string, limit int, fil
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("server returned %d: %s", resp.StatusCode, string(body))
+		return nil, fmt.Errorf("%s", utils.PrettyServerError(resp, body))
 	}
 
 	var docs []RAGDocument
@@ -404,7 +404,7 @@ func compactRAGDatabase(cfg *config.ServerConfig, database string) (*CompactionR
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("server returned %d: %s", resp.StatusCode, string(body))
+		return nil, fmt.Errorf("%s", utils.PrettyServerError(resp, body))
 	}
 
 	var result CompactionResult
@@ -446,7 +446,7 @@ func reindexRAGDatabase(cfg *config.ServerConfig, database string, strategy stri
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("server returned %d: %s", resp.StatusCode, string(body))
+		return nil, fmt.Errorf("%s", utils.PrettyServerError(resp, body))
 	}
 
 	var result ReindexResult

--- a/cli/cmd/rag_stats_test.go
+++ b/cli/cmd/rag_stats_test.go
@@ -1,0 +1,291 @@
+package cmd
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/llamafarm/cli/cmd/config"
+	"github.com/llamafarm/cli/cmd/utils"
+)
+
+func TestFetchRAGStats_Success(t *testing.T) {
+	// Mock response matching RAGStats structure
+	mockResponse := `{
+		"database": "test_db",
+		"vector_count": 1000,
+		"document_count": 50,
+		"chunk_count": 1000,
+		"collection_size_bytes": 5242880,
+		"index_size_bytes": 1048576,
+		"embedding_dimension": 768,
+		"distance_metric": "cosine",
+		"last_updated": "2025-01-01T12:00:00Z",
+		"metadata": {"collection_name": "test_db"}
+	}`
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify the request path
+		expectedPath := "/v1/projects/test-ns/test-project/rag/stats"
+		if r.URL.Path != expectedPath {
+			t.Errorf("unexpected path: got %s, want %s", r.URL.Path, expectedPath)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		io.WriteString(w, mockResponse)
+	}))
+	defer ts.Close()
+
+	cfg := &config.ServerConfig{
+		URL:       ts.URL,
+		Namespace: "test-ns",
+		Project:   "test-project",
+	}
+
+	stats, err := fetchRAGStats(cfg, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if stats.Database != "test_db" {
+		t.Errorf("expected database 'test_db', got '%s'", stats.Database)
+	}
+	if stats.VectorCount != 1000 {
+		t.Errorf("expected vector_count 1000, got %d", stats.VectorCount)
+	}
+	if stats.DocumentCount != 50 {
+		t.Errorf("expected document_count 50, got %d", stats.DocumentCount)
+	}
+	if stats.ChunkCount != 1000 {
+		t.Errorf("expected chunk_count 1000, got %d", stats.ChunkCount)
+	}
+	if stats.EmbeddingDim != 768 {
+		t.Errorf("expected embedding_dimension 768, got %d", stats.EmbeddingDim)
+	}
+	if stats.DistanceMetric != "cosine" {
+		t.Errorf("expected distance_metric 'cosine', got '%s'", stats.DistanceMetric)
+	}
+}
+
+func TestFetchRAGStats_WithDatabaseParam(t *testing.T) {
+	mockResponse := `{
+		"database": "specific_db",
+		"vector_count": 500,
+		"document_count": 25,
+		"chunk_count": 500,
+		"collection_size_bytes": 2621440,
+		"index_size_bytes": 524288,
+		"embedding_dimension": 1536,
+		"distance_metric": "l2",
+		"last_updated": "2025-01-01T12:00:00Z",
+		"metadata": null
+	}`
+
+	var receivedQuery string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		io.WriteString(w, mockResponse)
+	}))
+	defer ts.Close()
+
+	cfg := &config.ServerConfig{
+		URL:       ts.URL,
+		Namespace: "test-ns",
+		Project:   "test-project",
+	}
+
+	stats, err := fetchRAGStats(cfg, "specific_db")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify query parameter was passed
+	if receivedQuery != "database=specific_db" {
+		t.Errorf("expected query 'database=specific_db', got '%s'", receivedQuery)
+	}
+
+	if stats.Database != "specific_db" {
+		t.Errorf("expected database 'specific_db', got '%s'", stats.Database)
+	}
+	if stats.EmbeddingDim != 1536 {
+		t.Errorf("expected embedding_dimension 1536, got %d", stats.EmbeddingDim)
+	}
+}
+
+func TestFetchRAGStats_NotFoundError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		io.WriteString(w, `{"detail":"Database 'nonexistent' not found"}`)
+	}))
+	defer ts.Close()
+
+	cfg := &config.ServerConfig{
+		URL:       ts.URL,
+		Namespace: "test-ns",
+		Project:   "test-project",
+	}
+
+	_, err := fetchRAGStats(cfg, "nonexistent")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	// Verify the error message is human-friendly (uses PrettyServerError)
+	if !strings.Contains(err.Error(), "Database 'nonexistent' not found") {
+		t.Errorf("expected friendly error message, got: %v", err)
+	}
+	// Should NOT contain raw JSON
+	if strings.Contains(err.Error(), `{"detail"`) {
+		t.Errorf("error should not contain raw JSON: %v", err)
+	}
+}
+
+func TestFetchRAGStats_RAGNotConfigured(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		io.WriteString(w, `{"detail":"RAG not configured for this project"}`)
+	}))
+	defer ts.Close()
+
+	cfg := &config.ServerConfig{
+		URL:       ts.URL,
+		Namespace: "test-ns",
+		Project:   "test-project",
+	}
+
+	_, err := fetchRAGStats(cfg, "")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "RAG not configured") {
+		t.Errorf("expected 'RAG not configured' in error, got: %v", err)
+	}
+}
+
+func TestFetchRAGHealth_PrettyError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		io.WriteString(w, `{"detail":"Database 'missing' not found"}`)
+	}))
+	defer ts.Close()
+
+	cfg := &config.ServerConfig{
+		URL:       ts.URL,
+		Namespace: "test-ns",
+		Project:   "test-project",
+	}
+
+	_, err := fetchRAGHealth(cfg, "missing")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	// Verify error uses PrettyServerError
+	if !strings.Contains(err.Error(), "Database 'missing' not found") {
+		t.Errorf("expected friendly error message, got: %v", err)
+	}
+}
+
+func TestPrettyServerError_ExtractsDetail(t *testing.T) {
+	tests := []struct {
+		name           string
+		body           string
+		expectedResult string
+	}{
+		{
+			name:           "simple detail string",
+			body:           `{"detail":"Database not found"}`,
+			expectedResult: "Database not found",
+		},
+		{
+			name:           "message field",
+			body:           `{"message":"Something went wrong"}`,
+			expectedResult: "Something went wrong",
+		},
+		{
+			name:           "error field",
+			body:           `{"error":"Internal error occurred"}`,
+			expectedResult: "Internal error occurred",
+		},
+		{
+			name:           "nested detail message",
+			body:           `{"detail":{"message":"Validation failed"}}`,
+			expectedResult: "Validation failed",
+		},
+		{
+			name:           "array detail",
+			body:           `{"detail":[{"message":"Field required"}]}`,
+			expectedResult: "Field required",
+		},
+		{
+			name:           "non-json response",
+			body:           `Internal Server Error`,
+			expectedResult: "Internal Server Error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := &http.Response{
+				StatusCode: 400,
+				Status:     "400 Bad Request",
+				Header:     make(http.Header),
+			}
+
+			result := utils.PrettyServerError(resp, []byte(tt.body))
+			if result != tt.expectedResult {
+				t.Errorf("expected '%s', got '%s'", tt.expectedResult, result)
+			}
+		})
+	}
+}
+
+func TestFormatBytes(t *testing.T) {
+	tests := []struct {
+		bytes    int64
+		expected string
+	}{
+		{0, "0 B"},
+		{512, "512 B"},
+		{1024, "1.0 KB"},
+		{1536, "1.5 KB"},
+		{1048576, "1.0 MB"},
+		{1073741824, "1.0 GB"},
+		{5242880, "5.0 MB"},
+	}
+
+	for _, tt := range tests {
+		result := formatBytes(tt.bytes)
+		if result != tt.expected {
+			t.Errorf("formatBytes(%d) = %s, want %s", tt.bytes, result, tt.expected)
+		}
+	}
+}
+
+func TestTruncateString(t *testing.T) {
+	tests := []struct {
+		input    string
+		maxLen   int
+		expected string
+	}{
+		{"short", 10, "short"},
+		{"exactly10!", 10, "exactly10!"},
+		{"this is a long string", 10, "this is..."},
+		{"", 10, ""},
+	}
+
+	for _, tt := range tests {
+		result := truncateString(tt.input, tt.maxLen)
+		if result != tt.expected {
+			t.Errorf("truncateString(%q, %d) = %q, want %q", tt.input, tt.maxLen, result, tt.expected)
+		}
+	}
+}

--- a/rag/tasks/__init__.py
+++ b/rag/tasks/__init__.py
@@ -13,6 +13,7 @@ from .health_tasks import rag_health_check_task, rag_ping_task
 from .ingest_tasks import ingest_file_with_rag_task
 from .query_tasks import handle_rag_query_task
 from .search_tasks import search_with_rag_database_task
+from .stats_tasks import rag_get_database_stats_task
 
 __all__ = [
     "search_with_rag_database_task",
@@ -20,4 +21,5 @@ __all__ = [
     "handle_rag_query_task",
     "rag_health_check_task",
     "rag_ping_task",
+    "rag_get_database_stats_task",
 ]

--- a/rag/tasks/stats_tasks.py
+++ b/rag/tasks/stats_tasks.py
@@ -1,0 +1,314 @@
+"""
+RAG Stats Tasks
+
+Celery tasks for retrieving RAG database statistics.
+"""
+
+import sys
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from celery import Task
+
+from api import DatabaseSearchAPI
+from celery_app import app
+from core.logging import RAGStructLogger
+
+# Add the repo root to the path to find the config module
+repo_root = Path(__file__).parent.parent.parent
+if str(repo_root) not in sys.path:
+    sys.path.insert(0, str(repo_root))
+from config import load_config  # noqa: E402
+
+logger = RAGStructLogger("rag.tasks.stats")
+
+
+class StatsTask(Task):
+    """Base task class for stats operations."""
+
+    def on_failure(self, exc, task_id, args, kwargs, einfo):
+        """Log task failure details."""
+        logger.error(
+            "RAG stats task failed",
+            extra={
+                "task_id": task_id,
+                "task_name": self.name,
+                "error": str(exc),
+                "task_args": args,
+                "task_kwargs": kwargs,
+            },
+        )
+
+
+@app.task(bind=True, base=StatsTask, name="rag.get_database_stats")
+def rag_get_database_stats_task(
+    self, project_dir: str, database: str
+) -> dict[str, Any]:
+    """
+    Get comprehensive statistics for a specific RAG database.
+
+    This task retrieves vector counts, document counts, storage info,
+    and configuration details for the specified database.
+
+    Args:
+        project_dir: Directory containing llamafarm.yaml config
+        database: Database name to get stats for
+
+    Returns:
+        Dict containing database statistics matching the CLI's RAGStats struct
+    """
+    start_time = time.time()
+
+    logger.info(
+        "Starting database stats retrieval",
+        extra={
+            "task_id": self.request.id,
+            "project_dir": project_dir,
+            "database": database,
+        },
+    )
+
+    # Initialize response with defaults
+    stats_data = {
+        "database": database,
+        "vector_count": 0,
+        "document_count": 0,
+        "chunk_count": 0,
+        "collection_size_bytes": 0,
+        "index_size_bytes": 0,
+        "embedding_dimension": 0,
+        "distance_metric": "cosine",
+        "last_updated": datetime.now(UTC).isoformat(),
+        "metadata": {},
+    }
+
+    try:
+        # Load project configuration to get database settings
+        config = load_config(config_path=project_dir, validate=True)
+
+        if not config or not config.rag or not config.rag.databases:
+            return {
+                **stats_data,
+                "metadata": {"error": "RAG not configured in project"},
+            }
+
+        # Find the specific database configuration
+        database_config = None
+        for db_cfg in config.rag.databases:
+            if db_cfg.name == database:
+                database_config = db_cfg
+                break
+
+        if not database_config:
+            return {
+                **stats_data,
+                "metadata": {
+                    "error": f"Database '{database}' not found in configuration"
+                },
+            }
+
+        # Extract configuration details
+        # Distance metric from database config
+        if database_config.config and isinstance(database_config.config, dict):
+            stats_data["distance_metric"] = database_config.config.get(
+                "distance_function", "cosine"
+            )
+
+        # Embedding dimension from default embedding strategy
+        stats_data["embedding_dimension"] = _get_embedding_dimension(database_config)
+
+        # Initialize search API to access vector store
+        try:
+            search_api = DatabaseSearchAPI(project_dir=project_dir, database=database)
+
+            # Get collection info from vector store
+            collection_info = search_api.vector_store.get_collection_info()
+
+            if collection_info and "error" not in collection_info:
+                # Vector count is the total number of entries in the collection
+                # This includes all chunks
+                stats_data["vector_count"] = collection_info.get("count", 0)
+                stats_data["chunk_count"] = collection_info.get("count", 0)
+
+                # Try to get unique document count by querying metadata
+                # For now, use vector count as an approximation
+                # In the future, we could query unique source_file metadata
+                stats_data["document_count"] = _estimate_document_count(
+                    search_api, stats_data["chunk_count"]
+                )
+
+                # Add collection metadata
+                stats_data["metadata"]["collection_name"] = collection_info.get(
+                    "name", database
+                )
+                stats_data["metadata"]["persist_directory"] = collection_info.get(
+                    "persist_directory", ""
+                )
+
+                # Try to get storage size from persist directory
+                persist_dir = collection_info.get("persist_directory")
+                if persist_dir:
+                    collection_size, index_size = _get_storage_sizes(persist_dir)
+                    stats_data["collection_size_bytes"] = collection_size
+                    stats_data["index_size_bytes"] = index_size
+
+            else:
+                stats_data["metadata"]["collection_error"] = collection_info.get(
+                    "error", "Unknown error"
+                )
+
+        except Exception as e:
+            logger.warning(
+                f"Could not access vector store for stats: {e}",
+                extra={"database": database},
+            )
+            stats_data["metadata"]["access_error"] = str(e)
+
+        # Record timing
+        duration_ms = int((time.time() - start_time) * 1000)
+        stats_data["metadata"]["retrieval_duration_ms"] = duration_ms
+
+        logger.info(
+            "Database stats retrieval completed",
+            extra={
+                "task_id": self.request.id,
+                "database": database,
+                "vector_count": stats_data["vector_count"],
+                "duration_ms": duration_ms,
+            },
+        )
+
+        return stats_data
+
+    except Exception as e:
+        logger.error(
+            "Database stats retrieval failed",
+            extra={
+                "task_id": self.request.id,
+                "database": database,
+                "error": str(e),
+            },
+            exc_info=True,
+        )
+
+        return {
+            **stats_data,
+            "metadata": {
+                "error": f"Stats retrieval failed: {str(e)}",
+                "retrieval_duration_ms": int((time.time() - start_time) * 1000),
+            },
+        }
+
+
+def _get_embedding_dimension(database_config) -> int:
+    """
+    Extract embedding dimension from database config.
+
+    Uses the default embedding strategy if specified, otherwise the first strategy.
+
+    Args:
+        database_config: Database configuration object
+
+    Returns:
+        Embedding dimension (defaults to 768 if not found)
+    """
+    strategies = database_config.embedding_strategies
+    if not strategies:
+        return 768
+
+    # Find target strategy: default if specified, otherwise first
+    default_name = database_config.default_embedding_strategy
+    target = (
+        next(
+            (s for s in strategies if s.name == default_name),
+            strategies[0],
+        )
+        if default_name
+        else strategies[0]
+    )
+
+    # Extract dimension from config dict
+    config = target.config
+    if isinstance(config, dict):
+        return config.get("dimension", 768)
+
+    return 768
+
+
+def _estimate_document_count(search_api: DatabaseSearchAPI, chunk_count: int) -> int:
+    """
+    Estimate the number of unique documents in the database.
+
+    This tries to count unique source files. Falls back to chunk_count / 10
+    as a rough estimate if metadata query fails.
+
+    Args:
+        search_api: Initialized DatabaseSearchAPI
+        chunk_count: Total number of chunks in the database
+
+    Returns:
+        Estimated document count
+    """
+    try:
+        # Try to get unique document IDs from the collection
+        # ChromaDB allows getting all IDs but not metadata directly
+        if hasattr(search_api.vector_store, "collection"):
+            collection = search_api.vector_store.collection
+            # Get a sample of metadata to count unique source files
+            result = collection.get(
+                limit=min(chunk_count, 10000), include=["metadatas"]
+            )
+            if result and result.get("metadatas"):
+                unique_sources = set()
+                for meta in result["metadatas"]:
+                    if meta:
+                        # Try different metadata keys that might identify source
+                        source = (
+                            meta.get("source_file")
+                            or meta.get("source")
+                            or meta.get("filename")
+                        )
+                        if source:
+                            unique_sources.add(source)
+                if unique_sources:
+                    return len(unique_sources)
+    except Exception:
+        pass
+
+    # Fallback: estimate based on typical chunk ratio
+    # Assume ~10 chunks per document on average
+    if chunk_count > 0:
+        return max(1, chunk_count // 10)
+    return 0
+
+
+def _get_storage_sizes(persist_dir: str) -> tuple[int, int]:
+    """
+    Calculate storage sizes for the database.
+
+    Args:
+        persist_dir: Path to the persist directory
+
+    Returns:
+        Tuple of (collection_size_bytes, index_size_bytes)
+    """
+    collection_size = 0
+    index_size = 0
+
+    try:
+        persist_path = Path(persist_dir)
+        if persist_path.exists():
+            for file_path in persist_path.rglob("*"):
+                if file_path.is_file():
+                    file_size = file_path.stat().st_size
+                    # Index files typically have specific extensions
+                    if file_path.suffix in (".idx", ".index", ".bin"):
+                        index_size += file_size
+                    else:
+                        collection_size += file_size
+    except Exception:
+        pass
+
+    return collection_size, index_size

--- a/rag/tests/test_stats_tasks.py
+++ b/rag/tests/test_stats_tasks.py
@@ -1,0 +1,329 @@
+"""Tests for RAG stats Celery tasks."""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import Mock
+
+
+class TestEstimateDocumentCount:
+    """Tests for document count estimation helper."""
+
+    def test_estimate_from_unique_source_files(self):
+        """Test document count estimation from unique source files."""
+        from tasks.stats_tasks import _estimate_document_count
+
+        mock_api = Mock()
+        mock_collection = Mock()
+
+        # Simulate 6 chunks from 3 unique documents
+        mock_collection.get.return_value = {
+            "metadatas": [
+                {"source_file": "doc1.pdf"},
+                {"source_file": "doc1.pdf"},
+                {"source_file": "doc1.pdf"},
+                {"source_file": "doc2.pdf"},
+                {"source_file": "doc2.pdf"},
+                {"source_file": "doc3.pdf"},
+            ]
+        }
+        mock_api.vector_store.collection = mock_collection
+
+        count = _estimate_document_count(mock_api, chunk_count=6)
+        assert count == 3
+
+    def test_estimate_using_source_key(self):
+        """Test estimation using 'source' metadata key."""
+        from tasks.stats_tasks import _estimate_document_count
+
+        mock_api = Mock()
+        mock_collection = Mock()
+
+        mock_collection.get.return_value = {
+            "metadatas": [
+                {"source": "/path/to/doc1.pdf"},
+                {"source": "/path/to/doc1.pdf"},
+                {"source": "/path/to/doc2.pdf"},
+            ]
+        }
+        mock_api.vector_store.collection = mock_collection
+
+        count = _estimate_document_count(mock_api, chunk_count=3)
+        assert count == 2
+
+    def test_estimate_using_filename_key(self):
+        """Test estimation using 'filename' metadata key."""
+        from tasks.stats_tasks import _estimate_document_count
+
+        mock_api = Mock()
+        mock_collection = Mock()
+
+        mock_collection.get.return_value = {
+            "metadatas": [
+                {"filename": "report.pdf"},
+                {"filename": "report.pdf"},
+            ]
+        }
+        mock_api.vector_store.collection = mock_collection
+
+        count = _estimate_document_count(mock_api, chunk_count=2)
+        assert count == 1
+
+    def test_estimate_fallback_when_query_fails(self):
+        """Test fallback estimation when metadata query fails."""
+        from tasks.stats_tasks import _estimate_document_count
+
+        mock_api = Mock()
+        mock_api.vector_store.collection.get.side_effect = Exception("Query failed")
+
+        # Should fall back to chunk_count / 10
+        count = _estimate_document_count(mock_api, chunk_count=100)
+        assert count == 10
+
+    def test_estimate_fallback_no_source_metadata(self):
+        """Test fallback when metadata has no source info."""
+        from tasks.stats_tasks import _estimate_document_count
+
+        mock_api = Mock()
+        mock_collection = Mock()
+
+        mock_collection.get.return_value = {
+            "metadatas": [
+                {"chunk_index": 0},
+                {"chunk_index": 1},
+            ]
+        }
+        mock_api.vector_store.collection = mock_collection
+
+        # No source info found, should fall back
+        count = _estimate_document_count(mock_api, chunk_count=20)
+        assert count == 2  # 20 / 10
+
+    def test_estimate_with_zero_chunks(self):
+        """Test estimation with zero chunks."""
+        from tasks.stats_tasks import _estimate_document_count
+
+        mock_api = Mock()
+        mock_api.vector_store.collection.get.side_effect = Exception("Query failed")
+
+        count = _estimate_document_count(mock_api, chunk_count=0)
+        assert count == 0
+
+    def test_estimate_minimum_one_document(self):
+        """Test that estimate returns at least 1 for non-zero chunks."""
+        from tasks.stats_tasks import _estimate_document_count
+
+        mock_api = Mock()
+        mock_api.vector_store.collection.get.side_effect = Exception("Query failed")
+
+        # Even with just 5 chunks, should return at least 1
+        count = _estimate_document_count(mock_api, chunk_count=5)
+        assert count >= 1
+
+
+class TestGetStorageSizes:
+    """Tests for storage size calculation helper."""
+
+    def test_storage_sizes_with_data_and_index(self):
+        """Test storage size calculation with data and index files."""
+        from tasks.stats_tasks import _get_storage_sizes
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create data file
+            data_file = Path(tmpdir) / "data.db"
+            data_file.write_bytes(b"x" * 1000)
+
+            # Create index file
+            index_file = Path(tmpdir) / "index.idx"
+            index_file.write_bytes(b"y" * 500)
+
+            collection_size, index_size = _get_storage_sizes(tmpdir)
+
+            assert collection_size == 1000
+            assert index_size == 500
+
+    def test_storage_sizes_multiple_index_types(self):
+        """Test that various index file extensions are recognized."""
+        from tasks.stats_tasks import _get_storage_sizes
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create various index files
+            (Path(tmpdir) / "hnsw.idx").write_bytes(b"a" * 100)
+            (Path(tmpdir) / "vectors.index").write_bytes(b"b" * 200)
+            (Path(tmpdir) / "embeddings.bin").write_bytes(b"c" * 300)
+
+            # Create data file
+            (Path(tmpdir) / "metadata.json").write_bytes(b"d" * 50)
+
+            collection_size, index_size = _get_storage_sizes(tmpdir)
+
+            assert index_size == 600  # 100 + 200 + 300
+            assert collection_size == 50
+
+    def test_storage_sizes_nested_directories(self):
+        """Test storage size calculation with nested directories."""
+        from tasks.stats_tasks import _get_storage_sizes
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            subdir = Path(tmpdir) / "subdir"
+            subdir.mkdir()
+
+            (Path(tmpdir) / "root.db").write_bytes(b"x" * 100)
+            (subdir / "nested.db").write_bytes(b"y" * 200)
+            (subdir / "nested.idx").write_bytes(b"z" * 50)
+
+            collection_size, index_size = _get_storage_sizes(tmpdir)
+
+            assert collection_size == 300  # 100 + 200
+            assert index_size == 50
+
+    def test_storage_sizes_nonexistent_dir(self):
+        """Test storage sizes with nonexistent directory."""
+        from tasks.stats_tasks import _get_storage_sizes
+
+        collection_size, index_size = _get_storage_sizes("/nonexistent/path/xyz")
+
+        assert collection_size == 0
+        assert index_size == 0
+
+    def test_storage_sizes_empty_dir(self):
+        """Test storage sizes with empty directory."""
+        from tasks.stats_tasks import _get_storage_sizes
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            collection_size, index_size = _get_storage_sizes(tmpdir)
+
+            assert collection_size == 0
+            assert index_size == 0
+
+
+class TestGetEmbeddingDimension:
+    """Tests for the _get_embedding_dimension helper."""
+
+    def test_extracts_from_default_strategy(self):
+        """Test extraction from explicitly configured default strategy."""
+        from tasks.stats_tasks import _get_embedding_dimension
+
+        mock_strategy1 = Mock()
+        mock_strategy1.name = "small"
+        mock_strategy1.config = {"dimension": 384}
+
+        mock_strategy2 = Mock()
+        mock_strategy2.name = "large"
+        mock_strategy2.config = {"dimension": 1536}
+
+        mock_db = Mock()
+        mock_db.embedding_strategies = [mock_strategy1, mock_strategy2]
+        mock_db.default_embedding_strategy = "large"
+
+        assert _get_embedding_dimension(mock_db) == 1536
+
+    def test_uses_first_strategy_when_no_default(self):
+        """Test that first strategy is used when no default specified."""
+        from tasks.stats_tasks import _get_embedding_dimension
+
+        mock_strategy1 = Mock()
+        mock_strategy1.name = "first"
+        mock_strategy1.config = {"dimension": 512}
+
+        mock_strategy2 = Mock()
+        mock_strategy2.name = "second"
+        mock_strategy2.config = {"dimension": 768}
+
+        mock_db = Mock()
+        mock_db.embedding_strategies = [mock_strategy1, mock_strategy2]
+        mock_db.default_embedding_strategy = None
+
+        assert _get_embedding_dimension(mock_db) == 512
+
+    def test_returns_default_when_no_strategies(self):
+        """Test default value when no embedding strategies configured."""
+        from tasks.stats_tasks import _get_embedding_dimension
+
+        mock_db = Mock()
+        mock_db.embedding_strategies = []
+
+        assert _get_embedding_dimension(mock_db) == 768
+
+    def test_returns_default_when_strategies_is_none(self):
+        """Test default value when embedding_strategies is None."""
+        from tasks.stats_tasks import _get_embedding_dimension
+
+        mock_db = Mock()
+        mock_db.embedding_strategies = None
+
+        assert _get_embedding_dimension(mock_db) == 768
+
+    def test_returns_default_when_config_missing_dimension(self):
+        """Test default when strategy config lacks dimension key."""
+        from tasks.stats_tasks import _get_embedding_dimension
+
+        mock_strategy = Mock()
+        mock_strategy.name = "no_dimension"
+        mock_strategy.config = {"model": "nomic-embed-text"}
+
+        mock_db = Mock()
+        mock_db.embedding_strategies = [mock_strategy]
+        mock_db.default_embedding_strategy = None
+
+        assert _get_embedding_dimension(mock_db) == 768
+
+    def test_handles_non_dict_config(self):
+        """Test graceful handling when config is not a dict."""
+        from tasks.stats_tasks import _get_embedding_dimension
+
+        mock_strategy = Mock()
+        mock_strategy.name = "weird"
+        mock_strategy.config = "not a dict"
+
+        mock_db = Mock()
+        mock_db.embedding_strategies = [mock_strategy]
+        mock_db.default_embedding_strategy = None
+
+        assert _get_embedding_dimension(mock_db) == 768
+
+    def test_finds_default_not_at_first_position(self):
+        """Test finding default strategy when it's not the first in list."""
+        from tasks.stats_tasks import _get_embedding_dimension
+
+        strategies = []
+        for _, (name, dim) in enumerate([("a", 256), ("b", 512), ("c", 1024)]):
+            s = Mock()
+            s.name = name
+            s.config = {"dimension": dim}
+            strategies.append(s)
+
+        mock_db = Mock()
+        mock_db.embedding_strategies = strategies
+        mock_db.default_embedding_strategy = "c"
+
+        assert _get_embedding_dimension(mock_db) == 1024
+
+
+class TestStatsTaskTaskImport:
+    """Test that stats task can be imported and has correct metadata."""
+
+    def test_task_is_registered(self):
+        """Test that the stats task is properly registered."""
+        from tasks.stats_tasks import rag_get_database_stats_task
+
+        assert rag_get_database_stats_task.name == "rag.get_database_stats"
+
+    def test_task_module_imports(self):
+        """Test that all stats task components can be imported."""
+        from tasks.stats_tasks import (
+            StatsTask,
+            _estimate_document_count,
+            _get_storage_sizes,
+            rag_get_database_stats_task,
+        )
+
+        assert StatsTask is not None
+        assert rag_get_database_stats_task is not None
+        assert callable(_estimate_document_count)
+        assert callable(_get_storage_sizes)
+
+    def test_task_exported_from_package(self):
+        """Test that task is exported from tasks package."""
+        from tasks import rag_get_database_stats_task
+
+        assert rag_get_database_stats_task.name == "rag.get_database_stats"

--- a/rag/uv.lock
+++ b/rag/uv.lock
@@ -1311,6 +1311,38 @@ wheels = [
 ]
 
 [[package]]
+name = "hf-transfer"
+version = "0.1.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/eb/8fc64f40388c29ce8ce3b2b180a089d4d6b25b1d0d232d016704cb852104/hf_transfer-0.1.9.tar.gz", hash = "sha256:035572865dab29d17e783fbf1e84cf1cb24f3fcf8f1b17db1cfc7fdf139f02bf", size = 25201, upload-time = "2025-01-07T10:05:12.947Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/78/0dce00208f585fae675f40033ef9a30dedfa83665d5ac79f16beb4a0a6c2/hf_transfer-0.1.9-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:6e94e8822da79573c9b6ae4d6b2f847c59a7a06c5327d7db20751b68538dc4f6", size = 1386084, upload-time = "2025-01-07T10:04:47.874Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/2e/3d60b1a9e9f29a2152aa66c823bf5e399ae7be3fef310ff0de86779c5d2d/hf_transfer-0.1.9-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3ebc4ab9023414880c8b1d3c38174d1c9989eb5022d37e814fa91a3060123eb0", size = 1343558, upload-time = "2025-01-07T10:04:42.313Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/38/130a5ac3747f104033591bcac1c961cb1faadfdc91704f59b09c0b465ff2/hf_transfer-0.1.9-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8674026f21ed369aa2a0a4b46000aca850fc44cd2b54af33a172ce5325b4fc82", size = 3726676, upload-time = "2025-01-07T10:04:11.539Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a1/f4e27c5ad17aac616ae0849e2aede5aae31db8267a948c6b3eeb9fd96446/hf_transfer-0.1.9-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a736dfbb2c84f5a2c975478ad200c0c8bfcb58a25a35db402678fb87ce17fa4", size = 3062920, upload-time = "2025-01-07T10:04:16.297Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/0d/727abdfba39bc3f1132cfa4c970588c2c0bb0d82fe2d645cc10f4e2f8e0b/hf_transfer-0.1.9-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:504b8427fd785dd8546d53b9fafe6e436bd7a3adf76b9dce556507650a7b4567", size = 3578681, upload-time = "2025-01-07T10:04:29.702Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d0/2b213eb1ea8b1252ccaf1a6c804d0aba03fea38aae4124df6a3acb70511a/hf_transfer-0.1.9-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2c7fc1b85f4d0f76e452765d7648c9f4bfd0aedb9ced2ae1ebfece2d8cfaf8e2", size = 3398837, upload-time = "2025-01-07T10:04:22.778Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/8a/79dbce9006e0bd6b74516f97451a7b7c64dbbb426df15d901dd438cfeee3/hf_transfer-0.1.9-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0d991376f0eac70a60f0cbc95602aa708a6f7c8617f28b4945c1431d67b8e3c8", size = 3546986, upload-time = "2025-01-07T10:04:36.415Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f7/9ac239b6ee6fe0bad130325d987a93ea58c4118e50479f0786f1733b37e8/hf_transfer-0.1.9-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:e6ac4eddcd99575ed3735ed911ddf9d1697e2bd13aa3f0ad7e3904dd4863842e", size = 4071715, upload-time = "2025-01-07T10:04:53.224Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/a3/0ed697279f5eeb7a40f279bd783cf50e6d0b91f24120dcf66ef2cf8822b4/hf_transfer-0.1.9-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:57fd9880da1ee0f47250f735f791fab788f0aa1ee36afc49f761349869c8b4d9", size = 3388081, upload-time = "2025-01-07T10:04:57.818Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/eb/47e477bdf1d784f31c7540db6cc8c354b777e51a186897a7abda34517f36/hf_transfer-0.1.9-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:5d561f0520f493c66b016d99ceabe69c23289aa90be38dd802d2aef279f15751", size = 3658654, upload-time = "2025-01-07T10:05:03.168Z" },
+    { url = "https://files.pythonhosted.org/packages/45/07/6661e43fbee09594a8a5e9bb778107d95fe38dac4c653982afe03d32bd4d/hf_transfer-0.1.9-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a5b366d34cd449fe9b20ef25941e6eef0460a2f74e7389f02e673e1f88ebd538", size = 3690551, upload-time = "2025-01-07T10:05:09.238Z" },
+    { url = "https://files.pythonhosted.org/packages/81/f5/461d2e5f307e5048289b1168d5c642ae3bb2504e88dff1a38b92ed990a21/hf_transfer-0.1.9-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:e66acf91df4a8b72f60223059df3003062a5ae111757187ed1a06750a30e911b", size = 1393046, upload-time = "2025-01-07T10:04:51.003Z" },
+    { url = "https://files.pythonhosted.org/packages/41/ba/8d9fd9f1083525edfcb389c93738c802f3559cb749324090d7109c8bf4c2/hf_transfer-0.1.9-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:8669dbcc7a3e2e8d61d42cd24da9c50d57770bd74b445c65123291ca842a7e7a", size = 1348126, upload-time = "2025-01-07T10:04:45.712Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/cd7885bc9959421065a6fae0fe67b6c55becdeda4e69b873e52976f9a9f0/hf_transfer-0.1.9-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8fd0167c4407a3bc4cdd0307e65ada2294ec04f1813d8a69a5243e379b22e9d8", size = 3728604, upload-time = "2025-01-07T10:04:14.173Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/2e/a072cf196edfeda3310c9a5ade0a0fdd785e6154b3ce24fc738c818da2a7/hf_transfer-0.1.9-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ee8b10afedcb75f71091bcc197c526a6ebf5c58bbbadb34fdeee6160f55f619f", size = 3064995, upload-time = "2025-01-07T10:04:18.663Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/84/aec9ef4c0fab93c1ea2b1badff38c78b4b2f86f0555b26d2051dbc920cde/hf_transfer-0.1.9-cp38-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5828057e313de59300dd1abb489444bc452efe3f479d3c55b31a8f680936ba42", size = 3580908, upload-time = "2025-01-07T10:04:32.834Z" },
+    { url = "https://files.pythonhosted.org/packages/29/63/b560d39651a56603d64f1a0212d0472a44cbd965db2fa62b99d99cb981bf/hf_transfer-0.1.9-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fc6bd19e1cc177c66bdef15ef8636ad3bde79d5a4f608c158021153b4573509d", size = 3400839, upload-time = "2025-01-07T10:04:26.122Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/d8/f87ea6f42456254b48915970ed98e993110521e9263472840174d32c880d/hf_transfer-0.1.9-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cdca9bfb89e6f8f281890cc61a8aff2d3cecaff7e1a4d275574d96ca70098557", size = 3552664, upload-time = "2025-01-07T10:04:40.123Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/56/1267c39b65fc8f4e2113b36297320f102718bf5799b544a6cbe22013aa1d/hf_transfer-0.1.9-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:89a23f58b7b7effbc047b8ca286f131b17728c99a9f972723323003ffd1bb916", size = 4073732, upload-time = "2025-01-07T10:04:55.624Z" },
+    { url = "https://files.pythonhosted.org/packages/82/1a/9c748befbe3decf7cb415e34f8a0c3789a0a9c55910dea73d581e48c0ce5/hf_transfer-0.1.9-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:dc7fff1345980d6c0ebb92c811d24afa4b98b3e07ed070c8e38cc91fd80478c5", size = 3390096, upload-time = "2025-01-07T10:04:59.98Z" },
+    { url = "https://files.pythonhosted.org/packages/72/85/4c03da147b6b4b7cb12e074d3d44eee28604a387ed0eaf7eaaead5069c57/hf_transfer-0.1.9-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:1a6bd16c667ebe89a069ca163060127a794fa3a3525292c900b8c8cc47985b0d", size = 3664743, upload-time = "2025-01-07T10:05:05.416Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/6e/e597b04f753f1b09e6893075d53a82a30c13855cbaa791402695b01e369f/hf_transfer-0.1.9-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:d2fde99d502093ade3ab1b53f80da18480e9902aa960dab7f74fb1b9e5bc5746", size = 3695243, upload-time = "2025-01-07T10:05:11.411Z" },
+    { url = "https://files.pythonhosted.org/packages/09/89/d4e234727a26b2546c8fb70a276cd924260d60135f2165bf8b9ed67bb9a4/hf_transfer-0.1.9-cp38-abi3-win32.whl", hash = "sha256:435cc3cdc8524ce57b074032b8fd76eed70a4224d2091232fa6a8cef8fd6803e", size = 1086605, upload-time = "2025-01-07T10:05:18.873Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/14/f1e15b851d1c2af5b0b1a82bf8eb10bda2da62d98180220ba6fd8879bb5b/hf_transfer-0.1.9-cp38-abi3-win_amd64.whl", hash = "sha256:16f208fc678911c37e11aa7b586bc66a37d02e636208f18b6bc53d29b5df40ad", size = 1160240, upload-time = "2025-01-07T10:05:14.324Z" },
+]
+
+[[package]]
 name = "hf-xet"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2208,9 +2240,17 @@ dev = [
 name = "llamafarm-common"
 version = "0.1.0"
 source = { editable = "../common" }
+dependencies = [
+    { name = "hf-transfer" },
+    { name = "huggingface-hub" },
+]
 
 [package.metadata]
-requires-dist = [{ name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" }]
+requires-dist = [
+    { name = "hf-transfer", specifier = ">=0.1.9" },
+    { name = "huggingface-hub", specifier = ">=0.24.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
+]
 provides-extras = ["dev"]
 
 [package.metadata.requires-dev]

--- a/server/api/routers/rag/rag_stats.py
+++ b/server/api/routers/rag/rag_stats.py
@@ -1,0 +1,100 @@
+"""RAG Stats endpoint for database statistics."""
+
+from datetime import datetime
+from typing import Any
+
+import structlog
+from config.datamodel import LlamaFarmConfig
+from fastapi import HTTPException
+from pydantic import BaseModel, Field
+
+from core.celery.rag_client import get_rag_stats
+
+logger = structlog.get_logger()
+
+
+class RAGStatsResponse(BaseModel):
+    """RAG database statistics response matching Go CLI RAGStats struct."""
+
+    database: str
+    vector_count: int
+    document_count: int
+    chunk_count: int
+    collection_size_bytes: int = Field(alias="collection_size_bytes")
+    index_size_bytes: int = Field(alias="index_size_bytes")
+    embedding_dimension: int = Field(alias="embedding_dimension")
+    distance_metric: str = Field(alias="distance_metric")
+    last_updated: datetime = Field(alias="last_updated")
+    metadata: dict[str, Any] | None = None
+
+    class Config:
+        populate_by_name = True
+
+
+async def handle_rag_stats(
+    project_config: LlamaFarmConfig, project_dir: str, database: str | None = None
+) -> RAGStatsResponse:
+    """Handle RAG stats request using Celery service."""
+
+    # Determine which database to get stats for
+    database_name = database
+    if not database_name and project_config.rag and project_config.rag.databases:
+        # Use first database as default
+        database_name = project_config.rag.databases[0].name
+        logger.info(f"Using default database for stats: {database_name}")
+
+    if not database_name:
+        raise HTTPException(
+            status_code=400, detail="No database specified and no default available"
+        )
+
+    # Validate database exists
+    database_exists = False
+    if project_config.rag:
+        for db in project_config.rag.databases:
+            if db.name == database_name:
+                database_exists = True
+                break
+
+    if not database_exists:
+        raise HTTPException(
+            status_code=404, detail=f"Database '{database_name}' not found"
+        )
+
+    try:
+        # Use Celery service to get stats
+        logger.info(
+            f"Fetching RAG stats via Celery service for database: '{database_name}'"
+        )
+
+        stats_data = get_rag_stats(project_dir=project_dir, database=database_name)
+
+        # Parse last_updated if it's a string
+        last_updated = stats_data.get("last_updated")
+        if isinstance(last_updated, str):
+            last_updated = datetime.fromisoformat(last_updated.replace("Z", "+00:00"))
+        elif not isinstance(last_updated, datetime):
+            from datetime import UTC
+
+            last_updated = datetime.now(UTC)
+
+        return RAGStatsResponse(
+            database=stats_data.get("database", database_name),
+            vector_count=stats_data.get("vector_count", 0),
+            document_count=stats_data.get("document_count", 0),
+            chunk_count=stats_data.get("chunk_count", 0),
+            collection_size_bytes=stats_data.get("collection_size_bytes", 0),
+            index_size_bytes=stats_data.get("index_size_bytes", 0),
+            embedding_dimension=stats_data.get("embedding_dimension", 0),
+            distance_metric=stats_data.get("distance_metric", "unknown"),
+            last_updated=last_updated,
+            metadata=stats_data.get("metadata"),
+        )
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Failed to get RAG stats: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=500, detail=f"Failed to retrieve RAG stats: {str(e)}"
+        ) from e

--- a/server/core/celery/rag_client.py
+++ b/server/core/celery/rag_client.py
@@ -193,6 +193,31 @@ def get_rag_health(project_dir: str, database: str) -> dict[str, Any]:
     }
 
 
+def get_rag_stats(project_dir: str, database: str) -> dict[str, Any]:
+    """
+    Fetch RAG database statistics via rag.get_database_stats.
+    """
+    from datetime import UTC, datetime
+
+    task = signature(
+        "rag.get_database_stats",
+        args=[project_dir, database],
+        app=app,
+    )
+    return _run_sync_task_with_polling(task, timeout=30, poll_interval=0.5) or {
+        "database": database,
+        "vector_count": 0,
+        "document_count": 0,
+        "chunk_count": 0,
+        "collection_size_bytes": 0,
+        "index_size_bytes": 0,
+        "embedding_dimension": 0,
+        "distance_metric": "unknown",
+        "last_updated": datetime.now(UTC).isoformat(),
+        "metadata": {"error": "Stats retrieval task timed out or failed"},
+    }
+
+
 def batch_search(
     project_dir: str,
     database: str,

--- a/server/tests/test_rag_stats_endpoint.py
+++ b/server/tests/test_rag_stats_endpoint.py
@@ -1,0 +1,200 @@
+"""Tests for RAG stats endpoint."""
+
+from datetime import UTC, datetime
+from unittest.mock import Mock
+
+from fastapi.testclient import TestClient
+
+from api.main import llama_farm_api
+
+
+def _client() -> TestClient:
+    """Create test client."""
+    app = llama_farm_api()
+    return TestClient(app)
+
+
+def test_rag_stats_endpoint_requires_rag_config(mocker):
+    """Test that stats endpoint returns 400 when RAG is not configured."""
+    # Mock ProjectService to return a project without RAG config
+    mock_project = Mock()
+    mock_project.config.rag = None
+
+    mock_project_service = mocker.patch("api.routers.rag.router.ProjectService")
+    mock_project_service.get_project.return_value = mock_project
+    mock_project_service.get_project_dir.return_value = "/fake/path"
+
+    client = _client()
+    resp = client.get("/v1/projects/test-ns/test-project/rag/stats")
+
+    assert resp.status_code == 400
+    assert "RAG not configured" in resp.json()["detail"]
+
+
+def test_rag_stats_endpoint_success(mocker):
+    """Test successful stats retrieval."""
+    # Mock ProjectService to return a project with RAG config
+    mock_database = Mock()
+    mock_database.name = "test_db"
+
+    mock_rag_config = Mock()
+    mock_rag_config.databases = [mock_database]
+
+    mock_project = Mock()
+    mock_project.config.rag = mock_rag_config
+
+    mock_project_service = mocker.patch("api.routers.rag.router.ProjectService")
+    mock_project_service.get_project.return_value = mock_project
+    mock_project_service.get_project_dir.return_value = "/fake/path"
+
+    # Mock the stats handler to return test data
+    mock_stats_response = Mock()
+    mock_stats_response.database = "test_db"
+    mock_stats_response.vector_count = 1000
+    mock_stats_response.document_count = 50
+    mock_stats_response.chunk_count = 1000
+    mock_stats_response.collection_size_bytes = 5242880
+    mock_stats_response.index_size_bytes = 1048576
+    mock_stats_response.embedding_dimension = 768
+    mock_stats_response.distance_metric = "cosine"
+    mock_stats_response.last_updated = datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC)
+    mock_stats_response.metadata = {"collection_name": "test_db"}
+
+    mock_handle_rag_stats = mocker.patch("api.routers.rag.router.handle_rag_stats")
+    mock_handle_rag_stats.return_value = mock_stats_response
+
+    client = _client()
+    resp = client.get("/v1/projects/test-ns/test-project/rag/stats")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["database"] == "test_db"
+    assert data["vector_count"] == 1000
+    assert data["document_count"] == 50
+    assert data["chunk_count"] == 1000
+    assert data["embedding_dimension"] == 768
+    assert data["distance_metric"] == "cosine"
+
+
+def test_rag_stats_endpoint_with_database_param(mocker):
+    """Test stats endpoint with specific database parameter."""
+    # Mock ProjectService
+    mock_database = Mock()
+    mock_database.name = "specific_db"
+
+    mock_rag_config = Mock()
+    mock_rag_config.databases = [mock_database]
+
+    mock_project = Mock()
+    mock_project.config.rag = mock_rag_config
+
+    mock_project_service = mocker.patch("api.routers.rag.router.ProjectService")
+    mock_project_service.get_project.return_value = mock_project
+    mock_project_service.get_project_dir.return_value = "/fake/path"
+
+    # Mock the stats handler
+    mock_stats_response = Mock()
+    mock_stats_response.database = "specific_db"
+    mock_stats_response.vector_count = 500
+    mock_stats_response.document_count = 25
+    mock_stats_response.chunk_count = 500
+    mock_stats_response.collection_size_bytes = 2621440
+    mock_stats_response.index_size_bytes = 524288
+    mock_stats_response.embedding_dimension = 1536
+    mock_stats_response.distance_metric = "l2"
+    mock_stats_response.last_updated = datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC)
+    mock_stats_response.metadata = None
+
+    mock_handle_rag_stats = mocker.patch("api.routers.rag.router.handle_rag_stats")
+    mock_handle_rag_stats.return_value = mock_stats_response
+
+    client = _client()
+    resp = client.get(
+        "/v1/projects/test-ns/test-project/rag/stats?database=specific_db"
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["database"] == "specific_db"
+    assert data["vector_count"] == 500
+    assert data["embedding_dimension"] == 1536
+    assert data["distance_metric"] == "l2"
+
+    # Verify handle_rag_stats was called with the specific database
+    mock_handle_rag_stats.assert_called_once()
+    call_args = mock_handle_rag_stats.call_args
+    assert call_args[0][2] == "specific_db"  # database parameter
+
+
+def test_rag_stats_endpoint_empty_database(mocker):
+    """Test stats endpoint with empty database (should use first configured database)."""
+    # Mock ProjectService
+    mock_database1 = Mock()
+    mock_database1.name = "first_db"
+    mock_database2 = Mock()
+    mock_database2.name = "second_db"
+
+    mock_rag_config = Mock()
+    mock_rag_config.databases = [mock_database1, mock_database2]
+
+    mock_project = Mock()
+    mock_project.config.rag = mock_rag_config
+
+    mock_project_service = mocker.patch("api.routers.rag.router.ProjectService")
+    mock_project_service.get_project.return_value = mock_project
+    mock_project_service.get_project_dir.return_value = "/fake/path"
+
+    # Mock the stats handler
+    mock_stats_response = Mock()
+    mock_stats_response.database = "first_db"
+    mock_stats_response.vector_count = 100
+    mock_stats_response.document_count = 10
+    mock_stats_response.chunk_count = 100
+    mock_stats_response.collection_size_bytes = 1000000
+    mock_stats_response.index_size_bytes = 100000
+    mock_stats_response.embedding_dimension = 768
+    mock_stats_response.distance_metric = "cosine"
+    mock_stats_response.last_updated = datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC)
+    mock_stats_response.metadata = {}
+
+    mock_handle_rag_stats = mocker.patch("api.routers.rag.router.handle_rag_stats")
+    mock_handle_rag_stats.return_value = mock_stats_response
+
+    client = _client()
+    resp = client.get("/v1/projects/test-ns/test-project/rag/stats")
+
+    assert resp.status_code == 200
+    # Should default to first database
+    mock_handle_rag_stats.assert_called_once()
+    call_args = mock_handle_rag_stats.call_args
+    assert call_args[0][2] is None  # No database parameter passed
+
+
+def test_rag_stats_response_model_serialization():
+    """Test that RAGStatsResponse model serializes correctly."""
+    from api.routers.rag.rag_stats import RAGStatsResponse
+
+    response = RAGStatsResponse(
+        database="test_db",
+        vector_count=1000,
+        document_count=50,
+        chunk_count=1000,
+        collection_size_bytes=5242880,
+        index_size_bytes=1048576,
+        embedding_dimension=768,
+        distance_metric="cosine",
+        last_updated=datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC),
+        metadata={"key": "value"},
+    )
+
+    # Verify serialization produces expected fields
+    data = response.model_dump()
+    assert data["database"] == "test_db"
+    assert data["vector_count"] == 1000
+    assert data["document_count"] == 50
+    assert data["chunk_count"] == 1000
+    assert data["collection_size_bytes"] == 5242880
+    assert data["index_size_bytes"] == 1048576
+    assert data["embedding_dimension"] == 768
+    assert data["distance_metric"] == "cosine"
+    assert data["metadata"] == {"key": "value"}


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add comprehensive RAG database statistics retrieval via Celery task

- Create new `/stats` endpoint to expose database metrics and storage info

- Implement helper functions for embedding dimension, document count estimation, and storage size calculation

- Improve error handling in CLI by using `PrettyServerError` utility for user-friendly messages


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CLI Request"] -->|GET /stats| B["FastAPI Endpoint"]
  B -->|handle_rag_stats| C["Stats Handler"]
  C -->|get_rag_stats| D["Celery Client"]
  D -->|rag.get_database_stats| E["Celery Task"]
  E -->|DatabaseSearchAPI| F["Vector Store"]
  F -->|collection_info| E
  E -->|stats_data| D
  D -->|dict| C
  C -->|RAGStatsResponse| B
  B -->|JSON| A
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>__init__.py</strong><dd><code>Export new stats task from package</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/543/files#diff-1eeee2ab7a27dc40299138fcc796eba2b53ebf83e1501b26de7b6caa83989823">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>stats_tasks.py</strong><dd><code>Implement RAG database statistics Celery task</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/543/files#diff-81e94871ae99b6d5dcc54e695471d5100c2f4f965d02e0ffb3c1a57eb6a30d43">+314/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>rag_stats.py</strong><dd><code>Create RAG stats endpoint handler and response model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/543/files#diff-94770269c0e16d215b918e63e320af9196e114ab7f8e1322d1758cfd6036a7ab">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>router.py</strong><dd><code>Add GET /stats endpoint to RAG router</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/543/files#diff-74628d29907b8533bda60f3de5d777718db3763cc6bbc3c4f7dc44b030cd0a4f">+25/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rag_client.py</strong><dd><code>Add Celery client function for stats retrieval</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/543/files#diff-ae047300bef7e05c5108b15a00d9cf062a01e2ef429242f2b07fb5e3cbbd622f">+25/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>test_stats_tasks.py</strong><dd><code>Add comprehensive tests for stats task helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/543/files#diff-a092d7a660d8efd9082caf848a4d10eed48d0995eb570bf80e782e2c24138a3a">+329/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_rag_stats_endpoint.py</strong><dd><code>Add endpoint tests for stats retrieval</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/543/files#diff-5fe46752ead6b37eb9b0a50f9c25d8a9d67b0e8a3aea20180c436bb9b35e844a">+200/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>rag_stats_test.go</strong><dd><code>Add tests for stats fetching and error formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/543/files#diff-2d2538b993814ccecc2abeb7a41c15e0f6b9474abb1414fd15e6d333f12721ec">+291/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Error handling</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>rag_stats.go</strong><dd><code>Improve error handling with PrettyServerError utility</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/543/files#diff-b91a3b09cd8c595b99dc8a9895763e78cb41b62983eab59aa54c4a9c0746d419">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

