### PR TITLE
fix(cli): resolve upgrade hang caused by process stop deadlock

### DIFF
--- a/cli/cmd/orchestrator/process_manager.go
+++ b/cli/cmd/orchestrator/process_manager.go
@@ -263,7 +263,7 @@ func (pm *ProcessManager) StopProcess(name string) error {
 
 	for time.Now().Before(deadline) {
 		// Check if process is still running using signal 0 (works for both native and orphaned)
-		if !pm.isProcessStillRunning(proc) {
+		if !pm.isProcessRunning(proc) {
 			utils.OutputProgress("%s process stopped\n", name)
 			proc.mu.Lock()
 			proc.Status = "stopped"
@@ -306,23 +306,6 @@ func (pm *ProcessManager) StopAllProcesses() {
 
 // isProcessRunning checks if a process is still running
 func (pm *ProcessManager) isProcessRunning(proc *ProcessInfo) bool {
-	if proc.Cmd == nil || proc.Cmd.Process == nil {
-		return false
-	}
-
-	// On Unix, sending signal 0 checks if a process exists.
-	// On Windows, this is not supported, so we check if the process has exited.
-	if runtime.GOOS == "windows" {
-		return proc.Cmd.ProcessState == nil || !proc.Cmd.ProcessState.Exited()
-	}
-
-	err := proc.Cmd.Process.Signal(os.Signal(nil))
-	return err == nil
-}
-
-// isProcessStillRunning checks if a process is still running (inverse of isProcessRunning for readability)
-// This is used during shutdown to poll for process exit
-func (pm *ProcessManager) isProcessStillRunning(proc *ProcessInfo) bool {
 	if proc.Cmd == nil || proc.Cmd.Process == nil {
 		return false
 	}


### PR DESCRIPTION
### **User description**
StopProcess was calling Wait() on processes, which caused two critical bugs:

1. Double Wait() - monitorProcess() goroutine already called Wait() on native processes, causing the second Wait() in StopProcess to hang indefinitely
2. Invalid Wait() - orphaned processes from killed sessions have synthetic Cmd objects that were never Start()ed, violating Go's exec.Cmd contract and causing undefined behavior

This fix replaces Wait() with process polling using signal 0, which:
- Works for both native and orphaned processes
- Avoids coordination issues between goroutines
- Completes process shutdown in ~300ms instead of hanging forever
- Enables successful CLI upgrades and orphaned process cleanup

Fixes the v0.0.18 -> v0.0.19 upgrade hang issue where killing the terminal during upgrade left orphaned processes that caused all subsequent lf commands to hang.


___

### **PR Type**
Bug fix


___

### **Description**
- Replace Wait() calls with signal 0 polling to prevent deadlock

- Fixes double Wait() issue in monitorProcess goroutine coordination

- Handles orphaned processes with synthetic Cmd objects safely

- Enables successful CLI upgrades and orphaned process cleanup


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["StopProcess called"] --> B["Send Interrupt signal"]
  B --> C["Poll with signal 0"]
  C --> D{Process still running?}
  D -->|Yes| E["Sleep 100ms"]
  E --> C
  D -->|No| F["Mark stopped"]
  C --> G{Timeout reached?}
  G -->|Yes| H["Force Kill"]
  H --> I["Sleep 500ms"]
  I --> F
  F --> J["Return success"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>process_manager.go</strong><dd><code>Replace Wait() with signal 0 polling for process shutdown</code></dd></summary>
<hr>

cli/cmd/orchestrator/process_manager.go

<ul><li>Replaced Wait() call with polling loop using signal 0 to check process <br>status<br> <li> Added new <code>isProcessStillRunning()</code> helper method for process existence <br>checking<br> <li> Implemented deadline-based polling with 100ms intervals instead of <br>goroutine-based waiting<br> <li> Added explicit process status update and logging during shutdown <br>sequence<br> <li> Increased post-kill sleep to 500ms to ensure process termination</ul>


</details>


  </td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/566/files#diff-5096463c78e1d7794eaa6e13c4d265688785b0554e7e4bb3661aa3fc02810eda">+43/-13</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

