### PR TITLE
fix(cli): ignore python specific env vars

### DIFF
--- a/cli/cmd/orchestrator/python_env.go
+++ b/cli/cmd/orchestrator/python_env.go
@@ -164,10 +164,14 @@ func (m *PythonEnvManager) getEnv() []string {
 
 	for _, e := range env {
 		parts := strings.SplitN(e, "=", 2)
+		if len(parts) == 0 {
+			continue
+		}
 		varName := parts[0]
 
-		// Only include non-Python environment variables
-		if _, isPythonEnv := pythonEnvVars[varName]; !isPythonEnv {
+		// Case-insensitive comparison to prevent bypass attacks (e.g., Virtual_Env, virtual_env)
+		// This is critical on Windows where env vars are case-insensitive
+		if _, isPythonEnv := pythonEnvVars[strings.ToUpper(varName)]; !isPythonEnv {
 			filteredEnv = append(filteredEnv, e)
 		}
 	}


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Filter out Python-specific environment variables before UV execution

- Prevents interference from virtual environments and Python managers

- Ensures UV uses managed Python environment without conflicts


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Current Environment"] --> B["Filter Python Vars"]
  B --> C["Remove VIRTUAL_ENV, PYTHONHOME, etc."]
  C --> D["Clean Environment for UV"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>python_env.go</strong><dd><code>Filter Python environment variables from UV execution</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/cmd/orchestrator/python_env.go

<ul><li>Added filtering logic to remove Python-specific environment variables <br>from the environment passed to UV commands<br> <li> Created a map of 14 Python-related environment variable names to <br>filter out (VIRTUAL_ENV, PYTHONHOME, PYTHONPATH, PYTHONSTARTUP, <br>PYTHONEXECUTABLE, PYTHONUSERBASE, CONDA_DEFAULT_ENV, CONDA_PREFIX, <br>CONDA_PYTHON_EXE, PYENV_VERSION, PYENV_VIRTUAL_ENV, PIPENV_ACTIVE, <br>POETRY_ACTIVE, PDM_PYTHON)<br> <li> Implemented filtering loop that checks each environment variable <br>against the map and only includes non-Python variables in the filtered <br>environment<br> <li> Replaced the original environment with the filtered version before <br>passing to UV</ul>


</details>


  </td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/564/files#diff-59665dec8b35055244e23ee27c52f9f4c240530d551d8b76d01c1a1f1c74040c">+39/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

