### PR TITLE
Small color/sizing/layout update to chunk preview

### DIFF
--- a/designer/src/components/Rag/Preview/DocumentPreviewModal.tsx
+++ b/designer/src/components/Rag/Preview/DocumentPreviewModal.tsx
@@ -105,7 +105,7 @@ export function DocumentPreviewModal({
     <Dialog open={isOpen} onOpenChange={open => !open && onClose()}>
       <DialogContent
         data-testid="preview-modal"
-        className="max-w-6xl max-h-[90vh] overflow-hidden"
+        className="max-w-6xl h-[85vh] max-h-[85vh] overflow-hidden flex flex-col"
       >
         <DialogHeader>
           <DialogTitle>
@@ -121,7 +121,7 @@ export function DocumentPreviewModal({
         {preview.isPending && (
           <div
             data-testid="preview-loading"
-            className="flex items-center justify-center p-8"
+            className="flex-1 flex items-center justify-center"
           >
             <Loader2 className="w-8 h-8 animate-spin text-primary" />
             <span className="ml-2">Loading preview...</span>
@@ -131,14 +131,16 @@ export function DocumentPreviewModal({
         {preview.isError && (
           <div
             data-testid="preview-error"
-            className="p-4 bg-destructive/10 text-destructive rounded"
+            className="flex-1 flex items-center justify-center p-4"
           >
-            Error loading preview: {preview.error?.message || 'Unknown error'}
+            <div className="bg-destructive/10 text-destructive rounded p-4">
+              Error loading preview: {preview.error?.message || 'Unknown error'}
+            </div>
           </div>
         )}
 
         {preview.isSuccess && preview.data && (
-          <div className="flex flex-col gap-4 h-[600px]">
+          <div className="flex flex-col gap-4 flex-1 min-h-0">
             {/* Controls and Statistics Row */}
             <div className="flex items-start gap-4 flex-wrap">
               {/* Strategy Selector */}

--- a/designer/src/components/Rag/Preview/OriginalDocumentPanel.tsx
+++ b/designer/src/components/Rag/Preview/OriginalDocumentPanel.tsx
@@ -77,18 +77,6 @@ export function OriginalDocumentPanel({
 
   return (
     <div className="flex flex-col">
-      {isBinary && (
-        <div
-          data-testid="binary-file-banner"
-          className="flex items-center gap-2 p-3 mb-2 bg-blue-50 dark:bg-blue-950/30 text-blue-700 dark:text-blue-300 rounded-lg border border-blue-200 dark:border-blue-800"
-        >
-          <AlertCircle className="w-4 h-4 flex-shrink-0" />
-          <span className="text-sm">
-            This is a binary file ({filename.split('.').pop()?.toUpperCase()}). The text shown below was extracted from the document.
-          </span>
-        </div>
-      )}
-
       <div
         data-testid="original-document-panel"
         className="font-mono text-sm leading-6 whitespace-pre-wrap p-4 pl-8 bg-muted rounded-lg border border-border relative"
@@ -121,6 +109,18 @@ export function OriginalDocumentPanel({
           </div>
         )}
       </div>
+
+      {isBinary && (
+        <div
+          data-testid="binary-file-banner"
+          className="flex items-center gap-2 p-3 mt-2 bg-blue-50 dark:bg-blue-950/30 text-blue-700 dark:text-blue-300 rounded-lg border border-blue-200 dark:border-blue-800"
+        >
+          <AlertCircle className="w-4 h-4 flex-shrink-0" />
+          <span className="text-sm">
+            This is a binary file ({filename.split('.').pop()?.toUpperCase()}). The text shown above was extracted from the document.
+          </span>
+        </div>
+      )}
     </div>
   )
 }

--- a/designer/src/components/Rag/Preview/PreviewPanel.tsx
+++ b/designer/src/components/Rag/Preview/PreviewPanel.tsx
@@ -65,13 +65,15 @@ export function PreviewPanel({
               }
               className={cn(
                 seg.color,
-                'relative [box-decoration-break:clone]',
-                isSelected && 'ring-2 ring-primary',
+                'relative [box-decoration-break:clone] outline-none',
+                isSelected
+                  ? 'ring-2 ring-teal-500 dark:ring-teal-400'
+                  : 'ring-0',
                 seg.index !== undefined &&
                   chunks[seg.index]?.start_position < 0 &&
                   'opacity-50',
                 onChunkClick &&
-                  'cursor-pointer hover:ring-1 hover:ring-primary/50 transition-shadow'
+                  'cursor-pointer hover:ring-2 hover:ring-slate-400 dark:hover:ring-slate-500/60 transition-shadow'
               )}
             >
               <span className="absolute -left-7 text-xs text-muted-foreground font-bold select-none">

--- a/designer/src/components/Rag/Preview/utils.ts
+++ b/designer/src/components/Rag/Preview/utils.ts
@@ -5,9 +5,11 @@
 import type { PreviewChunk } from '../../../hooks/useDocumentPreview'
 
 // Chunk background colors (alternating, dark mode aware)
+// Uses teal, pink, purple, and indigo for variety and accessibility
 export const CHUNK_COLORS = [
-  'bg-purple-200/60 dark:bg-purple-500/40',
+  'bg-teal-200/60 dark:bg-teal-600/40',
   'bg-pink-200/60 dark:bg-pink-500/40',
+  'bg-purple-200/60 dark:bg-purple-500/40',
   'bg-indigo-200/60 dark:bg-indigo-500/40',
 ]
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Updated chunk preview colors: teal, pink, purple, indigo palette

- Improved modal layout with flexible height and proper flex distribution

- Enhanced chunk selection styling with teal ring and better hover states

- Repositioned binary file banner below content for better UX


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Chunk Colors"] -->|"Add teal, reorder palette"| B["Color Palette"]
  C["Modal Layout"] -->|"Set h-85vh, flex-col"| D["Responsive Container"]
  E["Chunk Selection"] -->|"Teal ring, slate hover"| F["Visual Feedback"]
  G["Binary Banner"] -->|"Move below content"| H["Improved Layout"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.ts</strong><dd><code>Update chunk color palette with teal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

designer/src/components/Rag/Preview/utils.ts

<ul><li>Added teal color as first chunk background option<br> <li> Reordered colors: teal, pink, purple, indigo<br> <li> Added comment documenting color choices for variety and accessibility</ul>


</details>


  </td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/711/files#diff-49e57f97594369b71c55bd3425bedaa46456f6e1592504fa749efc7fe4f86764">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DocumentPreviewModal.tsx</strong><dd><code>Improve modal layout with flexible height distribution</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

designer/src/components/Rag/Preview/DocumentPreviewModal.tsx

<ul><li>Changed modal height from max-h-[90vh] to fixed h-[85vh] with flex-col <br>layout<br> <li> Updated loading state to use flex-1 for proper vertical centering<br> <li> Refactored error state with nested div for better layout control<br> <li> Changed preview content container from fixed h-[600px] to flex-1 <br>min-h-0</ul>


</details>


  </td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/711/files#diff-32d7f3496f749eef1e8404b863a53ddb1e886fdf32bfa90374f19995b2c84c21">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OriginalDocumentPanel.tsx</strong><dd><code>Reposition binary file banner below content</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

designer/src/components/Rag/Preview/OriginalDocumentPanel.tsx

<ul><li>Moved binary file banner from top to bottom of component<br> <li> Changed banner margin from mb-2 to mt-2<br> <li> Updated banner text from "shown below" to "shown above"<br> <li> Improves content hierarchy by showing banner after document content</ul>


</details>


  </td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/711/files#diff-754352e52510a77661a5c5abf21de4c9f284966037df0ba47bf9f3d3246ea36e">+12/-12</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PreviewPanel.tsx</strong><dd><code>Enhance chunk selection and hover styling with teal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

designer/src/components/Rag/Preview/PreviewPanel.tsx

<ul><li>Added outline-none to chunk styling<br> <li> Changed selected chunk ring from ring-primary to ring-2 ring-teal-500 <br>with dark mode support<br> <li> Updated unselected state to explicitly use ring-0<br> <li> Enhanced hover state with ring-2 ring-slate-400 and dark mode variant</ul>


</details>


  </td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/711/files#diff-b3aaa708be822b5c4dc242eb8d76567fbdc6b2c4d1e20d27e71706e4c9cf42e8">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

