### PR TITLE
fix: expand ~ before path resolution

### DIFF
--- a/cli/cmd/utils/cwd.go
+++ b/cli/cmd/utils/cwd.go
@@ -8,14 +8,56 @@ import (
 
 var OverrideCwd string
 
-// getEffectiveCWD returns the directory to treat as the working directory.
-// If the global --cwd flag is provided, it returns its absolute path; otherwise os.Getwd().
+// ExpandTilde expands the tilde (~) prefix to the user's home directory.
+// It handles:
+//   - "~" alone → home directory
+//   - "~/path" → home directory + path
+//
+// Note: "~user/path" syntax is NOT supported as it requires looking up other
+// users' home directories, which has security implications and platform-specific
+// behavior. Such paths are returned unchanged.
+//
+// If os.UserHomeDir() fails, the original path is returned unchanged.
+func ExpandTilde(path string) string {
+	if path == "" {
+		return path
+	}
+
+	// Handle "~" alone
+	if path == "~" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return path
+		}
+		return home
+	}
+
+	// Handle "~/..." pattern
+	if strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return path
+		}
+		return filepath.Join(home, path[2:])
+	}
+
+	// All other cases: return unchanged
+	// This includes ~user/path, absolute paths, relative paths, etc.
+	return path
+}
+
+// GetEffectiveCWD returns the directory to treat as the working directory.
+// If the global --cwd flag is provided, it expands tilde and returns its
+// absolute path; otherwise os.Getwd().
 func GetEffectiveCWD() string {
 	if strings.TrimSpace(OverrideCwd) != "" {
-		if filepath.IsAbs(OverrideCwd) {
-			return OverrideCwd
+		// Expand tilde before checking if path is absolute
+		expandedPath := ExpandTilde(OverrideCwd)
+
+		if filepath.IsAbs(expandedPath) {
+			return expandedPath
 		}
-		abs, err := filepath.Abs(OverrideCwd)
+		abs, err := filepath.Abs(expandedPath)
 		if err != nil {
 			return "."
 		}

--- a/cli/cmd/utils/format_test.go
+++ b/cli/cmd/utils/format_test.go
@@ -117,9 +117,9 @@ func TestFormatDuration(t *testing.T) {
 
 func TestFormatTransferRate(t *testing.T) {
 	tests := []struct {
-		name         string
-		bytesPerSec  int64
-		expected     string
+		name        string
+		bytesPerSec int64
+		expected    string
 	}{
 		{
 			name:        "kilobytes per second",


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add `ExpandTilde()` function to expand ~ prefix to home directory

- Support "~" and "~/path" patterns with proper error handling

- Integrate tilde expansion into `GetEffectiveCWD()` before path resolution

- Fix struct field alignment in test file formatting


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["OverrideCwd with ~"] --> B["ExpandTilde()"]
  B --> C["Expand ~ to home dir"]
  C --> D["GetEffectiveCWD()"]
  D --> E["Resolve absolute path"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cwd.go</strong><dd><code>Add tilde expansion to path resolution logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/cmd/utils/cwd.go

<ul><li>Add new <code>ExpandTilde()</code> function to handle ~ and ~/path expansion<br> <li> Support home directory expansion with error handling for <br><code>os.UserHomeDir()</code> failures<br> <li> Explicitly document that ~user/path syntax is not supported for <br>security reasons<br> <li> Integrate <code>ExpandTilde()</code> into <code>GetEffectiveCWD()</code> to expand tilde before <br>path resolution<br> <li> Update function documentation to reflect tilde expansion behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/563/files#diff-bbce12313e933548639b98957d8dd14040d2c85e6c48e0b9f1d702139e30e899">+47/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>format_test.go</strong><dd><code>Fix struct field alignment formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/cmd/utils/format_test.go

<ul><li>Fix struct field alignment in <code>TestFormatTransferRate</code> test<br> <li> Align field names to consistent spacing for readability</ul>


</details>


  </td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/563/files#diff-0c593d077d2efde62562cd0b38ef7eaa2efb213fd80777ee2393cfb2b159097b">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

