### PR TITLE
ci: improve E2E workflow resilience to runner queue delays

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -15,6 +15,10 @@ permissions:
   contents: read
   actions: read
 
+concurrency:
+  group: cli-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-cli:
     name: Build CLI Binaries

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,6 +16,10 @@ on:
 env:
   NX_NO_CLOUD: true
 
+concurrency:
+  group: e2e-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # ============================================================
   # Notify PR that E2E tests are starting
@@ -151,22 +155,32 @@ jobs:
           fi
           echo "Looking for CLI build for commit: $COMMIT_SHA"
 
-          # Wait up to 15 minutes for the CLI workflow to complete
-          MAX_ATTEMPTS=30
+          # Wait up to 30 minutes for the CLI workflow to complete
+          # This accounts for GitHub runner queue delays, not just build time
+          MAX_ATTEMPTS=60
           SLEEP_TIME=30
+          START_TIME=$(date +%s)
+          PREV_STATUS=""
 
           for i in $(seq 1 $MAX_ATTEMPTS); do
-            echo "Attempt $i/$MAX_ATTEMPTS: Checking CLI workflow status..."
+            CURRENT_TIME=$(date +%s)
+            ELAPSED=$(( (CURRENT_TIME - START_TIME) / 60 ))
+            REMAINING=$(( (MAX_ATTEMPTS - i) * SLEEP_TIME / 60 ))
+
+            echo ""
+            echo "Attempt $i/$MAX_ATTEMPTS (${ELAPSED}m elapsed, ~${REMAINING}m remaining)"
 
             # Find the CLI workflow run for this commit
             RUN_INFO=$(gh api \
               -H "Accept: application/vnd.github+json" \
               "/repos/${{ github.repository }}/actions/workflows/cli.yml/runs?head_sha=$COMMIT_SHA&per_page=1" \
-              --jq '.workflow_runs[0] | {id: .id, status: .status, conclusion: .conclusion}' 2>/dev/null || echo "{}")
+              --jq '.workflow_runs[0] | {id: .id, status: .status, conclusion: .conclusion, created_at: .created_at, run_started_at: .run_started_at}' 2>/dev/null || echo "{}")
 
             RUN_ID=$(echo "$RUN_INFO" | jq -r '.id // empty')
             STATUS=$(echo "$RUN_INFO" | jq -r '.status // empty')
             CONCLUSION=$(echo "$RUN_INFO" | jq -r '.conclusion // empty')
+            CREATED_AT=$(echo "$RUN_INFO" | jq -r '.created_at // empty')
+            RUN_STARTED_AT=$(echo "$RUN_INFO" | jq -r '.run_started_at // empty')
 
             if [ -z "$RUN_ID" ]; then
               echo "  No CLI workflow run found yet, waiting..."
@@ -174,24 +188,92 @@ jobs:
               continue
             fi
 
-            echo "  Found run $RUN_ID: status=$STATUS, conclusion=$CONCLUSION"
+            echo "  CLI workflow $RUN_ID: status=$STATUS, conclusion=$CONCLUSION"
 
-            if [ "$STATUS" = "completed" ]; then
-              if [ "$CONCLUSION" = "success" ]; then
-                echo "✓ CLI workflow completed successfully!"
-                echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT
-                exit 0
-              else
-                echo "❌ CLI workflow failed with conclusion: $CONCLUSION"
-                exit 1
-              fi
+            # Detect status transitions
+            if [ -n "$PREV_STATUS" ] && [ "$STATUS" != "$PREV_STATUS" ]; then
+              echo "  Status changed: $PREV_STATUS → $STATUS"
             fi
+            PREV_STATUS="$STATUS"
 
-            echo "  Workflow still running, waiting ${SLEEP_TIME}s..."
+            # Get queue statistics for context
+            QUEUED_COUNT=$(gh api \
+              -H "Accept: application/vnd.github+json" \
+              "/repos/${{ github.repository }}/actions/workflows/cli.yml/runs?status=queued" \
+              --jq '.total_count' 2>/dev/null || echo "?")
+            IN_PROGRESS_COUNT=$(gh api \
+              -H "Accept: application/vnd.github+json" \
+              "/repos/${{ github.repository }}/actions/workflows/cli.yml/runs?status=in_progress" \
+              --jq '.total_count' 2>/dev/null || echo "?")
+            echo "  Queue status: $QUEUED_COUNT jobs queued, $IN_PROGRESS_COUNT running"
+
+            # Status-specific messaging
+            case "$STATUS" in
+              queued)
+                echo "  Waiting for GitHub runner..."
+                ;;
+              in_progress)
+                if [ -n "$RUN_STARTED_AT" ] && [ "$RUN_STARTED_AT" != "null" ]; then
+                  RUN_START_EPOCH=$(date -d "$RUN_STARTED_AT" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%SZ" "$RUN_STARTED_AT" +%s 2>/dev/null || echo "")
+                  if [ -n "$RUN_START_EPOCH" ]; then
+                    BUILD_DURATION=$(( (CURRENT_TIME - RUN_START_EPOCH) / 60 ))
+                    echo "  Building... (started ${BUILD_DURATION}m ago)"
+                  else
+                    echo "  Building..."
+                  fi
+                else
+                  echo "  Building..."
+                fi
+                ;;
+              completed)
+                if [ "$CONCLUSION" = "success" ]; then
+                  echo "✓ CLI workflow completed successfully!"
+                  echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT
+
+                  # Write job summary
+                  {
+                    echo "## CLI Build Wait Summary"
+                    echo ""
+                    echo "- **Total wait time**: ${ELAPSED}m"
+                    echo "- **Attempts**: $i/$MAX_ATTEMPTS"
+                    echo "- **CLI Run ID**: $RUN_ID"
+                    echo "- **Conclusion**: $CONCLUSION"
+                  } >> $GITHUB_STEP_SUMMARY
+
+                  exit 0
+                elif [ "$CONCLUSION" = "cancelled" ]; then
+                  echo "❌ CLI workflow was cancelled (likely by concurrency controls)"
+                  echo "  This can happen when a new commit is pushed while the previous build is queued."
+                  echo "  The E2E tests for the previous commit will not run."
+                  exit 1
+                else
+                  echo "❌ CLI workflow failed with conclusion: $CONCLUSION"
+                  exit 1
+                fi
+                ;;
+            esac
+
             sleep $SLEEP_TIME
           done
 
-          echo "❌ Timed out waiting for CLI workflow"
+          FINAL_ELAPSED=$(( ($(date +%s) - START_TIME) / 60 ))
+          echo ""
+          echo "❌ Timed out waiting for CLI workflow after ${FINAL_ELAPSED}m"
+          echo "  Last known status: $STATUS"
+          echo "  Queue stats at timeout: $QUEUED_COUNT queued, $IN_PROGRESS_COUNT running"
+
+          # Write timeout summary
+          {
+            echo "## CLI Build Wait - TIMEOUT"
+            echo ""
+            echo "- **Total wait time**: ${FINAL_ELAPSED}m"
+            echo "- **Last status**: $STATUS"
+            echo "- **Queue at timeout**: $QUEUED_COUNT queued, $IN_PROGRESS_COUNT running"
+            echo ""
+            echo "The CLI workflow did not complete within the 30-minute timeout."
+            echo "This is usually caused by GitHub runner availability issues."
+          } >> $GITHUB_STEP_SUMMARY
+
           exit 1
 
   e2e-test:


### PR DESCRIPTION
### **User description**
## Summary

- Add concurrency controls to cancel stale workflow runs when new commits are pushed
- Increase wait-for-cli timeout from 15 to 30 minutes to handle GitHub runner queue delays
- Add queue position tracking and status transition detection for better observability
- Handle cancelled workflow conclusions gracefully with informative error messages

## Problem

The E2E workflow fails when the CLI build workflow gets stuck in GitHub's runner queue. In the [failing run](https://github.com/llama-farm/llamafarm/actions/runs/21494572595/job/61925861812?pr=740), the CLI workflow stayed in "queued" status for 15+ minutes (never started building), exceeding the 15-minute polling timeout.

**Root cause**: GitHub Actions runner availability, not slow builds. CLI builds complete in 2-4 minutes once a runner is assigned.

## Changes

### Concurrency Controls (cli.yml and e2e.yml)
- Cancel in-progress runs when new commits are pushed
- Reduces queue contention and provides faster feedback

### Improved Wait Logic (e2e.yml)
- Increased timeout from 15 to 30 minutes (60 attempts)
- Added queue position tracking via GitHub API
- Status transition detection (queued → in_progress → completed)
- Status-specific messaging with elapsed/remaining time
- Job summary output with wait statistics
- Handle "cancelled" conclusion with informative message

## Example Output

```
Attempt 5/60 (2m elapsed, ~28m remaining)
  CLI workflow 12345: status=queued
  Queue status: 3 jobs queued, 2 running
  Waiting for GitHub runner...

Attempt 10/60 (5m elapsed, ~25m remaining)
  CLI workflow 12345: status=in_progress
  Status changed: queued → in_progress
  Queue status: 2 jobs queued, 3 running
  Building... (started 30s ago)

Attempt 14/60 (7m elapsed, ~23m remaining)
  CLI workflow 12345: status=completed, conclusion=success
✓ CLI workflow completed successfully!
```

## Test Plan

- [ ] Push a commit to trigger both workflows
- [ ] Verify E2E logs show queue position and progress transitions
- [ ] Push another commit quickly to verify concurrency cancellation works
- [ ] Check job summary shows wait statistics


___

### **PR Type**
Enhancement


___

### **Description**
- Add concurrency controls to cancel stale workflow runs on new commits

- Increase CLI wait timeout from 15 to 30 minutes for runner queue delays

- Add queue position tracking and status transition detection for observability

- Implement job summaries with wait statistics and graceful cancellation handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Concurrency Controls"] --> B["Cancel Stale Runs"]
  C["Extended Timeout"] --> D["30 Minutes Wait"]
  E["Queue Tracking"] --> F["Status Transitions"]
  F --> G["Job Summary Output"]
  H["Cancellation Handling"] --> I["Informative Errors"]
  D --> J["Better Observability"]
  B --> J
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cli.yml</strong><dd><code>Add concurrency controls to CLI workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/cli.yml

<ul><li>Add concurrency group configuration to cancel in-progress runs on new <br>commits<br> <li> Prevents duplicate builds and reduces queue contention</ul>


</details>


  </td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/744/files#diff-302cf6f60da3e4f2ef11792a8bcf7b39c384c4c0e4e065b575e0aaf7d5fa5c79">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>e2e.yml</strong><dd><code>Enhance CLI wait logic with queue tracking and observability</code></dd></summary>
<hr>

.github/workflows/e2e.yml

<ul><li>Add concurrency group configuration matching CLI workflow pattern<br> <li> Increase wait timeout from 15 to 30 minutes (60 attempts) to handle <br>runner queue delays<br> <li> Add elapsed/remaining time tracking and status transition detection<br> <li> Implement queue statistics retrieval showing queued and in-progress <br>job counts<br> <li> Add status-specific messaging for queued, in_progress, and completed <br>states<br> <li> Include build duration calculation when workflow starts<br> <li> Handle cancelled conclusion with informative error message about <br>concurrency controls<br> <li> Generate job summary with wait statistics on success and timeout <br>scenarios</ul>


</details>


  </td>
  <td><a href="https://github.com/llama-farm/llamafarm/pull/744/files#diff-3e103440521ada06efd263ae09b259e5507e4b8f7408308dc227621ad9efa31e">+98/-16</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

