### PR TITLE
Remove redundant save calls causing 404 and 500 on train (anomaly and classifier) 

### DIFF
--- a/designer/src/hooks/useMLModels.ts
+++ b/designer/src/hooks/useMLModels.ts
@@ -242,23 +242,18 @@ export function useDeleteAnomalyModel() {
 // =============================================================================
 
 /**
- * Train and save a classifier in one operation
+ * Train a classifier (fit auto-saves the model)
  */
 export function useTrainAndSaveClassifier() {
   const queryClient = useQueryClient()
 
   return useMutation({
     mutationFn: async (request: ClassifierFitRequest) => {
-      // First fit the model
+      // Fit the model - this auto-saves to disk
       const fitResult = await mlService.fitClassifier(request)
 
-      // Then save it to disk (pass description to save endpoint)
-      const saveResult = await mlService.saveClassifier({
-        model: fitResult.versioned_name,
-        description: request.description,
-      })
-
-      return { fitResult, saveResult }
+      // No separate save call needed - fit endpoint auto-saves
+      return { fitResult }
     },
     onSuccess: () => {
       // Invalidate and force refetch to ensure models list is up to date
@@ -271,24 +266,18 @@ export function useTrainAndSaveClassifier() {
 }
 
 /**
- * Train and save an anomaly detector in one operation
+ * Train an anomaly detector (fit auto-saves the model)
  */
 export function useTrainAndSaveAnomaly() {
   const queryClient = useQueryClient()
 
   return useMutation({
     mutationFn: async (request: AnomalyFitRequest) => {
-      // First fit the model
+      // Fit the model - this auto-saves to disk
       const fitResult = await mlService.fitAnomaly(request)
 
-      // Then save it to disk (pass description to save endpoint)
-      const saveResult = await mlService.saveAnomaly({
-        model: fitResult.versioned_name,
-        backend: request.backend || 'isolation_forest',
-        description: request.description,
-      })
-
-      return { fitResult, saveResult }
+      // No separate save call needed - fit endpoint auto-saves
+      return { fitResult }
     },
     onSuccess: () => {
       // Invalidate and force refetch to ensure models list is up to date

--- a/server/api/routers/ml/router.py
+++ b/server/api/routers/ml/router.py
@@ -83,6 +83,10 @@ async def fit_classifier(request: ClassifierFitRequest) -> dict[str, Any]:
         batch_size=request.batch_size,
     )
 
+    # Save description metadata if provided (model auto-saves during fit)
+    if request.description:
+        MLModelService.save_description("classifier", versioned_name, request.description)
+
     # Add versioning info to response
     result["base_name"] = request.model
     result["versioned_name"] = versioned_name
@@ -280,6 +284,10 @@ async def fit_anomaly_detector(request: AnomalyFitRequest) -> dict[str, Any]:
         epochs=request.epochs,
         batch_size=request.batch_size,
     )
+
+    # Save description metadata if provided (model auto-saves during fit)
+    if request.description:
+        MLModelService.save_description("anomaly", versioned_name, request.description)
 
     # Add versioning info to response
     result["base_name"] = request.model


### PR DESCRIPTION
### **User description**
The Universal Runtime removed /v1/anomaly/save and /v1/classifier/save endpoints (models now auto-save during fit), but the frontend hooks still called them after fit completed, causing 404 errors.

- Remove saveAnomaly() call from useTrainAndSaveAnomaly hook
- Remove saveClassifier() call from useTrainAndSaveClassifier hook
- Add description saving to server fit endpoints (was previously in save)

@rgthelen you fix this in your PR but I wanted to get a smaller fix out


___

### **PR Type**
Bug fix


___

### **Description**
- Remove redundant save API calls causing 404 errors after model training

- Move description metadata saving into fit endpoints (auto-save during fit)

- Simplify training hooks to eliminate separate save operations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Frontend Train Hook"] -->|"fit request with description"| B["fit_classifier/fit_anomaly endpoint"]
  B -->|"auto-saves model"| C["Model saved to disk"]
  B -->|"saves description if provided"| D["Description metadata saved"]
  E["Old: separate save call"] -.->|"removed"| F["404 error"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>router.py</strong><dd><code>Add description saving to fit endpoints</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/api/routers/ml/router.py

<ul><li>Add description metadata saving to <code>fit_classifier</code> endpoint after model <br>training<br> <li> Add description metadata saving to <code>fit_anomaly_detector</code> endpoint after <br>model training<br> <li> Preserve description handling that was previously in separate save <br>endpoints</ul>


</details>


  </td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/741/files#diff-13792ae3ab8a4e252cd250aad9f07d8eef1498935f0129358fb5569712414e3c">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>useMLModels.ts</strong><dd><code>Remove redundant save calls from training hooks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

designer/src/hooks/useMLModels.ts

<ul><li>Remove <code>saveClassifier()</code> call from <code>useTrainAndSaveClassifier</code> hook<br> <li> Remove <code>saveAnomaly()</code> call from <code>useTrainAndSaveAnomaly</code> hook<br> <li> Update hook documentation to clarify auto-save behavior during fit<br> <li> Simplify mutation return values to only include fit results</ul>


</details>


  </td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/741/files#diff-6ccaba3b8886020a63d1e80eaaec81a6a512a4a491afa749085cfce28e582d52">+8/-19</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

