### PR TITLE
Allow lf start to continue without universal-runtime

### DIFF
--- a/cli/cmd/context.go
+++ b/cli/cmd/context.go
@@ -58,11 +58,12 @@ func (f *ServiceConfigFactory) StartCommand(serverURL string) *orchestrator.Serv
 		ServerURL:   serverURL,
 		PrintStatus: true,
 		ServiceNeeds: map[string]orchestrator.ServiceRequirement{
-			"server": orchestrator.ServiceRequired,
-			"rag":    orchestrator.ServiceOptional,
+			"server":            orchestrator.ServiceRequired,
+			"rag":               orchestrator.ServiceOptional,
+			"universal-runtime": orchestrator.ServiceOptional,
 		},
 		DefaultTimeout: f.ctx.ServerStartTimeout,
-		AutoStart:       f.ctx.AutoStart,
+		AutoStart:      f.ctx.AutoStart,
 	}
 }
 
@@ -76,7 +77,7 @@ func (f *ServiceConfigFactory) RAGCommand(serverURL string) *orchestrator.Servic
 			"rag":    orchestrator.ServiceRequired,
 		},
 		DefaultTimeout: f.ctx.ServerStartTimeout,
-		AutoStart:       f.ctx.AutoStart,
+		AutoStart:      f.ctx.AutoStart,
 	}
 }
 
@@ -89,7 +90,7 @@ func (f *ServiceConfigFactory) ChatNoRAG(serverURL string) *orchestrator.Service
 			"server": orchestrator.ServiceRequired,
 		},
 		DefaultTimeout: f.ctx.ServerStartTimeout,
-		AutoStart:       f.ctx.AutoStart,
+		AutoStart:      f.ctx.AutoStart,
 	}
 }
 
@@ -103,7 +104,7 @@ func (f *ServiceConfigFactory) ServerOnly(serverURL string) *orchestrator.Servic
 			"rag":    orchestrator.ServiceOptional,
 		},
 		DefaultTimeout: f.ctx.ServerStartTimeout,
-		AutoStart:       f.ctx.AutoStart,
+		AutoStart:      f.ctx.AutoStart,
 	}
 }
 

--- a/cli/cmd/dev.go
+++ b/cli/cmd/dev.go
@@ -63,8 +63,8 @@ func start(mode SessionMode) {
 	serverURL = serverInfo.URL
 
 	factory := GetServiceConfigFactory()
-	config := factory.ServerOnly(serverURL)
-	orchestrator.EnsureServicesOrExitWithConfig(config, "server", "universal-runtime")
+	config := factory.StartCommand(serverURL)
+	orchestrator.EnsureServicesOrExitWithConfig(config)
 
 	runChatSessionTUI(mode, projectInfo)
 }

--- a/cli/cmd/orchestrator/services.go
+++ b/cli/cmd/orchestrator/services.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -309,11 +310,24 @@ func EnsureServicesOrExit(serverURL string, serviceNames ...string) {
 
 // EnsureServicesWithConfig ensures services are running, respecting AutoStart flag
 func (sm *ServiceManager) EnsureServicesWithConfig(config *ServiceOrchestrationConfig, serviceNames ...string) error {
+	if config == nil {
+		return fmt.Errorf("service configuration is required")
+	}
+
+	targetServices, err := sm.resolveServiceTargets(config, serviceNames...)
+	if err != nil {
+		return err
+	}
+
 	// If auto-start is disabled, check health but don't start services
 	if !config.AutoStart {
 		var unhealthyServices []string
 
-		for _, serviceName := range serviceNames {
+		for _, serviceName := range targetServices {
+			if sm.serviceRequirement(config, serviceName) != ServiceRequired {
+				continue
+			}
+
 			serviceDef, exists := ServiceGraph[serviceName]
 			if !exists {
 				return fmt.Errorf("unknown service: %s", serviceName)
@@ -334,8 +348,8 @@ func (sm *ServiceManager) EnsureServicesWithConfig(config *ServiceOrchestrationC
 		return nil
 	}
 
-	// Auto-start is enabled, use existing logic
-	return sm.EnsureServices(serviceNames...)
+	// Auto-start is enabled, use configured requirements
+	return sm.ensureServicesWithRequirements(config, targetServices)
 }
 
 // EnsureServicesOrExitWithConfig wraps EnsureServicesWithConfig with exit behavior
@@ -350,6 +364,100 @@ func EnsureServicesOrExitWithConfig(config *ServiceOrchestrationConfig, serviceN
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
+}
+
+func (sm *ServiceManager) resolveServiceTargets(config *ServiceOrchestrationConfig, serviceNames ...string) ([]string, error) {
+	if len(serviceNames) == 0 && len(config.ServiceNeeds) > 0 {
+		serviceNames = make([]string, 0, len(config.ServiceNeeds))
+		for name := range config.ServiceNeeds {
+			serviceNames = append(serviceNames, name)
+		}
+		sort.Strings(serviceNames)
+	}
+
+	for _, serviceName := range serviceNames {
+		if _, exists := ServiceGraph[serviceName]; !exists {
+			return nil, fmt.Errorf("unknown service: %s", serviceName)
+		}
+	}
+
+	return serviceNames, nil
+}
+
+func (sm *ServiceManager) serviceRequirement(config *ServiceOrchestrationConfig, serviceName string) ServiceRequirement {
+	if config == nil || config.ServiceNeeds == nil {
+		return ServiceRequired
+	}
+	if requirement, ok := config.ServiceNeeds[serviceName]; ok {
+		return requirement
+	}
+	return ServiceRequired
+}
+
+func (sm *ServiceManager) ensureServicesWithRequirements(
+	config *ServiceOrchestrationConfig,
+	serviceNames []string,
+) error {
+	var required []string
+	var optional []string
+
+	for _, serviceName := range serviceNames {
+		switch sm.serviceRequirement(config, serviceName) {
+		case ServiceIgnored:
+			continue
+		case ServiceOptional:
+			optional = append(optional, serviceName)
+		default:
+			required = append(required, serviceName)
+		}
+	}
+
+	for _, serviceName := range required {
+		if err := sm.EnsureService(serviceName); err != nil {
+			return err
+		}
+	}
+
+	for _, serviceName := range optional {
+		if err := sm.ensureServiceOptional(serviceName, config); err != nil {
+			utils.OutputWarning(
+				"Warning: Failed to start optional service %s: %v\n",
+				serviceName,
+				err,
+			)
+		}
+	}
+
+	return nil
+}
+
+func (sm *ServiceManager) ensureServiceOptional(serviceName string, config *ServiceOrchestrationConfig) error {
+	resolvedOrder, err := sm.resolveDependencies(serviceName)
+	if err != nil {
+		return err
+	}
+
+	for _, svcName := range resolvedOrder {
+		switch sm.serviceRequirement(config, svcName) {
+		case ServiceIgnored:
+			continue
+		case ServiceRequired:
+			if err := sm.ensureSingleService(svcName); err != nil {
+				return err
+			}
+			continue
+		}
+
+		serviceDef := ServiceGraph[svcName]
+		if sm.isServiceHealthy(serviceDef) {
+			continue
+		}
+		if err := sm.startService(serviceDef); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // ensureSingleService ensures a single service is running without checking dependencies.

--- a/cli/cmd/orchestrator/services_test.go
+++ b/cli/cmd/orchestrator/services_test.go
@@ -305,6 +305,7 @@ func TestEnsureServicesWithConfig_AutoStartDisabled(t *testing.T) {
 		name         string
 		autoStart    bool
 		serviceNames []string
+		serviceNeeds map[string]ServiceRequirement
 		wantErr      bool
 		errContains  string
 		// Note: We can't easily mock isServiceHealthy without refactoring,
@@ -323,14 +324,22 @@ func TestEnsureServicesWithConfig_AutoStartDisabled(t *testing.T) {
 			serviceNames: []string{},
 			wantErr:      false,
 		},
+		{
+			name:         "optional service without auto-start does not error",
+			autoStart:    false,
+			serviceNames: []string{},
+			serviceNeeds: map[string]ServiceRequirement{"server": ServiceOptional},
+			wantErr:      false,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			config := &ServiceOrchestrationConfig{
-				ServerURL:   "http://localhost:8000",
-				PrintStatus: false,
-				AutoStart:   tt.autoStart,
+				ServerURL:    "http://localhost:8000",
+				PrintStatus:  false,
+				AutoStart:    tt.autoStart,
+				ServiceNeeds: tt.serviceNeeds,
 			}
 
 			err := sm.EnsureServicesWithConfig(config, tt.serviceNames...)


### PR DESCRIPTION
### **User description**
- log runtime start failures without blocking
- keep other services running

Tests: go test ./... (cli)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Make universal-runtime optional in start command

- Allow lf start to continue without universal-runtime failures

- Implement service requirement handling for optional services

- Add non-blocking error handling for optional service startup


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["StartCommand Config"] -->|"marks universal-runtime optional"| B["ServiceNeeds Map"]
  B -->|"resolveServiceTargets"| C["Service Resolution"]
  C -->|"ensureServicesWithRequirements"| D["Required Services"]
  C -->|"ensureServiceOptional"| E["Optional Services"]
  D -->|"EnsureService"| F["Start or Error"]
  E -->|"ensureServiceOptional"| G["Start with Warning"]
  F -->|"blocks on failure"| H["Exit"]
  G -->|"continues on failure"| I["Continue"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>context.go</strong><dd><code>Mark universal-runtime as optional service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/cmd/context.go

<ul><li>Mark <code>universal-runtime</code> as <code>ServiceOptional</code> in <code>StartCommand</code> <br>configuration<br> <li> Fix alignment/formatting of <code>ServiceNeeds</code> map entries<br> <li> Standardize whitespace in <code>AutoStart</code> field assignments across multiple <br>methods</ul>


</details>


  </td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/634/files#diff-7b03b947c151834de4959d5d8a7685b5006749d462dfe418ac495812bd3404d8">+7/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dev.go</strong><dd><code>Use StartCommand config for dev mode</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/cmd/dev.go

<ul><li>Change from <code>ServerOnly</code> to <code>StartCommand</code> configuration factory<br> <li> Remove explicit service name parameters from <br><code>EnsureServicesOrExitWithConfig</code> call<br> <li> Allow configuration to define service requirements instead of <br>hardcoding</ul>


</details>


  </td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/634/files#diff-5dd045a079ea6553e3f02c0aacced61c4ae8e1c9e092670f8b5bb7804ef91b81">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>services.go</strong><dd><code>Add service requirement-aware orchestration logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/cmd/orchestrator/services.go

<ul><li>Add <code>sort</code> import for deterministic service ordering<br> <li> Implement <code>resolveServiceTargets</code> to extract services from config or <br>parameters<br> <li> Implement <code>serviceRequirement</code> helper to check service requirement level<br> <li> Implement <code>ensureServicesWithRequirements</code> to handle required vs <br>optional services separately<br> <li> Implement <code>ensureServiceOptional</code> to start optional services with <br>non-blocking error handling<br> <li> Update <code>EnsureServicesWithConfig</code> to use new requirement-aware logic <br>with warning output for optional service failures<br> <li> Add nil check for service configuration parameter</ul>


</details>


  </td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/634/files#diff-9d524758560b8c261cebc0fd9b2ad7db069c192dd8a1e3eaf48205b72ac76ad5">+111/-3</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>services_test.go</strong><dd><code>Add tests for optional service handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/cmd/orchestrator/services_test.go

<ul><li>Add <code>serviceNeeds</code> field to test struct for configuration-based <br>requirements<br> <li> Add test case for optional services without auto-start<br> <li> Update test setup to include <code>ServiceNeeds</code> in configuration<br> <li> Fix whitespace alignment in config initialization</ul>


</details>


  </td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/634/files#diff-6398eae95fc04b2b8bd9bbece621902c68bd2b246d8e6161ac02a1ffa31e504a">+12/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Make `universal-runtime` optional in start/dev flows and enhance orchestrator to resolve/configure required vs optional services with proper auto-start behavior.
> 
> - **Orchestrator**:
>   - Add config-driven service resolution and requirement handling: `resolveServiceTargets`, `serviceRequirement`, `ensureServicesWithRequirements`, `ensureServiceOptional`.
>   - Update `EnsureServicesWithConfig` to validate config, honor `AutoStart`, and only block on required services; start optional services best-effort.
>   - Minor: import `sort`; adjust `EnsureServicesOrExitWithConfig` to use new logic.
> - **CLI**:
>   - `StartCommand` now includes `"universal-runtime"` as `ServiceOptional` in `ServiceNeeds`.
>   - `dev` command switches to `StartCommand` + `EnsureServicesOrExitWithConfig(config)` (no explicit service list), leveraging config-driven orchestration.
> - **Tests**:
>   - Extend tests to cover optional service handling and config-driven targets (e.g., optional server with auto-start disabled).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 447c7ea50b9a32470de7bf15db47d4a6a6da3254. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->