### PR TITLE
feat(config): add environment variable substitution in configs

### DIFF
--- a/docs/website/docs/configuration/index.md
+++ b/docs/website/docs/configuration/index.md
@@ -196,9 +196,100 @@ datasets:
 
 Example: To support a new provider `together`, add it to the `provider` enum, regenerate types, and update runtime selection to issue HTTP requests to Together’s API.
 
+## Environment Variable Substitution
+
+LlamaFarm supports `${VAR}` syntax for injecting secrets and environment-specific values into your config. This lets you commit `llamafarm.yaml` to version control while keeping secrets in a `.env` file (which you can gitignore).
+
+### Basic Syntax
+
+```yaml
+runtime:
+  models:
+    - name: gpt4
+      provider: openai
+      model: gpt-4
+      api_key: ${OPENAI_API_KEY}           # From .env or environment
+      base_url: ${OPENAI_BASE_URL:-https://api.openai.com/v1}  # With default
+```
+
+### Supported Patterns
+
+| Pattern | Description |
+| ------- | ----------- |
+| `${VAR}` | Look up in `.env` file, then `os.environ`. Empty string if not found. |
+| `${VAR:-default}` | Same as above, but use `default` if not found. |
+| `${file:.env-llamafarm:VAR}` | Look up in specific file (e.g., `.env-llamafarm`). |
+| `${file:.env.local:VAR:-default}` | Specific file with default fallback. |
+
+### Resolution Priority
+
+1. **Project `.env` file** (in the project directory) - checked first for `${VAR}` syntax
+2. **Environment variables** (`os.environ`) - fallback if not in `.env`
+3. **Default value** (if specified with `:-`) - fallback if not found anywhere
+
+### Example Setup
+
+**Project structure:**
+```
+~/.llamafarm/projects/default/my-project/
+├── llamafarm.yaml     # Committed to git
+└── .env               # Gitignored, contains secrets
+```
+
+**llamafarm.yaml:**
+```yaml
+version: v1
+name: my-project
+namespace: default
+
+runtime:
+  models:
+    - name: openai-gpt4
+      provider: openai
+      model: gpt-4
+      api_key: ${OPENAI_API_KEY}
+
+    - name: anthropic-claude
+      provider: openai
+      model: claude-3-opus
+      base_url: https://api.anthropic.com/v1
+      api_key: ${file:.env-anthropic:ANTHROPIC_API_KEY}
+```
+
+**.env:**
+```bash
+OPENAI_API_KEY=sk-abc123...
+```
+
+**.env-anthropic:** (separate file for Anthropic secrets)
+```bash
+ANTHROPIC_API_KEY=sk-ant-xyz789...
+```
+
+### Using Different Env Files
+
+The `${file:filename:VAR}` syntax lets you organize secrets into separate files:
+
+```yaml
+# Use different env files for different providers
+api_key: ${file:.env-openai:API_KEY}      # From .env-openai
+api_key: ${file:.env-anthropic:API_KEY}   # From .env-anthropic
+api_key: ${file:secrets.env:API_KEY}      # From secrets.env
+```
+
+This is useful when:
+- You want to separate LlamaFarm secrets from other project secrets
+- Different team members have access to different API keys
+- You're using multiple AI providers with separate credentials
+
+### Cache Behavior
+
+Environment files are cached for performance. If you update a `.env` file, restart the server for changes to take effect.
+
 ## Best Practices
 
-- Keep secrets out of YAML; use environment variables and reference them at runtime.
+- Keep secrets out of YAML; use `${VAR}` references to load from `.env` files.
+- Add `.env`, `.env-*`, and `secrets.env` to `.gitignore`.
 - Version control your config; treat `llamafarm.yaml` like application code.
 - Use separate namespaces or configs for dev/staging/prod to avoid cross-talk.
 - Document uncommon parser/extractor choices for future maintainers.

--- a/server/services/env_service.py
+++ b/server/services/env_service.py
@@ -1,0 +1,200 @@
+"""Service for environment variable substitution in config values.
+
+Supports these syntaxes:
+- ${VAR_NAME} - Looks up VAR_NAME in project .env, then os.environ
+- ${VAR_NAME:-default} - Same as above, with fallback default value
+- ${file:.env-llamafarm:VAR_NAME} - Explicitly load from specific file
+- ${file:.env.local:VAR_NAME:-default} - Explicit file with default
+
+The default .env file is automatically loaded from the project directory.
+Use ${file:...} syntax to load from a different file (e.g., .env-llamafarm).
+"""
+
+import os
+import re
+from pathlib import Path
+
+from dotenv import dotenv_values
+
+from core.logging import FastAPIStructLogger
+
+logger = FastAPIStructLogger()
+
+# Pattern to match ${VAR}, ${VAR:-default}, ${file:.env:VAR}, ${file:.env:VAR:-default}
+# Group 1: optional "file:" prefix with filename (e.g., "file:.env.local:")
+# Group 2: the filename if file: prefix is used
+# Group 3: variable name
+# Group 4: optional default value (after :-)
+ENV_VAR_PATTERN = re.compile(r"\$\{(?:(file:([^:]+):))?([^}:]+)(?::-([^}]*))?\}")
+
+
+class EnvService:
+    """Service for managing environment variables and substitution in configs."""
+
+    # Cache for loaded env files to avoid re-reading
+    _file_cache: dict[str, dict[str, str]] = {}
+
+    @classmethod
+    def clear_cache(cls):
+        """Clear the env file cache. Useful for testing or when files change."""
+        cls._file_cache.clear()
+
+    @classmethod
+    def load_env_file(cls, file_path: Path, use_cache: bool = True) -> dict[str, str]:
+        """Load environment variables from a .env file.
+
+        Args:
+            file_path: Path to the .env file
+            use_cache: Whether to use cached values (default True)
+
+        Returns:
+            Dict of environment variables from the file.
+            Returns empty dict if file doesn't exist.
+        """
+        path_str = str(file_path.resolve())
+
+        if use_cache and path_str in cls._file_cache:
+            return cls._file_cache[path_str]
+
+        if not file_path.exists():
+            logger.debug("Env file not found", path=path_str)
+            return {}
+
+        try:
+            env_vars = dotenv_values(file_path)
+            result = {k: v for k, v in env_vars.items() if v is not None}
+            if use_cache:
+                cls._file_cache[path_str] = result
+            logger.debug(
+                "Loaded env file",
+                path=path_str,
+                var_count=len(result),
+            )
+            return result
+        except Exception as e:
+            logger.warning(
+                "Failed to load env file",
+                path=path_str,
+                error=str(e),
+            )
+            return {}
+
+    @classmethod
+    def substitute_env_vars(
+        cls,
+        value: str,
+        project_dir: str | Path | None = None,
+    ) -> str:
+        """Substitute ${VAR} patterns in a string.
+
+        Supports:
+        - ${VAR_NAME} - Look up in .env file, then os.environ
+        - ${VAR_NAME:-default} - With fallback default value
+        - ${file:.env-llamafarm:VAR_NAME} - Explicitly load from specific file
+        - ${file:.env.local:VAR_NAME:-default} - Explicit file with default
+
+        Args:
+            value: String potentially containing env var references
+            project_dir: Project directory for resolving relative file paths
+
+        Returns:
+            String with env vars substituted
+        """
+        project_path = Path(project_dir) if project_dir else None
+
+        # Load default .env file from project directory
+        default_env: dict[str, str] = {}
+        if project_path:
+            env_file_path = project_path / ".env"
+            default_env = cls.load_env_file(env_file_path)
+
+        def replacer(match: re.Match) -> str:
+            # Group 1 is full "file:.env:" prefix, group 2 is just the filename
+            explicit_file = match.group(2)  # ".env.local" or None
+            var_name = match.group(3)
+            default = match.group(4)  # May be None
+
+            # Determine where to look for the variable
+            if explicit_file and project_path:
+                # Explicit file specified: ${file:.env.local:VAR}
+                file_path = project_path / explicit_file
+                file_env = cls.load_env_file(file_path)
+                env_value = file_env.get(var_name)
+            else:
+                # Standard lookup: default_env_file → os.environ
+                env_value = default_env.get(var_name)
+                if env_value is None:
+                    env_value = os.environ.get(var_name)
+
+            # Return value or default
+            if env_value is not None:
+                return env_value
+            if default is not None:
+                return default
+            return ""
+
+        return ENV_VAR_PATTERN.sub(replacer, value)
+
+    @classmethod
+    def substitute_in_dict(
+        cls,
+        data: dict,
+        project_dir: str | Path | None = None,
+    ) -> dict:
+        """Recursively substitute env vars in all string values of a dict.
+
+        Args:
+            data: Dictionary to process
+            project_dir: Project directory for resolving relative file paths
+
+        Returns:
+            New dictionary with env vars substituted in string values
+        """
+        return cls._substitute_recursive(data, project_dir)
+
+    @classmethod
+    def _substitute_recursive(
+        cls,
+        obj,
+        project_dir: str | Path | None = None,
+    ):
+        """Recursively substitute env vars in any data structure."""
+        if isinstance(obj, str):
+            return cls.substitute_env_vars(obj, project_dir)
+        elif isinstance(obj, dict):
+            return {
+                k: cls._substitute_recursive(v, project_dir) for k, v in obj.items()
+            }
+        elif isinstance(obj, list):
+            return [cls._substitute_recursive(item, project_dir) for item in obj]
+        else:
+            return obj
+
+    @classmethod
+    def has_env_vars(cls, value: str) -> bool:
+        """Check if a string contains env var references.
+
+        Args:
+            value: String to check
+
+        Returns:
+            True if string contains ${...} patterns
+        """
+        return bool(ENV_VAR_PATTERN.search(value))
+
+    @classmethod
+    def find_env_vars(cls, value: str) -> list[tuple[str | None, str]]:
+        """Find all env var references in a string.
+
+        Args:
+            value: String to search
+
+        Returns:
+            List of tuples (file_name or None, var_name)
+        """
+        results = []
+        for match in ENV_VAR_PATTERN.finditer(value):
+            explicit_file = match.group(2)  # filename or None
+            var_name = match.group(3)
+            results.append((explicit_file, var_name))
+        return results

--- a/server/services/project_service.py
+++ b/server/services/project_service.py
@@ -22,6 +22,7 @@ from api.errors import (
 )
 from core.logging import FastAPIStructLogger
 from core.settings import settings
+from services.env_service import EnvService
 
 logger = FastAPIStructLogger()
 
@@ -487,7 +488,30 @@ class ProjectService:
 
     @classmethod
     def load_config(cls, namespace: str, project_id: str) -> LlamaFarmConfig:
-        return load_config(cls.get_project_dir(namespace, project_id))
+        """Load and validate a project configuration with env var substitution.
+
+        Supports ${VAR} syntax for environment variable substitution:
+        - ${VAR_NAME} - Look up in .env file, then os.environ
+        - ${VAR_NAME:-default} - With fallback default value
+        - ${file:.env-llamafarm:VAR_NAME} - Load from specific file
+
+        Args:
+            namespace: Project namespace
+            project_id: Project ID
+
+        Returns:
+            Validated LlamaFarmConfig with env vars substituted
+        """
+        project_dir = cls.get_project_dir(namespace, project_id)
+
+        # Load raw config dict (validates schema but not Pydantic model)
+        config_dict = load_config_dict(project_dir)
+
+        # Substitute environment variables
+        config_dict = EnvService.substitute_in_dict(config_dict, project_dir)
+
+        # Validate and return as Pydantic model
+        return LlamaFarmConfig(**config_dict)
 
     @classmethod
     def save_config(

--- a/server/tests/test_env_service.py
+++ b/server/tests/test_env_service.py
@@ -1,0 +1,331 @@
+"""Tests for EnvService."""
+
+import os
+import tempfile
+from pathlib import Path
+
+from services.env_service import EnvService
+
+
+class TestEnvService:
+    """Tests for EnvService."""
+
+    def setup_method(self):
+        """Clear cache before each test."""
+        EnvService.clear_cache()
+
+    # ==========================================================================
+    # Basic ${VAR} substitution
+    # ==========================================================================
+
+    def test_substitute_simple_var(self):
+        """Test simple ${VAR} substitution from os.environ."""
+        original = os.environ.get("TEST_VAR_SIMPLE")
+        try:
+            os.environ["TEST_VAR_SIMPLE"] = "hello_world"
+            result = EnvService.substitute_env_vars("${TEST_VAR_SIMPLE}")
+            assert result == "hello_world"
+        finally:
+            if original:
+                os.environ["TEST_VAR_SIMPLE"] = original
+            else:
+                os.environ.pop("TEST_VAR_SIMPLE", None)
+
+    def test_substitute_var_with_surrounding_text(self):
+        """Test ${VAR} substitution with surrounding text."""
+        original = os.environ.get("TEST_API_KEY")
+        try:
+            os.environ["TEST_API_KEY"] = "sk-123456"
+            result = EnvService.substitute_env_vars("Bearer ${TEST_API_KEY}")
+            assert result == "Bearer sk-123456"
+        finally:
+            if original:
+                os.environ["TEST_API_KEY"] = original
+            else:
+                os.environ.pop("TEST_API_KEY", None)
+
+    def test_substitute_missing_var_returns_empty(self):
+        """Test that missing var without default returns empty string."""
+        result = EnvService.substitute_env_vars("${NONEXISTENT_VAR_12345}")
+        assert result == ""
+
+    def test_substitute_no_vars_passes_through(self):
+        """Test string without vars passes through unchanged."""
+        result = EnvService.substitute_env_vars("plain string")
+        assert result == "plain string"
+
+    # ==========================================================================
+    # ${VAR:-default} syntax
+    # ==========================================================================
+
+    def test_substitute_with_default_when_missing(self):
+        """Test ${VAR:-default} uses default when var is missing."""
+        result = EnvService.substitute_env_vars("${MISSING_VAR:-fallback_value}")
+        assert result == "fallback_value"
+
+    def test_substitute_with_default_when_set(self):
+        """Test ${VAR:-default} uses var value when set."""
+        original = os.environ.get("TEST_VAR_DEFAULT")
+        try:
+            os.environ["TEST_VAR_DEFAULT"] = "actual_value"
+            result = EnvService.substitute_env_vars("${TEST_VAR_DEFAULT:-fallback}")
+            assert result == "actual_value"
+        finally:
+            if original:
+                os.environ["TEST_VAR_DEFAULT"] = original
+            else:
+                os.environ.pop("TEST_VAR_DEFAULT", None)
+
+    def test_substitute_with_empty_default(self):
+        """Test ${VAR:-} returns empty string when missing."""
+        result = EnvService.substitute_env_vars("${MISSING:-}")
+        assert result == ""
+
+    def test_substitute_default_with_special_chars(self):
+        """Test default value can contain URLs and special chars."""
+        result = EnvService.substitute_env_vars(
+            "${MISSING:-https://api.example.com/v1}"
+        )
+        assert result == "https://api.example.com/v1"
+
+    # ==========================================================================
+    # ${file:filename:VAR} explicit file syntax
+    # ==========================================================================
+
+    def test_substitute_from_explicit_file(self):
+        """Test ${file:.env.local:VAR} loads from specific file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create .env.local with a variable
+            env_path = Path(tmpdir) / ".env.local"
+            env_path.write_text("MY_SECRET=from_local_file\n")
+
+            result = EnvService.substitute_env_vars(
+                "${file:.env.local:MY_SECRET}", project_dir=tmpdir
+            )
+            assert result == "from_local_file"
+
+    def test_substitute_from_explicit_file_with_default(self):
+        """Test ${file:.env.local:VAR:-default} with default."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # File doesn't exist, should use default
+            result = EnvService.substitute_env_vars(
+                "${file:.env.local:MISSING:-default_val}", project_dir=tmpdir
+            )
+            assert result == "default_val"
+
+    def test_substitute_different_files(self):
+        """Test different ${file:} references in same string."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create two different env files
+            (Path(tmpdir) / ".env.a").write_text("VAR_A=value_a\n")
+            (Path(tmpdir) / ".env.b").write_text("VAR_B=value_b\n")
+
+            result = EnvService.substitute_env_vars(
+                "${file:.env.a:VAR_A} and ${file:.env.b:VAR_B}", project_dir=tmpdir
+            )
+            assert result == "value_a and value_b"
+
+    # ==========================================================================
+    # Default .env file loading
+    # ==========================================================================
+
+    def test_substitute_from_default_env_file(self):
+        """Test ${VAR} loads from .env in project directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create .env with a variable
+            env_path = Path(tmpdir) / ".env"
+            env_path.write_text("PROJECT_VAR=from_dotenv\n")
+
+            result = EnvService.substitute_env_vars(
+                "${PROJECT_VAR}", project_dir=tmpdir
+            )
+            assert result == "from_dotenv"
+
+    def test_env_file_takes_precedence_over_environ(self):
+        """Test .env file values take precedence over os.environ."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            original = os.environ.get("PRIORITY_TEST")
+            try:
+                os.environ["PRIORITY_TEST"] = "from_environ"
+                env_path = Path(tmpdir) / ".env"
+                env_path.write_text("PRIORITY_TEST=from_dotenv\n")
+
+                result = EnvService.substitute_env_vars(
+                    "${PRIORITY_TEST}", project_dir=tmpdir
+                )
+                assert result == "from_dotenv"
+            finally:
+                if original:
+                    os.environ["PRIORITY_TEST"] = original
+                else:
+                    os.environ.pop("PRIORITY_TEST", None)
+
+    def test_fallback_to_environ_when_not_in_file(self):
+        """Test falls back to os.environ when not in .env file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            original = os.environ.get("FALLBACK_VAR")
+            try:
+                os.environ["FALLBACK_VAR"] = "from_environ"
+                # Empty .env file
+                env_path = Path(tmpdir) / ".env"
+                env_path.write_text("OTHER_VAR=other\n")
+
+                result = EnvService.substitute_env_vars(
+                    "${FALLBACK_VAR}", project_dir=tmpdir
+                )
+                assert result == "from_environ"
+            finally:
+                if original:
+                    os.environ["FALLBACK_VAR"] = original
+                else:
+                    os.environ.pop("FALLBACK_VAR", None)
+
+    # ==========================================================================
+    # Dict substitution
+    # ==========================================================================
+
+    def test_substitute_in_dict_simple(self):
+        """Test substitution in dict values."""
+        original = os.environ.get("DICT_VAR")
+        try:
+            os.environ["DICT_VAR"] = "dict_value"
+            data = {"key": "${DICT_VAR}", "static": "unchanged"}
+            result = EnvService.substitute_in_dict(data)
+            assert result == {"key": "dict_value", "static": "unchanged"}
+        finally:
+            if original:
+                os.environ["DICT_VAR"] = original
+            else:
+                os.environ.pop("DICT_VAR", None)
+
+    def test_substitute_in_dict_nested(self):
+        """Test substitution in nested dict."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            env_path = Path(tmpdir) / ".env"
+            env_path.write_text("NESTED_VAR=nested_value\n")
+
+            data = {
+                "runtime": {"models": [{"name": "test", "api_key": "${NESTED_VAR}"}]}
+            }
+            result = EnvService.substitute_in_dict(data, project_dir=tmpdir)
+            assert result["runtime"]["models"][0]["api_key"] == "nested_value"
+
+    def test_substitute_in_dict_list(self):
+        """Test substitution in list values."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            env_path = Path(tmpdir) / ".env"
+            env_path.write_text("LIST_VAR=list_val\n")
+
+            data = {"items": ["${LIST_VAR}", "static"]}
+            result = EnvService.substitute_in_dict(data, project_dir=tmpdir)
+            assert result["items"] == ["list_val", "static"]
+
+    def test_substitute_in_dict_preserves_non_strings(self):
+        """Test non-string values are preserved."""
+        data = {"num": 42, "bool": True, "float": 3.14, "none": None}
+        result = EnvService.substitute_in_dict(data)
+        assert result == data
+
+    # ==========================================================================
+    # Utility methods
+    # ==========================================================================
+
+    def test_has_env_vars_true(self):
+        """Test has_env_vars returns True for strings with vars."""
+        assert EnvService.has_env_vars("${VAR}") is True
+        assert EnvService.has_env_vars("prefix ${VAR} suffix") is True
+        assert EnvService.has_env_vars("${file:.env:VAR}") is True
+
+    def test_has_env_vars_false(self):
+        """Test has_env_vars returns False for strings without vars."""
+        assert EnvService.has_env_vars("plain") is False
+        assert EnvService.has_env_vars("$NOT_A_VAR") is False
+        assert EnvService.has_env_vars("{NOT_A_VAR}") is False
+
+    def test_find_env_vars(self):
+        """Test find_env_vars returns var info."""
+        result = EnvService.find_env_vars("${VAR1} and ${file:.env:VAR2}")
+        assert result == [(None, "VAR1"), (".env", "VAR2")]
+
+    def test_find_env_vars_empty(self):
+        """Test find_env_vars returns empty for no vars."""
+        result = EnvService.find_env_vars("no variables")
+        assert result == []
+
+    # ==========================================================================
+    # Cache behavior
+    # ==========================================================================
+
+    def test_file_cache_works(self):
+        """Test that file contents are cached."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            env_path = Path(tmpdir) / ".env"
+            env_path.write_text("CACHE_VAR=initial\n")
+
+            # First read
+            result1 = EnvService.substitute_env_vars("${CACHE_VAR}", project_dir=tmpdir)
+            assert result1 == "initial"
+
+            # Modify file (cache should still return old value)
+            env_path.write_text("CACHE_VAR=modified\n")
+            result2 = EnvService.substitute_env_vars("${CACHE_VAR}", project_dir=tmpdir)
+            assert result2 == "initial"  # Still cached
+
+            # Clear cache and re-read
+            EnvService.clear_cache()
+            result3 = EnvService.substitute_env_vars("${CACHE_VAR}", project_dir=tmpdir)
+            assert result3 == "modified"  # Now updated
+
+    # ==========================================================================
+    # Edge cases
+    # ==========================================================================
+
+    def test_multiple_vars_in_string(self):
+        """Test multiple ${VAR} in one string."""
+        original_a = os.environ.get("MULTI_A")
+        original_b = os.environ.get("MULTI_B")
+        try:
+            os.environ["MULTI_A"] = "val_a"
+            os.environ["MULTI_B"] = "val_b"
+            result = EnvService.substitute_env_vars("${MULTI_A}:${MULTI_B}")
+            assert result == "val_a:val_b"
+        finally:
+            if original_a:
+                os.environ["MULTI_A"] = original_a
+            else:
+                os.environ.pop("MULTI_A", None)
+            if original_b:
+                os.environ["MULTI_B"] = original_b
+            else:
+                os.environ.pop("MULTI_B", None)
+
+    def test_var_name_with_underscore(self):
+        """Test var names with underscores."""
+        original = os.environ.get("MY_LONG_VAR_NAME")
+        try:
+            os.environ["MY_LONG_VAR_NAME"] = "value"
+            result = EnvService.substitute_env_vars("${MY_LONG_VAR_NAME}")
+            assert result == "value"
+        finally:
+            if original:
+                os.environ["MY_LONG_VAR_NAME"] = original
+            else:
+                os.environ.pop("MY_LONG_VAR_NAME", None)
+
+    def test_var_name_with_numbers(self):
+        """Test var names with numbers."""
+        original = os.environ.get("VAR123")
+        try:
+            os.environ["VAR123"] = "value"
+            result = EnvService.substitute_env_vars("${VAR123}")
+            assert result == "value"
+        finally:
+            if original:
+                os.environ["VAR123"] = original
+            else:
+                os.environ.pop("VAR123", None)
+
+    def test_missing_env_file_returns_empty_dict(self):
+        """Test loading nonexistent env file returns empty dict."""
+        result = EnvService.load_env_file(Path("/nonexistent/.env"))
+        assert result == {}


### PR DESCRIPTION
### **User description**
## Summary

Add support for `${VAR}` syntax in `llamafarm.yaml` to load secrets from `.env` files without hardcoding them in the config. This solves the problem of wanting to commit config to git while keeping secrets secure.

## Supported Patterns

| Pattern | Description |
| ------- | ----------- |
| `${VAR}` | Look up in `.env` file, then `os.environ`. Empty string if not found. |
| `${VAR:-default}` | Same as above, but use `default` if not found. |
| `${file:.env-llamafarm:VAR}` | Look up in specific file (e.g., `.env-llamafarm`). |
| `${file:.env.local:VAR:-default}` | Specific file with default fallback. |

## Example Usage

**llamafarm.yaml** (committed to git):
```yaml
runtime:
  models:
    - name: gpt4
      provider: openai
      model: gpt-4
      api_key: ${OPENAI_API_KEY}
      base_url: ${OPENAI_BASE_URL:-https://api.openai.com/v1}

    - name: anthropic
      provider: openai
      model: claude-3-opus
      api_key: ${file:.env-anthropic:ANTHROPIC_API_KEY}
```

**.env** (gitignored):
```bash
OPENAI_API_KEY=sk-abc123...
```

## Resolution Priority

1. Project `.env` file - checked first for `${VAR}` syntax
2. `os.environ` - fallback if not in `.env`
3. Default value (if specified with `:-`)

## Changes

### New Files
- `server/services/env_service.py` - EnvService with substitution logic
- `server/tests/test_env_service.py` - 27 tests

### Modified Files
- `server/services/project_service.py` - Integrate env substitution in `load_config`
- `docs/website/docs/configuration/index.md` - Comprehensive documentation

## Test Plan
- [x] 27 unit tests for EnvService
- [x] Tests cover: basic substitution, defaults, explicit files, caching, edge cases

## Backward Compatibility
100% backward compatible - configs without `${VAR}` syntax work unchanged.


___

### **PR Type**
Enhancement


___

### **Description**
- Add environment variable substitution with `${VAR}` syntax in config files

- Support multiple patterns: basic vars, defaults, and explicit file loading

- Integrate substitution into project config loading pipeline

- Add comprehensive documentation and 27 unit tests for new functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["llamafarm.yaml<br/>with ${VAR} syntax"] -->|load_config| B["ProjectService"]
  B -->|substitute_in_dict| C["EnvService"]
  C -->|load_env_file| D[".env files"]
  D -->|resolve vars| E["LlamaFarmConfig<br/>with values"]
  C -->|fallback| F["os.environ"]
  F -->|resolve vars| E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>env_service.py</strong><dd><code>New EnvService for environment variable substitution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/services/env_service.py

<ul><li>New service class for environment variable substitution with <br>regex-based pattern matching<br> <li> Supports four syntax patterns: <code>${VAR}</code>, <code>${VAR:-default}</code>, <br><code>${file:name:VAR}</code>, <code>${file:name:VAR:-default}</code><br> <li> Implements file caching mechanism to avoid re-reading <code>.env</code> files<br> <li> Provides recursive substitution for nested dicts and lists<br> <li> Includes utility methods for detecting and finding env var references</ul>


</details>


  </td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/614/files#diff-8cbfe013314506c5d44ec492bd1b6f76d130f915ff0ed2edd271361a147c55e6">+200/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>project_service.py</strong><dd><code>Integrate env substitution into config loading</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/services/project_service.py

<ul><li>Import <code>EnvService</code> for environment variable substitution<br> <li> Refactor <code>load_config</code> method to apply env var substitution after <br>loading raw config dict<br> <li> Add comprehensive docstring explaining supported substitution patterns<br> <li> Maintain backward compatibility with configs without <code>${VAR}</code> syntax</ul>


</details>


  </td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/614/files#diff-5c157104d94adec5df6561d2298e32d1ce3d007d49cb25b6ea72406cb1e21c5a">+25/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_env_service.py</strong><dd><code>Comprehensive test suite for EnvService</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/tests/test_env_service.py

<ul><li>Add 27 comprehensive unit tests covering all substitution patterns<br> <li> Test basic <code>${VAR}</code> substitution from os.environ and <code>.env</code> files<br> <li> Test <code>${VAR:-default}</code> syntax with missing and present variables<br> <li> Test explicit file syntax <code>${file:name:VAR}</code> with multiple files<br> <li> Test recursive substitution in nested dicts and lists<br> <li> Test caching behavior and edge cases like multiple vars and special <br>characters<br> <li> Test utility methods <code>has_env_vars</code> and <code>find_env_vars</code></ul>


</details>


  </td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/614/files#diff-bca298ad03ad2ac0f3029d688ebb14c763d4ff7ae7199a3a393bd68a39aeef52">+331/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.md</strong><dd><code>Add environment variable substitution documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/website/docs/configuration/index.md

<ul><li>Add new "Environment Variable Substitution" section with detailed <br>explanation<br> <li> Document all four supported syntax patterns with examples<br> <li> Explain resolution priority: <code>.env</code> file → <code>os.environ</code> → default value<br> <li> Provide complete example setup with project structure and multiple <br><code>.env</code> files<br> <li> Document use cases for separate env files (multi-provider, team access <br>control)<br> <li> Explain cache behavior and update best practices to recommend <code>${VAR}</code> <br>usage</ul>


</details>


  </td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/614/files#diff-7c7f8cb9ba8007a3fe15acd30fc985c25c60c1a5a3a066c8a24c2067fbe45bd4">+92/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

