### PR TITLE
build: use static filenames for desktop app artifacts

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -281,14 +281,14 @@ jobs:
 
           # Generate SHA256 for all distributable files (using shasum on macOS/Linux)
           if [[ "${{ matrix.platform }}" == "macos" ]]; then
-            for file in *.dmg *.zip; do
+            for file in LlamaFarm-desktop-app-mac*.dmg LlamaFarm-desktop-app-mac*.zip; do
               if [ -f "$file" ]; then
                 shasum -a 256 "$file" > "$file.sha256"
                 echo "✅ Generated checksum for $file"
               fi
             done
           elif [[ "${{ matrix.platform }}" == "linux" ]]; then
-            for file in *.AppImage *.deb; do
+            for file in LlamaFarm-desktop-app-linux*.AppImage LlamaFarm-desktop-app-linux*.deb; do
               if [ -f "$file" ]; then
                 shasum -a 256 "$file" > "$file.sha256"
                 echo "✅ Generated checksum for $file"
@@ -306,7 +306,7 @@ jobs:
           cd "release/$VERSION_NO_V"
 
           # Generate SHA256 for all distributable files (using PowerShell on Windows)
-          Get-ChildItem -Filter "*.exe" | ForEach-Object {
+          Get-ChildItem -Filter "LlamaFarm-desktop-app-windows*.exe" | ForEach-Object {
             $hash = Get-FileHash -Algorithm SHA256 -Path $_.FullName
             "$($hash.Hash.ToLower())  $($_.Name)" | Out-File -FilePath "$($_.Name).sha256" -Encoding ascii
             Write-Host "✅ Generated checksum for $($_.Name)"
@@ -342,11 +342,11 @@ jobs:
         with:
           tag_name: ${{ steps.version.outputs.version }}
           files: |
-            electron-app/release/${{ steps.version.outputs.version_no_v }}/*.exe
-            electron-app/release/${{ steps.version.outputs.version_no_v }}/*.dmg
-            electron-app/release/${{ steps.version.outputs.version_no_v }}/*.zip
-            electron-app/release/${{ steps.version.outputs.version_no_v }}/*.deb
-            electron-app/release/${{ steps.version.outputs.version_no_v }}/*.AppImage
+            electron-app/release/${{ steps.version.outputs.version_no_v }}/LlamaFarm-desktop-app-windows*.exe
+            electron-app/release/${{ steps.version.outputs.version_no_v }}/LlamaFarm-desktop-app-mac*.dmg
+            electron-app/release/${{ steps.version.outputs.version_no_v }}/LlamaFarm-desktop-app-mac*.zip
+            electron-app/release/${{ steps.version.outputs.version_no_v }}/LlamaFarm-desktop-app-linux*.deb
+            electron-app/release/${{ steps.version.outputs.version_no_v }}/LlamaFarm-desktop-app-linux*.AppImage
             electron-app/release/${{ steps.version.outputs.version_no_v }}/*.sha256
           fail_on_unmatched_files: false
           append_body: false
@@ -380,33 +380,34 @@ jobs:
             ## Desktop App Downloads
 
             ### macOS
-            Download the universal DMG that works on both Apple Silicon and Intel Macs:
-            - **Universal (Apple Silicon and Intel)**: `LlamaFarm-${{ steps.version.outputs.version_no_v }}.dmg`
+            Download for Apple Silicon (M1+) or Intel Macs:
+            - **Apple Silicon (arm64)**: `LlamaFarm-desktop-app-mac-arm64.dmg` or `.zip`
+            - **Intel (x64)**: `LlamaFarm-desktop-app-mac-x64.dmg` or `.zip`
 
             **Installation:**
-            1. Download the DMG file
-            2. Open the DMG and drag LlamaFarm to Applications
+            1. Download the DMG or ZIP file for your architecture
+            2. Open the DMG and drag LlamaFarm to Applications (or extract the ZIP)
             3. Launch the app (it's signed and notarized, so it will open normally)
             4. The app will auto-install the CLI and start services
 
             ### Linux
             Download the appropriate package for your Linux distribution:
-            - **AppImage** (Universal): `LlamaFarm-${{ steps.version.outputs.version_no_v }}.AppImage`
-            - **Debian/Ubuntu**: `llamafarm-desktop_${{ steps.version.outputs.version_no_v }}_amd64.deb`
+            - **AppImage** (Universal): `LlamaFarm-desktop-app-linux.AppImage`
+            - **Debian/Ubuntu**: `LlamaFarm-desktop-app-linux.deb`
 
             **Installation:**
             ```bash
             # AppImage (works on all distributions)
-            chmod +x LlamaFarm-${{ steps.version.outputs.version_no_v }}.AppImage
-            ./LlamaFarm-${{ steps.version.outputs.version_no_v }}.AppImage
+            chmod +x LlamaFarm-desktop-app-linux.AppImage
+            ./LlamaFarm-desktop-app-linux.AppImage
 
             # Debian/Ubuntu
-            sudo dpkg -i llamafarm-desktop_${{ steps.version.outputs.version_no_v }}_amd64.deb
+            sudo dpkg -i LlamaFarm-desktop-app-linux.deb
             ```
 
             ### Windows
             Download the Windows installer:
-            - **Windows Installer**: `LlamaFarm-Setup-${{ steps.version.outputs.version_no_v }}.exe`
+            - **Windows Installer**: `LlamaFarm-desktop-app-windows.exe`
 
             **Installation:**
             1. Download the installer
@@ -444,13 +445,12 @@ jobs:
           echo "Waiting 60 seconds for release assets to be available..."
           sleep 60
 
-      - name: Download and verify DMG (Universal)
+      - name: Download and verify DMG (arm64)
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          VERSION_NO_V="${{ steps.version.outputs.version_no_v }}"
 
-          # Download the Universal DMG
-          DMG_URL="https://github.com/llama-farm/llamafarm/releases/download/${VERSION}/LlamaFarm-${VERSION_NO_V}.dmg"
+          # Download the arm64 DMG (testing on Apple Silicon runner)
+          DMG_URL="https://github.com/llama-farm/llamafarm/releases/download/${VERSION}/LlamaFarm-desktop-app-mac-arm64.dmg"
           echo "Downloading from: $DMG_URL"
 
           # Download with retries
@@ -484,8 +484,8 @@ jobs:
           FILE_SIZE=$(stat -f%z "LlamaFarm.dmg")
           echo "✅ DMG downloaded successfully (${FILE_SIZE} bytes)"
 
-          # Verify minimum file size (DMG should be at least 80MB for universal binary)
-          MIN_SIZE=$((80 * 1024 * 1024))
+          # Verify minimum file size (DMG should be at least 50MB)
+          MIN_SIZE=$((50 * 1024 * 1024))
           if [ $FILE_SIZE -lt $MIN_SIZE ]; then
             echo "❌ ERROR: DMG file is too small (${FILE_SIZE} bytes < ${MIN_SIZE} bytes)"
             echo "The file may be corrupted or incomplete"
@@ -516,17 +516,17 @@ jobs:
 
           echo "✅ App bundle structure is valid"
 
-          # Verify universal binary (contains both arm64 and x86_64)
+          # Verify binary architecture
           ARCHITECTURES=$(lipo -archs "/Volumes/LlamaFarm/LlamaFarm.app/Contents/MacOS/LlamaFarm")
           echo "Binary architectures: $ARCHITECTURES"
 
-          if [[ ! "$ARCHITECTURES" =~ "arm64" ]] || [[ ! "$ARCHITECTURES" =~ "x86_64" ]]; then
-            echo "❌ ERROR: Binary is not universal (missing arm64 or x86_64)"
+          if [[ ! "$ARCHITECTURES" =~ "arm64" ]]; then
+            echo "❌ ERROR: arm64 architecture not found in binary"
             hdiutil detach /Volumes/LlamaFarm
             exit 1
           fi
 
-          echo "✅ Binary is universal (contains both arm64 and x86_64)"
+          echo "✅ Binary contains arm64 architecture"
 
           # Unmount
           hdiutil detach /Volumes/LlamaFarm

--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -93,6 +93,7 @@
           ]
         }
       ],
+      "artifactName": "LlamaFarm-desktop-app-mac-${arch}.${ext}",
       "identity": null,
       "darkModeSupport": true
     },
@@ -102,6 +103,7 @@
         "portable"
       ],
       "icon": "build/icon.ico",
+      "artifactName": "LlamaFarm-desktop-app-windows.${ext}",
       "signtoolOptions": {
         "sign": "./sign-windows.js"
       }
@@ -112,7 +114,8 @@
         "deb"
       ],
       "category": "Development",
-      "icon": "build/icons"
+      "icon": "build/icons",
+      "artifactName": "LlamaFarm-desktop-app-linux.${ext}"
     },
     "extraResources": [
       {


### PR DESCRIPTION
### **User description**
## Summary

Use static, version-independent filenames for desktop app artifacts to enable stable "latest" download URLs.

## Changes

### electron-app/package.json
Added `artifactName` to electron-builder config:
- **Mac**: `LlamaFarm-desktop-app-mac-{arch}.dmg/.zip`
- **Windows**: `LlamaFarm-desktop-app-windows.exe`
- **Linux**: `LlamaFarm-desktop-app-linux.AppImage/.deb`

### release-desktop.yml
- Updated checksum generation to use new filename patterns
- Updated upload step file globs
- Updated release notes with new static filenames
- Updated test step to verify arm64 DMG

## Benefits

After merging, download links can use `/releases/latest/download/` URLs:
- No manual doc updates needed for each release
- Consistent, searchable artifact names with "desktop-app" identifier
- Easier to script/automate downloads


___

### **PR Type**
Enhancement


___

### **Description**
- Add static, version-independent filenames for desktop app artifacts

- Update release workflow to use new consistent naming patterns

- Simplify release notes with architecture-specific download instructions

- Adjust DMG verification to test arm64 architecture specifically


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["electron-builder config"] -->|"artifactName"| B["Static filenames"]
  B -->|"mac-arm64/x64"| C["macOS artifacts"]
  B -->|"windows"| D["Windows artifacts"]
  B -->|"linux"| E["Linux artifacts"]
  B -->|"enables"| F["Stable download URLs"]
  C -->|"updated"| G["release-desktop.yml"]
  D -->|"updated"| G
  E -->|"updated"| G
  G -->|"checksums"| H["SHA256 generation"]
  G -->|"uploads"| I["GitHub Release"]
  G -->|"docs"| J["Release notes"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Add static artifact naming to electron-builder config</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

electron-app/package.json

<ul><li>Add <code>artifactName</code> configuration to macOS build with <code>${arch}</code> placeholder <br>for architecture-specific naming<br> <li> Add <code>artifactName</code> configuration to Windows build with static filename <br>pattern<br> <li> Add <code>artifactName</code> configuration to Linux build with static filename <br>pattern</ul>


</details>


  </td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/580/files#diff-60e7eeb6bc8be48e5693ebc9be980d76bb7973ab861bf167c666b519d437f501">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>release-desktop.yml</strong><dd><code>Update release workflow for static artifact names</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release-desktop.yml

<ul><li>Update checksum generation file globs to match new static filename <br>patterns for macOS, Linux, and Windows<br> <li> Update GitHub Release upload file patterns to use new static naming <br>conventions<br> <li> Revise release notes to document architecture-specific downloads <br>(arm64/x64 for macOS, universal for Linux/Windows)<br> <li> Change DMG verification test from universal binary check to <br>arm64-specific validation<br> <li> Reduce minimum DMG file size requirement from 80MB to 50MB</ul>


</details>


  </td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/580/files#diff-7a42dc8739297053550b8882b7bf3fcc770725f51365f7b273ed5a7d9d91c329">+28/-28</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

