### PR TITLE
Bug fix for delete projects action in designer 

### DIFF
--- a/designer/src/App.tsx
+++ b/designer/src/App.tsx
@@ -120,7 +120,7 @@ function ProjectModalRoot() {
 
       <DeleteProjectModal
         isOpen={modal.isDeleteModalOpen}
-        projectName={modal.projectName}
+        projectName={modal.projectToDelete}
         onClose={modal.closeDeleteModal}
         onConfirm={modal.deleteProject}
         isLoading={modal.isLoading}

--- a/designer/src/hooks/useProjectModal.ts
+++ b/designer/src/hooks/useProjectModal.ts
@@ -43,6 +43,7 @@ export interface UseProjectModalReturn {
 
   // Delete modal state
   isDeleteModalOpen: boolean
+  projectToDelete: string
 
   // Validation state
   projectError: string | null
@@ -92,6 +93,9 @@ export const useProjectModal = ({
 
   // Delete modal state
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
+  // Store the project name to delete separately, since closeModal() resets projectName
+  // when the edit modal closes (triggered by Radix Dialog's onOpenChange)
+  const [projectToDelete, setProjectToDelete] = useState('')
 
   // API hooks
   const { data: currentProjectResponse, isLoading: isProjectLoading } =
@@ -139,6 +143,10 @@ export const useProjectModal = ({
   }
 
   const openDeleteModal = () => {
+    // Save the project name BEFORE closing the edit modal
+    // This is necessary because Radix Dialog's onOpenChange callback
+    // triggers closeModal() which resets projectName to ''
+    setProjectToDelete(projectName)
     // Close the edit modal first, then open delete modal
     setIsModalOpen(false)
     setProjectError(null)
@@ -148,6 +156,7 @@ export const useProjectModal = ({
   const closeDeleteModal = () => {
     setIsDeleteModalOpen(false)
     setProjectError(null)
+    setProjectToDelete('')
   }
 
   // Name validation with better error handling
@@ -346,10 +355,11 @@ export const useProjectModal = ({
 
   // Delete project
   const deleteProject = async (): Promise<void> => {
-    if (modalMode !== 'edit') return
+    // Use projectToDelete which was saved before the edit modal closed
+    const nameToDelete = projectToDelete
+    if (!nameToDelete) return
 
     try {
-      const nameToDelete = projectName
       await deleteProjectMutation.mutateAsync({
         namespace,
         projectId: nameToDelete,
@@ -589,6 +599,7 @@ export const useProjectModal = ({
 
     // Delete modal state
     isDeleteModalOpen,
+    projectToDelete,
 
     // Loading
     isLoading,


### PR DESCRIPTION
### **User description**
The delete modal was receiving an empty project name because closeModal() was being triggered by Radix Dialog's onOpenChange callback when the edit modal closed, resetting projectName to ''.

Add a separate projectToDelete state that captures the project name before the edit modal closes, ensuring the delete confirmation and API call use the correct project name.


___

### **PR Type**
Bug fix


___

### **Description**
- Preserve project name when opening delete modal from edit modal

- Add separate `projectToDelete` state to prevent name reset

- Update delete modal to use `projectToDelete` instead of `projectName`

- Fix delete operation to check `projectToDelete` instead of modal mode


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Edit Modal Open<br/>projectName set"] -->|"openDeleteModal()"| B["Save projectName<br/>to projectToDelete"]
  B -->|"closeModal() triggered"| C["projectName reset to ''"]
  C -->|"Delete Modal Opens"| D["Uses projectToDelete<br/>for confirmation"]
  D -->|"deleteProject()"| E["API call with<br/>correct project name"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useProjectModal.ts</strong><dd><code>Preserve project name across modal transitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

designer/src/hooks/useProjectModal.ts

<ul><li>Add <code>projectToDelete</code> state to interface and hook implementation<br> <li> Store project name in <code>projectToDelete</code> before closing edit modal in <br><code>openDeleteModal()</code><br> <li> Reset <code>projectToDelete</code> when closing delete modal in <code>closeDeleteModal()</code><br> <li> Update <code>deleteProject()</code> to use <code>projectToDelete</code> instead of <code>projectName</code> <br>and modal mode check<br> <li> Add explanatory comments about Radix Dialog's <code>onOpenChange</code> callback <br>behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/735/files#diff-b99678e85fc8e6a1e242377fe2088acc4055a860713adb9de89925407018a09a">+13/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>App.tsx</strong><dd><code>Pass correct project name to delete modal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

designer/src/App.tsx

<ul><li>Update <code>DeleteProjectModal</code> prop to use <code>modal.projectToDelete</code> instead of <br><code>modal.projectName</code></ul>


</details>


  </td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/735/files#diff-9f4c93bd3171b21497cebc8c7667ba2982bcecb3815807b43f7b2795af2a2036">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

