### PR TITLE
fix: show modal error dialog

### DIFF
--- a/electron-app/src/main/index.ts
+++ b/electron-app/src/main/index.ts
@@ -27,6 +27,7 @@ class LlamaFarmApp {
   private windowManager: WindowManager
   private menuManager: MenuManager
   private isQuitting = false
+  private startupErrorPending = false
 
   constructor() {
     // Set app name early
@@ -416,17 +417,17 @@ class LlamaFarmApp {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error'
     console.error('Startup error:', errorMessage)
 
+    this.startupErrorPending = true
     this.windowManager.showSplashError('Failed to start LlamaFarm', errorMessage)
 
-    // Remove always-on-top and close splash to ensure error dialog is visible
+    // Remove always-on-top before showing dialog to ensure visibility
     setTimeout(() => {
       const splash = this.windowManager.getSplashWindow()
       if (splash && !splash.isDestroyed()) {
         splash.setAlwaysOnTop(false)
       }
-      this.windowManager.closeSplash()
 
-      // Use modal dialog with better UX
+      // Use modal dialog with better UX (keep splash open until after dialog)
       dialog.showMessageBoxSync({
         type: 'error',
         title: 'LlamaFarm Startup Failed',
@@ -434,6 +435,9 @@ class LlamaFarmApp {
         detail: `${errorMessage}\n\nPlease check the logs and try again.`,
         buttons: ['OK']
       })
+
+      this.windowManager.closeSplash()
+      this.isQuitting = true
       app.quit()
     }, 3000)
   }
@@ -443,6 +447,10 @@ class LlamaFarmApp {
    */
   private onWindowsClosed(): void {
     // On macOS, keep app running when windows are closed
+    if (this.startupErrorPending) {
+      return
+    }
+
     if (process.platform !== 'darwin') {
       app.quit()
     }


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Replace error dialog with modal message box for better visibility

- Remove splash window always-on-top flag before showing error

- Close splash window to prevent blocking error dialog display

- Use `showMessageBoxSync` with structured message and detail fields


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Startup Error Occurs"] --> B["Show Splash Error"]
  B --> C["Remove Always-On-Top Flag"]
  C --> D["Close Splash Window"]
  D --> E["Show Modal Error Dialog"]
  E --> F["Quit Application"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Improve error dialog visibility and modal behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

electron-app/src/main/index.ts

<ul><li>Refactored error handling in <code>handleStartupError</code> method to ensure modal <br>dialog visibility<br> <li> Added logic to disable always-on-top flag on splash window before <br>closing it<br> <li> Replaced <code>dialog.showErrorBox</code> with <code>dialog.showMessageBoxSync</code> for better <br>modal behavior<br> <li> Improved error message formatting with separate message and detail <br>fields</ul>


</details>


  </td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/570/files#diff-e50b8cea1c6dff4b49e3ec3d8e2d43ca101250c3c1e2b01de200696a2944f053">+16/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switch to a modal error dialog for startup failures, temporarily disable splash always-on-top for visibility, track pending startup errors, and prevent quitting on window close until after dialog handling.
> 
> - **Electron main (`electron-app/src/main/index.ts`)**:
>   - **Startup error handling**:
>     - Add `startupErrorPending` flag to track errors and block `onWindowsClosed` from quitting.
>     - Replace `dialog.showErrorBox` with modal `dialog.showMessageBoxSync` (structured `message`/`detail`).
>     - Before showing dialog, unset splash `alwaysOnTop`; keep splash open until after dialog, then close it.
>     - After dialog, set `isQuitting` and quit the app.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24df80b42ec0ac853050bc3bfdc7f376c7acf54d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->