### PR TITLE
fix error causing sample projects to fail in designer 

### DIFF
--- a/cli/cmd/orchestrator/services.go
+++ b/cli/cmd/orchestrator/services.go
@@ -143,10 +143,12 @@ var ServiceGraph = map[string]*ServiceDefinition{
 			"TRANSFORMERS_CACHE_DIR":       filepath.Join("${HOME}", ".cache", "huggingface"),
 			"HF_HUB_DISABLE_PROGRESS_BARS": hfHubDisableProgressBars,
 			// Device control (empty = inherit from parent environment)
-			"TRANSFORMERS_SKIP_MPS":            "", // Set to "1" to skip MPS on macOS
-			"TRANSFORMERS_FORCE_CPU":           "", // Set to "1" to force CPU (useful in CI)
-			"PYTORCH_MPS_HIGH_WATERMARK_RATIO": "0.9",
-			"HF_TOKEN":                         "",
+			"TRANSFORMERS_SKIP_MPS":  "", // Set to "1" to skip MPS on macOS
+			"TRANSFORMERS_FORCE_CPU": "", // Set to "1" to force CPU (useful in CI)
+			// Note: PYTORCH_MPS_HIGH_WATERMARK_RATIO removed - setting it to non-default
+			// values causes "invalid low watermark ratio" errors on some PyTorch versions.
+			// Let PyTorch use its default memory management.
+			"HF_TOKEN": "",
 			// In CI environments, use CPU-only PyTorch to avoid downloading 3GB+ of CUDA packages
 			"UV_EXTRA_INDEX_URL": "${UV_EXTRA_INDEX_URL}",
 		},


### PR DESCRIPTION
### **User description**
remove PYTORCH_MPS_HIGH_WATERMARK_RATIO to fix sample proje…ct creation

Setting PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.9 caused a PyTorch MPS bug on Apple Silicon where the internal "low watermark ratio" calculation became invalid (1.4), resulting in RuntimeError during embedding generation.

This broke sample/demo project creation in Designer and the Mac app because RAG embedding would fail with "invalid low watermark ratio 1.4" error, even though the project itself was created successfully.

Fix: Remove the environment variable and let PyTorch use its default memory management, which works correctly.

Affects: Apple Silicon Macs (M1/M2/M3/M4) only.


___

### **PR Type**
Bug fix


___

### **Description**
- Remove PYTORCH_MPS_HIGH_WATERMARK_RATIO environment variable causing PyTorch MPS errors

- Fixes sample project creation failures on Apple Silicon Macs

- Let PyTorch use default memory management instead of problematic configuration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.9"] -->|causes invalid low watermark ratio| B["PyTorch MPS RuntimeError"]
  B -->|breaks sample project creation| C["Designer/Mac app failures"]
  D["Remove env variable"] -->|use PyTorch defaults| E["Correct memory management"]
  E -->|fixes embedding generation| F["Sample projects work"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>services.go</strong><dd><code>Remove problematic PyTorch MPS memory configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cli/cmd/orchestrator/services.go

<ul><li>Removed <code>PYTORCH_MPS_HIGH_WATERMARK_RATIO</code> environment variable from <br>service configuration<br> <li> Added explanatory comment documenting why the variable was removed<br> <li> Reformatted surrounding environment variable assignments for <br>consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/725/files#diff-9d524758560b8c261cebc0fd9b2ad7db069c192dd8a1e3eaf48205b72ac76ad5">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

