### PR TITLE
fix(cli): prevent dev builds from stopping running services

### DIFF
--- a/cli/cmd/orchestrator/source_manager.go
+++ b/cli/cmd/orchestrator/source_manager.go
@@ -78,8 +78,9 @@ func (m *SourceManager) EnsureSource() error {
 		return fmt.Errorf("failed to determine CLI version: %w", err)
 	}
 
-	// Run everything manually
-	if targetVersion == "dev" {
+	// Dev builds should skip source management entirely - developer runs services manually
+	// Check the actual build version, not targetVersion (which returns "main" for dev builds)
+	if buildinfo.CurrentVersion == "dev" || buildinfo.CurrentVersion == "" {
 		return nil
 	}
 


### PR DESCRIPTION
### **User description**
## Summary

- Fix dev build detection in source manager to prevent incorrectly stopping running services
- Check `buildinfo.CurrentVersion` directly instead of `targetVersion` which returns "main" for dev builds

## Problem

When running CLI commands with a dev build (e.g., `lf datasets list`), the CLI would unexpectedly stop all running servers with messages like:
```
server process stopped
universal-runtime process stopped
```

This happened because `GetCurrentCLIVersion()` returns `"main"` for dev builds, but the check was comparing against `"dev"`, so the early return never triggered.

## Solution

Change the check from:
```go
if targetVersion == "dev" {
    return nil
}
```

To:
```go
if buildinfo.CurrentVersion == "dev" || buildinfo.CurrentVersion == "" {
    return nil
}
```

## Test plan

- [x] Build CLI locally with `nx build cli`
- [x] Start servers with `nx start server` and `nx start universal-runtime`
- [x] Run `lf datasets list` - servers should remain running
- [x] Verified fix by reverting change and confirming servers were stopped

Fixes #698


___

### **PR Type**
Bug fix


___

### **Description**
- Fix dev build detection to prevent stopping running services

- Check `buildinfo.CurrentVersion` directly instead of `targetVersion`

- Correctly identify dev builds that should skip source management


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["EnsureSource called"] --> B{"Check buildinfo.CurrentVersion"}
  B -->|"dev or empty"| C["Skip source management"]
  B -->|"production version"| D["Proceed with version check"]
  C --> E["Return nil"]
  D --> F["Continue orchestration"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>source_manager.go</strong><dd><code>Fix dev build version detection logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/cmd/orchestrator/source_manager.go

<ul><li>Changed version detection logic in <code>EnsureSource()</code> method<br> <li> Now checks <code>buildinfo.CurrentVersion</code> directly instead of <code>targetVersion</code><br> <li> Added condition to handle both "dev" and empty version strings<br> <li> Updated comment to clarify dev builds skip source management</ul>


</details>


  </td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/699/files#diff-4df46f2b27c060762236df936562952693b4f73902b25ae243a2f860213d3fb3">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

