### PR TITLE
docs(vision): add documentation, demos, and examples

### DIFF
--- a/demos/vision/README.md
+++ b/demos/vision/README.md
@@ -1,0 +1,73 @@
+# Vision Demos
+
+Interactive demos for the LlamaFarm Vision system.
+
+## Prerequisites
+
+1. Start the Universal Runtime:
+   ```bash
+   cd runtimes/universal
+   uv run python server.py
+   ```
+
+2. Start the LlamaFarm Server:
+   ```bash
+   cd server
+   uv run python main.py
+   ```
+
+## Demos
+
+### 1. Basic Detection Demo
+Detects objects in sample images.
+
+```bash
+cd demos/vision
+python demo_detection.py
+```
+
+### 2. Classification Demo
+Zero-shot image classification with custom labels.
+
+```bash
+python demo_classification.py
+```
+
+### 3. Embedding & Similarity Demo
+Generate embeddings and compute image similarity.
+
+```bash
+python demo_embeddings.py
+```
+
+### 4. Streaming Detection Demo
+Simulates real-time video analysis with cooldown.
+
+```bash
+python demo_streaming.py
+```
+
+### 5. Training Demo
+Fine-tune YOLO on a small custom dataset.
+
+```bash
+python demo_training.py
+```
+
+### 6. Full Pipeline Demo
+End-to-end: detect → classify → store → train.
+
+```bash
+python demo_full_pipeline.py
+```
+
+## Sample Images
+
+The demos automatically download sample images from:
+- Ultralytics test images (COCO objects)
+- Public domain images
+
+Or provide your own:
+```bash
+python demo_detection.py --image /path/to/your/image.jpg
+```

--- a/demos/vision/demo_classification.py
+++ b/demos/vision/demo_classification.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""
+Demo: Zero-Shot Image Classification with CLIP
+
+Demonstrates:
+- Zero-shot classification with custom labels
+- Confidence scores for all classes
+- Using different CLIP model variants
+"""
+
+import argparse
+import base64
+import os
+import sys
+
+import httpx
+
+API_URL = os.environ.get("LLAMAFARM_URL", "http://localhost:14345")
+RUNTIME_URL = API_URL
+
+# Sample classification scenarios
+SCENARIOS = [
+    {
+        "name": "Animal Classification",
+        "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/3/3a/Cat03.jpg/1200px-Cat03.jpg",
+        "classes": ["cat", "dog", "bird", "fish", "rabbit"],
+        "expected": "cat",
+    },
+    {
+        "name": "Vehicle Classification",
+        "url": "https://ultralytics.com/images/bus.jpg",
+        "classes": ["car", "bus", "truck", "motorcycle", "bicycle"],
+        "expected": "bus",
+    },
+    {
+        "name": "Scene Classification",
+        "url": "https://ultralytics.com/images/zidane.jpg",
+        "classes": [
+            "a soccer game",
+            "a tennis match",
+            "a basketball game",
+            "a golf course",
+            "a swimming pool",
+        ],
+        "expected": "a soccer game",
+    },
+    {
+        "name": "Fine-Grained Classification",
+        "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/3/3a/Cat03.jpg/1200px-Cat03.jpg",
+        "classes": [
+            "a tabby cat",
+            "a siamese cat",
+            "a persian cat",
+            "a black cat",
+            "an orange cat",
+        ],
+        "expected": "a tabby cat",
+    },
+]
+
+
+def download_image(url: str) -> bytes:
+    """Download image from URL."""
+    print(f"  Downloading image...")
+    response = httpx.get(url, timeout=30.0, follow_redirects=True)
+    response.raise_for_status()
+    return response.content
+
+
+def classify_image(image_b64: str, classes: list[str], model: str = "clip-vit-base") -> dict:
+    """Classify image using CLIP."""
+    response = httpx.post(
+        f"{RUNTIME_URL}/v1/vision/classify",
+        json={
+            "model": model,
+            "image": image_b64,
+            "classes": classes,
+            "top_k": len(classes),
+        },
+        timeout=60.0,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def print_classification(result: dict, scenario: dict):
+    """Pretty-print classification results."""
+    print(f"\n{'='*60}")
+    print(f"🏷️  Scenario: {scenario['name']}")
+    print(f"{'='*60}")
+    
+    print(f"Model: {result.get('model', 'unknown')}")
+    print(f"Inference time: {result.get('inference_time_ms', 0):.1f}ms")
+    
+    predicted = result.get("class", "unknown")
+    confidence = result.get("confidence", 0)
+    
+    print(f"\n🎯 Prediction: {predicted}")
+    print(f"   Confidence: {confidence:.1%}")
+    
+    print(f"\n📊 All Scores:")
+    scores = result.get("scores", {})
+    sorted_scores = sorted(scores.items(), key=lambda x: x[1], reverse=True)
+    
+    for i, (cls, score) in enumerate(sorted_scores, 1):
+        bar = "█" * int(score * 30) + "░" * (30 - int(score * 30))
+        marker = " ✓" if cls == predicted else ""
+        print(f"  {i}. [{bar}] {score:5.1%} {cls}{marker}")
+    
+    # Check expected
+    expected = scenario.get("expected", "")
+    if predicted == expected:
+        print(f"\n✅ Correct! Matched expected: {expected}")
+    else:
+        print(f"\n⚠️  Expected '{expected}' but got '{predicted}'")
+
+
+def run_demo(model: str = "clip-vit-base"):
+    """Run the classification demo."""
+    print("🏷️  LlamaFarm Vision - Zero-Shot Classification Demo")
+    print("=" * 60)
+    print(f"Using model: {model}")
+    print(f"Running {len(SCENARIOS)} classification scenarios...\n")
+    
+    correct = 0
+    total = len(SCENARIOS)
+    
+    for scenario in SCENARIOS:
+        try:
+            image_data = download_image(scenario["url"])
+            image_b64 = base64.b64encode(image_data).decode()
+            
+            result = classify_image(image_b64, scenario["classes"], model)
+            print_classification(result, scenario)
+            
+            if result.get("class") == scenario.get("expected"):
+                correct += 1
+                
+        except Exception as e:
+            print(f"❌ Error in {scenario['name']}: {e}")
+    
+    print("\n" + "=" * 60)
+    print(f"📈 Results: {correct}/{total} scenarios classified correctly")
+    print("✨ Classification demo complete!")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Vision Classification Demo")
+    parser.add_argument("--model", "-m", default="clip-vit-base",
+                       help="CLIP model variant (clip-vit-base, siglip-base, etc.)")
+    parser.add_argument("--image", "-i", help="Custom image path")
+    parser.add_argument("--classes", "-c", nargs="+", 
+                       help="Custom classes (requires --image)")
+    args = parser.parse_args()
+    
+    if args.image and args.classes:
+        # Custom classification
+        print("🏷️  Custom Classification")
+        with open(args.image, "rb") as f:
+            image_b64 = base64.b64encode(f.read()).decode()
+        
+        result = classify_image(image_b64, args.classes, args.model)
+        scenario = {"name": "Custom", "classes": args.classes, "expected": ""}
+        print_classification(result, scenario)
+    else:
+        # Run all scenarios
+        try:
+            run_demo(args.model)
+        except httpx.ConnectError:
+            print("❌ Could not connect to runtime!")
+            print("   Make sure the runtime is running:")
+            print("   cd runtimes/universal && uv run python server.py")
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/demos/vision/demo_detection.py
+++ b/demos/vision/demo_detection.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""
+Demo: Object Detection with YOLO
+
+Demonstrates:
+- Loading images from URL or file
+- Running YOLO detection
+- Visualizing results with bounding boxes
+"""
+
+import argparse
+import base64
+import json
+import sys
+from pathlib import Path
+
+import httpx
+
+# LlamaFarm API server (proxies to Universal Runtime)
+API_URL = os.environ.get("LLAMAFARM_URL", "http://localhost:14345")
+RUNTIME_URL = API_URL  # backwards compat
+SERVER_URL = API_URL
+
+# Sample images for demo
+SAMPLE_IMAGES = [
+    {
+        "name": "Zidane Soccer",
+        "url": "https://ultralytics.com/images/zidane.jpg",
+        "expected": ["person"],
+    },
+    {
+        "name": "Bus Scene",
+        "url": "https://ultralytics.com/images/bus.jpg",
+        "expected": ["person", "bus"],
+    },
+]
+
+
+def download_image(url: str) -> bytes:
+    """Download image from URL."""
+    print(f"  Downloading: {url}")
+    response = httpx.get(url, timeout=30.0)
+    response.raise_for_status()
+    return response.content
+
+
+def detect_via_runtime(image_b64: str, model: str = "yolov8n") -> dict:
+    """Call runtime detection endpoint directly."""
+    response = httpx.post(
+        f"{RUNTIME_URL}/v1/vision/detect",
+        json={
+            "model": model,
+            "image": image_b64,
+            "confidence_threshold": 0.5,
+        },
+        timeout=60.0,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def detect_via_server(image_b64: str, model: str = "yolov8n") -> dict:
+    """Call server detection endpoint (proxies to runtime)."""
+    response = httpx.post(
+        f"{SERVER_URL}/v1/vision/detect",
+        json={
+            "model": model,
+            "image": image_b64,
+            "confidence_threshold": 0.5,
+        },
+        timeout=60.0,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def print_detections(result: dict, name: str):
+    """Pretty-print detection results."""
+    print(f"\n{'='*60}")
+    print(f"🖼️  Image: {name}")
+    print(f"{'='*60}")
+    
+    print(f"Model: {result.get('model', 'unknown')}")
+    print(f"Inference time: {result.get('inference_time_ms', 0):.1f}ms")
+    
+    detections = result.get("detections", [])
+    print(f"Detections: {len(detections)}")
+    
+    if detections:
+        print("\n📦 Detected Objects:")
+        for i, det in enumerate(detections, 1):
+            cls = det.get("class", "unknown")
+            conf = det.get("confidence", 0)
+            box = det.get("box", {})
+            
+            print(f"  {i}. {cls}")
+            print(f"     Confidence: {conf:.1%}")
+            print(f"     Box: ({box.get('x1', 0):.0f}, {box.get('y1', 0):.0f}) → "
+                  f"({box.get('x2', 0):.0f}, {box.get('y2', 0):.0f})")
+    else:
+        print("\n  (No objects detected)")
+
+
+def run_demo(image_path: str | None = None, model: str = "yolov8n", use_server: bool = False):
+    """Run the detection demo."""
+    detect_fn = detect_via_server if use_server else detect_via_runtime
+    print("🔍 LlamaFarm Vision - Object Detection Demo")
+    print("=" * 60)
+
+    if image_path:
+        # Use provided image
+        print(f"\nUsing custom image: {image_path}")
+        with open(image_path, "rb") as f:
+            image_data = f.read()
+        image_b64 = base64.b64encode(image_data).decode()
+
+        print(f"\nDetecting with {model}...")
+        result = detect_fn(image_b64, model)
+        print_detections(result, Path(image_path).name)
+    else:
+        # Use sample images
+        print(f"\nUsing {len(SAMPLE_IMAGES)} sample images...")
+
+        for sample in SAMPLE_IMAGES:
+            try:
+                image_data = download_image(sample["url"])
+                image_b64 = base64.b64encode(image_data).decode()
+
+                print(f"\nDetecting with {model}...")
+                result = detect_fn(image_b64, model)
+                print_detections(result, sample["name"])
+                
+                # Verify expected classes
+                detected_classes = {d["class"] for d in result.get("detections", [])}
+                expected = set(sample["expected"])
+                if expected & detected_classes:
+                    print(f"✅ Found expected: {expected & detected_classes}")
+                else:
+                    print(f"⚠️  Expected {expected} but got {detected_classes}")
+                    
+            except Exception as e:
+                print(f"❌ Error processing {sample['name']}: {e}")
+    
+    print("\n" + "=" * 60)
+    print("✨ Detection demo complete!")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Vision Detection Demo")
+    parser.add_argument("--image", "-i", help="Path to image file")
+    parser.add_argument("--model", "-m", default="yolov8n", 
+                       help="YOLO model variant (yolov8n, yolov8s, etc.)")
+    parser.add_argument("--server", action="store_true",
+                       help="Use server endpoint instead of runtime")
+    args = parser.parse_args()
+    
+    try:
+        run_demo(args.image, args.model, args.server)
+    except httpx.ConnectError:
+        print("❌ Could not connect to server!")
+        print("   Make sure the runtime is running:")
+        print("   cd runtimes/universal && uv run python server.py")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/demos/vision/demo_embeddings.py
+++ b/demos/vision/demo_embeddings.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""
+Demo: Image Embeddings with CLIP
+
+Demonstrates:
+- Generating image embeddings
+- Generating text embeddings
+- Computing cross-modal similarity (image ↔ text)
+- Image-to-image similarity search
+"""
+
+import argparse
+import base64
+import os
+import sys
+from typing import List
+
+import httpx
+import numpy as np
+
+API_URL = os.environ.get("LLAMAFARM_URL", "http://localhost:14345")
+RUNTIME_URL = API_URL
+
+# Sample images for similarity demo
+SAMPLE_IMAGES = [
+    {
+        "name": "Cat",
+        "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/3/3a/Cat03.jpg/1200px-Cat03.jpg",
+    },
+    {
+        "name": "Soccer",
+        "url": "https://ultralytics.com/images/zidane.jpg",
+    },
+    {
+        "name": "Bus",
+        "url": "https://ultralytics.com/images/bus.jpg",
+    },
+]
+
+# Text queries for cross-modal search
+TEXT_QUERIES = [
+    "a photo of a cat",
+    "people playing soccer",
+    "a bus on the street",
+    "a dog running",
+    "a beautiful sunset",
+]
+
+
+def download_image(url: str) -> bytes:
+    """Download image from URL."""
+    response = httpx.get(url, timeout=30.0, follow_redirects=True)
+    response.raise_for_status()
+    return response.content
+
+
+def embed_images(images_b64: List[str], model: str = "clip-vit-base") -> dict:
+    """Generate embeddings for images."""
+    response = httpx.post(
+        f"{RUNTIME_URL}/v1/vision/embed/image",
+        json={
+            "model": model,
+            "images": images_b64,
+        },
+        timeout=120.0,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def embed_texts(texts: List[str], model: str = "clip-vit-base") -> dict:
+    """Generate embeddings for texts."""
+    response = httpx.post(
+        f"{RUNTIME_URL}/v1/vision/embed/text",
+        json={
+            "model": model,
+            "texts": texts,
+        },
+        timeout=60.0,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def cosine_similarity(a: List[float], b: List[float]) -> float:
+    """Compute cosine similarity between two vectors."""
+    a = np.array(a)
+    b = np.array(b)
+    return float(np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b)))
+
+
+def run_demo(model: str = "clip-vit-base"):
+    """Run the embeddings demo."""
+    print("🔢 LlamaFarm Vision - Embeddings Demo")
+    print("=" * 60)
+    print(f"Using model: {model}")
+    
+    # === Part 1: Generate Image Embeddings ===
+    print("\n📸 Part 1: Image Embeddings")
+    print("-" * 40)
+    
+    images_b64 = []
+    image_names = []
+    
+    for sample in SAMPLE_IMAGES:
+        print(f"  Downloading {sample['name']}...")
+        image_data = download_image(sample["url"])
+        images_b64.append(base64.b64encode(image_data).decode())
+        image_names.append(sample["name"])
+    
+    print("\n  Generating embeddings...")
+    img_result = embed_images(images_b64, model)
+    img_embeddings = img_result["embeddings"]
+    
+    print(f"  ✅ Generated {len(img_embeddings)} image embeddings")
+    print(f"  Dimensions: {img_result['dimensions']}")
+    print(f"  Inference time: {img_result['inference_time_ms']:.1f}ms")
+    
+    # === Part 2: Generate Text Embeddings ===
+    print("\n📝 Part 2: Text Embeddings")
+    print("-" * 40)
+    
+    print(f"  Embedding {len(TEXT_QUERIES)} text queries...")
+    txt_result = embed_texts(TEXT_QUERIES, model)
+    txt_embeddings = txt_result["embeddings"]
+    
+    print(f"  ✅ Generated {len(txt_embeddings)} text embeddings")
+    print(f"  Inference time: {txt_result['inference_time_ms']:.1f}ms")
+    
+    # === Part 3: Cross-Modal Similarity ===
+    print("\n🔗 Part 3: Cross-Modal Similarity (Image ↔ Text)")
+    print("-" * 40)
+    
+    # Build similarity matrix
+    print("\n  Similarity Matrix (Image → Text):\n")
+    
+    # Header
+    header = "           " + " ".join(f"{name:>10}" for name in image_names)
+    print(header)
+    print("  " + "-" * (len(header) - 2))
+    
+    for i, query in enumerate(TEXT_QUERIES):
+        row = f"  {query[:25]:25}"
+        for j, _ in enumerate(image_names):
+            sim = cosine_similarity(txt_embeddings[i], img_embeddings[j])
+            row += f" {sim:>10.3f}"
+        print(row)
+    
+    # === Part 4: Image Search by Text ===
+    print("\n\n🔍 Part 4: Search Images by Text Query")
+    print("-" * 40)
+    
+    for query in TEXT_QUERIES[:3]:
+        query_emb = txt_embeddings[TEXT_QUERIES.index(query)]
+        
+        similarities = [
+            (name, cosine_similarity(query_emb, img_emb))
+            for name, img_emb in zip(image_names, img_embeddings)
+        ]
+        similarities.sort(key=lambda x: x[1], reverse=True)
+        
+        print(f"\n  Query: \"{query}\"")
+        print(f"  Results:")
+        for rank, (name, sim) in enumerate(similarities, 1):
+            bar = "█" * int(sim * 20) + "░" * (20 - int(sim * 20))
+            print(f"    {rank}. [{bar}] {sim:.3f} {name}")
+    
+    # === Part 5: Image-to-Image Similarity ===
+    print("\n\n🖼️  Part 5: Image-to-Image Similarity")
+    print("-" * 40)
+    
+    print("\n  Pairwise similarity:")
+    for i, name_i in enumerate(image_names):
+        for j, name_j in enumerate(image_names):
+            if j > i:
+                sim = cosine_similarity(img_embeddings[i], img_embeddings[j])
+                print(f"    {name_i} ↔ {name_j}: {sim:.3f}")
+    
+    print("\n" + "=" * 60)
+    print("✨ Embeddings demo complete!")
+    print("\n💡 Use cases for embeddings:")
+    print("   • Image search (find similar images)")
+    print("   • Image-text matching (caption retrieval)")
+    print("   • Deduplication (find near-duplicates)")
+    print("   • RAG (retrieve relevant images for context)")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Vision Embeddings Demo")
+    parser.add_argument("--model", "-m", default="clip-vit-base",
+                       help="CLIP model variant")
+    args = parser.parse_args()
+    
+    try:
+        run_demo(args.model)
+    except httpx.ConnectError:
+        print("❌ Could not connect to runtime!")
+        print("   Make sure the runtime is running:")
+        print("   cd runtimes/universal && uv run python server.py")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/demos/vision/demo_full_pipeline.py
+++ b/demos/vision/demo_full_pipeline.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+"""
+Demo: Full Vision Pipeline
+
+Demonstrates the complete end-to-end workflow:
+1. Detection: Find objects in images
+2. Classification: Classify detected regions
+3. Embedding: Generate vector representations
+4. Storage: Persist images and detections
+5. Similarity: Find similar images
+6. Review Queue: Simulate human review
+
+This shows how the components work together.
+"""
+
+import argparse
+import base64
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+import httpx
+import numpy as np
+
+API_URL = os.environ.get("LLAMAFARM_URL", "http://localhost:14345")
+RUNTIME_URL = API_URL
+
+# Sample images
+IMAGES = [
+    {
+        "name": "Soccer Match",
+        "url": "https://ultralytics.com/images/zidane.jpg",
+    },
+    {
+        "name": "Street Scene",
+        "url": "https://ultralytics.com/images/bus.jpg",
+    },
+    {
+        "name": "Cat Portrait",
+        "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/3/3a/Cat03.jpg/1200px-Cat03.jpg",
+    },
+]
+
+
+def download_image(url: str) -> bytes:
+    """Download image from URL."""
+    response = httpx.get(url, timeout=30.0, follow_redirects=True)
+    response.raise_for_status()
+    return response.content
+
+
+def detect(image_b64: str, model: str = "yolov8n") -> dict:
+    """Run object detection."""
+    response = httpx.post(
+        f"{RUNTIME_URL}/v1/vision/detect",
+        json={"model": model, "image": image_b64, "confidence_threshold": 0.5},
+        timeout=60.0,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def classify(image_b64: str, classes: list, model: str = "clip-vit-base") -> dict:
+    """Run classification."""
+    response = httpx.post(
+        f"{RUNTIME_URL}/v1/vision/classify",
+        json={"model": model, "image": image_b64, "classes": classes},
+        timeout=60.0,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def embed(images_b64: list, model: str = "clip-vit-base") -> dict:
+    """Generate embeddings."""
+    response = httpx.post(
+        f"{RUNTIME_URL}/v1/vision/embed",
+        json={"model": model, "images": images_b64},
+        timeout=120.0,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def cosine_similarity(a, b):
+    """Compute cosine similarity."""
+    a = np.array(a)
+    b = np.array(b)
+    return float(np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b)))
+
+
+class SimpleImageStore:
+    """Simple in-memory image store for demo."""
+    
+    def __init__(self, db_path: str = ":memory:"):
+        self.conn = sqlite3.connect(db_path)
+        self._create_tables()
+        self.images = {}
+        self.embeddings = {}
+    
+    def _create_tables(self):
+        self.conn.execute("""
+            CREATE TABLE IF NOT EXISTS images (
+                id TEXT PRIMARY KEY,
+                name TEXT,
+                source TEXT,
+                created_at REAL
+            )
+        """)
+        self.conn.execute("""
+            CREATE TABLE IF NOT EXISTS detections (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                image_id TEXT,
+                class_name TEXT,
+                confidence REAL,
+                box TEXT,
+                FOREIGN KEY (image_id) REFERENCES images(id)
+            )
+        """)
+        self.conn.execute("""
+            CREATE TABLE IF NOT EXISTS labels (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                image_id TEXT,
+                class_name TEXT,
+                annotator TEXT,
+                FOREIGN KEY (image_id) REFERENCES images(id)
+            )
+        """)
+        self.conn.commit()
+    
+    def store_image(self, image_id: str, name: str, image_data: bytes, embedding: list):
+        self.conn.execute(
+            "INSERT INTO images (id, name, source, created_at) VALUES (?, ?, ?, ?)",
+            (image_id, name, "demo", time.time())
+        )
+        self.conn.commit()
+        self.images[image_id] = image_data
+        self.embeddings[image_id] = embedding
+        return image_id
+    
+    def store_detection(self, image_id: str, class_name: str, confidence: float, box: dict):
+        self.conn.execute(
+            "INSERT INTO detections (image_id, class_name, confidence, box) VALUES (?, ?, ?, ?)",
+            (image_id, class_name, confidence, json.dumps(box))
+        )
+        self.conn.commit()
+    
+    def add_label(self, image_id: str, class_name: str, annotator: str = "demo"):
+        self.conn.execute(
+            "INSERT INTO labels (image_id, class_name, annotator) VALUES (?, ?, ?)",
+            (image_id, class_name, annotator)
+        )
+        self.conn.commit()
+    
+    def get_stats(self) -> dict:
+        images = self.conn.execute("SELECT COUNT(*) FROM images").fetchone()[0]
+        detections = self.conn.execute("SELECT COUNT(*) FROM detections").fetchone()[0]
+        labels = self.conn.execute("SELECT COUNT(*) FROM labels").fetchone()[0]
+        return {"images": images, "detections": detections, "labels": labels}
+    
+    def find_similar(self, query_id: str, k: int = 3) -> list:
+        """Find most similar images to query."""
+        query_emb = self.embeddings.get(query_id)
+        if not query_emb:
+            return []
+        
+        similarities = []
+        for img_id, emb in self.embeddings.items():
+            if img_id != query_id:
+                sim = cosine_similarity(query_emb, emb)
+                name = self.conn.execute(
+                    "SELECT name FROM images WHERE id = ?", (img_id,)
+                ).fetchone()[0]
+                similarities.append((img_id, name, sim))
+        
+        similarities.sort(key=lambda x: x[2], reverse=True)
+        return similarities[:k]
+
+
+def run_pipeline():
+    """Run the full pipeline demo."""
+    print("🚀 LlamaFarm Vision - Full Pipeline Demo")
+    print("=" * 70)
+    
+    store = SimpleImageStore()
+    
+    # ═══════════════════════════════════════════════════════════════
+    # STEP 1: Load and Store Images
+    # ═══════════════════════════════════════════════════════════════
+    print("\n📥 Step 1: Loading Images")
+    print("-" * 50)
+    
+    images_data = {}
+    for i, img_info in enumerate(IMAGES):
+        print(f"  [{i+1}/{len(IMAGES)}] Downloading: {img_info['name']}")
+        data = download_image(img_info["url"])
+        images_data[img_info["name"]] = data
+    
+    print(f"  ✅ Loaded {len(images_data)} images")
+    
+    # ═══════════════════════════════════════════════════════════════
+    # STEP 2: Generate Embeddings for All Images
+    # ═══════════════════════════════════════════════════════════════
+    print("\n🔢 Step 2: Generating Embeddings")
+    print("-" * 50)
+    
+    images_b64 = [base64.b64encode(d).decode() for d in images_data.values()]
+    embed_result = embed(images_b64)
+    embeddings = embed_result["embeddings"]
+    
+    print(f"  ✅ Generated {len(embeddings)} embeddings")
+    print(f"  Dimensions: {embed_result['dimensions']}")
+    
+    # Store images with embeddings
+    for (name, data), emb in zip(images_data.items(), embeddings):
+        img_id = f"img_{name.lower().replace(' ', '_')}"
+        store.store_image(img_id, name, data, emb)
+    
+    # ═══════════════════════════════════════════════════════════════
+    # STEP 3: Run Detection on Each Image
+    # ═══════════════════════════════════════════════════════════════
+    print("\n🔍 Step 3: Object Detection")
+    print("-" * 50)
+    
+    total_detections = 0
+    for (name, data), b64 in zip(images_data.items(), images_b64):
+        result = detect(b64)
+        detections = result.get("detections", [])
+        
+        print(f"\n  📸 {name}:")
+        if detections:
+            for det in detections:
+                cls = det["class"]
+                conf = det["confidence"]
+                print(f"      • {cls}: {conf:.1%}")
+                
+                # Store detection
+                img_id = f"img_{name.lower().replace(' ', '_')}"
+                store.store_detection(img_id, cls, conf, det["box"])
+                total_detections += 1
+        else:
+            print("      (no objects detected)")
+    
+    print(f"\n  ✅ Total detections: {total_detections}")
+    
+    # ═══════════════════════════════════════════════════════════════
+    # STEP 4: Classify Images
+    # ═══════════════════════════════════════════════════════════════
+    print("\n🏷️  Step 4: Scene Classification")
+    print("-" * 50)
+    
+    scene_classes = [
+        "sports event",
+        "street scene",
+        "animal portrait",
+        "indoor scene",
+        "landscape",
+    ]
+    
+    for (name, _), b64 in zip(images_data.items(), images_b64):
+        result = classify(b64, scene_classes)
+        predicted = result["class"]
+        confidence = result["confidence"]
+        
+        print(f"  📸 {name}: {predicted} ({confidence:.1%})")
+        
+        # Add label
+        img_id = f"img_{name.lower().replace(' ', '_')}"
+        store.add_label(img_id, predicted, "clip_classifier")
+    
+    # ═══════════════════════════════════════════════════════════════
+    # STEP 5: Similarity Search
+    # ═══════════════════════════════════════════════════════════════
+    print("\n🔗 Step 5: Similarity Search")
+    print("-" * 50)
+    
+    # Find images similar to each query
+    for img_id in ["img_soccer_match", "img_cat_portrait"]:
+        name = img_id.replace("img_", "").replace("_", " ").title()
+        similar = store.find_similar(img_id, k=2)
+        
+        print(f"\n  Similar to '{name}':")
+        for _, sim_name, score in similar:
+            print(f"      → {sim_name}: {score:.3f}")
+    
+    # ═══════════════════════════════════════════════════════════════
+    # STEP 6: Simulated Review Queue
+    # ═══════════════════════════════════════════════════════════════
+    print("\n👤 Step 6: Human Review Simulation")
+    print("-" * 50)
+    
+    # Simulate human adding labels
+    human_labels = [
+        ("img_soccer_match", "Zinedine Zidane"),
+        ("img_cat_portrait", "tabby cat"),
+        ("img_street_scene", "London bus"),
+    ]
+    
+    for img_id, label in human_labels:
+        store.add_label(img_id, label, "human_reviewer")
+        print(f"  ✏️  Added label '{label}' to {img_id}")
+    
+    # ═══════════════════════════════════════════════════════════════
+    # SUMMARY
+    # ═══════════════════════════════════════════════════════════════
+    print("\n" + "=" * 70)
+    print("📊 Pipeline Summary")
+    print("=" * 70)
+    
+    stats = store.get_stats()
+    print(f"  Images stored: {stats['images']}")
+    print(f"  Detections recorded: {stats['detections']}")
+    print(f"  Labels added: {stats['labels']}")
+    
+    print("\n🔄 Pipeline Flow:")
+    print("""
+    ┌─────────────┐    ┌───────────────┐    ┌─────────────────┐
+    │   Load      │ → │   Detect      │ → │   Classify      │
+    │   Images    │    │   Objects     │    │   Scenes        │
+    └─────────────┘    └───────────────┘    └─────────────────┘
+           │                  │                     │
+           ▼                  ▼                     ▼
+    ┌─────────────┐    ┌───────────────┐    ┌─────────────────┐
+    │   Generate  │ → │   Store       │ → │   Similarity    │
+    │   Embeddings│    │   Results     │    │   Search        │
+    └─────────────┘    └───────────────┘    └─────────────────┘
+           │                                        │
+           └────────────────────────────────────────┘
+                              ▼
+                    ┌─────────────────┐
+                    │   Human Review  │
+                    │   & Labeling    │
+                    └─────────────────┘
+    """)
+    
+    print("✨ Full pipeline demo complete!")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Full Vision Pipeline Demo")
+    args = parser.parse_args()
+    
+    try:
+        run_pipeline()
+    except httpx.ConnectError:
+        print("❌ Could not connect to runtime!")
+        print("   Make sure the runtime is running:")
+        print("   cd runtimes/universal && uv run python server.py")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/demos/vision/demo_streaming.py
+++ b/demos/vision/demo_streaming.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""
+Demo: Streaming Detection with Cooldown
+
+Demonstrates:
+- Starting a streaming session
+- Processing frames with action detection
+- Cooldown behavior (suppressing repeated triggers)
+- Session statistics
+"""
+
+import argparse
+import base64
+import os
+import sys
+import time
+
+import httpx
+
+API_URL = os.environ.get("LLAMAFARM_URL", "http://localhost:14345")
+RUNTIME_URL = API_URL
+
+# Simulated video frames (using same image repeatedly with slight variations)
+SAMPLE_IMAGE_URL = "https://ultralytics.com/images/zidane.jpg"
+
+
+def download_image(url: str) -> bytes:
+    """Download image from URL."""
+    response = httpx.get(url, timeout=30.0)
+    response.raise_for_status()
+    return response.content
+
+
+def start_session(
+    model: str = "yolov8n",
+    target_fps: float = 1.0,
+    confidence_threshold: float = 0.7,
+    action_classes: list = None,
+    cooldown_seconds: float = 5.0,
+) -> dict:
+    """Start a streaming session."""
+    payload = {
+        "model": model,
+        "target_fps": target_fps,
+        "confidence_threshold": confidence_threshold,
+        "cooldown_seconds": cooldown_seconds,
+    }
+    if action_classes:
+        payload["action_classes"] = action_classes
+    
+    response = httpx.post(
+        f"{RUNTIME_URL}/v1/vision/streaming/start",
+        json=payload,
+        timeout=30.0,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def process_frame(session_id: str, image_b64: str) -> dict:
+    """Process a frame in the session."""
+    response = httpx.post(
+        f"{RUNTIME_URL}/v1/vision/streaming/frame/{session_id}",
+        json={"image": image_b64},
+        timeout=30.0,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def stop_session(session_id: str) -> dict:
+    """Stop the session and get stats."""
+    response = httpx.post(
+        f"{RUNTIME_URL}/v1/vision/streaming/stop/{session_id}",
+        timeout=30.0,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def list_sessions() -> dict:
+    """List active sessions."""
+    response = httpx.get(
+        f"{RUNTIME_URL}/v1/vision/streaming/sessions",
+        timeout=30.0,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def run_demo(
+    num_frames: int = 10,
+    cooldown: float = 3.0,
+    frame_interval: float = 0.5,
+):
+    """Run the streaming demo."""
+    print("📹 LlamaFarm Vision - Streaming Detection Demo")
+    print("=" * 60)
+    
+    # Download sample image
+    print("\n📥 Downloading sample image...")
+    image_data = download_image(SAMPLE_IMAGE_URL)
+    image_b64 = base64.b64encode(image_data).decode()
+    print(f"  Image size: {len(image_data) / 1024:.1f} KB")
+    
+    # Start session
+    print("\n🎬 Starting streaming session...")
+    session = start_session(
+        model="yolov8n",
+        confidence_threshold=0.5,
+        action_classes=["person"],
+        cooldown_seconds=cooldown,
+    )
+    session_id = session["session_id"]
+    print(f"  Session ID: {session_id}")
+    print(f"  Model: {session['model']}")
+    print(f"  Cooldown: {cooldown}s")
+    
+    # Show active sessions
+    sessions = list_sessions()
+    print(f"  Active sessions: {len(sessions['sessions'])}")
+    
+    # Process frames
+    print(f"\n📊 Processing {num_frames} frames (interval: {frame_interval}s)...")
+    print("-" * 60)
+    
+    actions = 0
+    suppressed = 0
+    reviews = 0
+    
+    for i in range(1, num_frames + 1):
+        start_time = time.time()
+        
+        result = process_frame(session_id, image_b64)
+        
+        status = result["status"]
+        confidence = result.get("confidence", 0)
+        detections = result.get("detections", [])
+        is_suppressed = result.get("suppressed", False)
+        
+        # Status indicator
+        if status == "action":
+            icon = "🚨"
+            actions += 1
+        elif status == "review":
+            icon = "❓"
+            reviews += 1
+        else:
+            if is_suppressed:
+                icon = "🔇"
+                suppressed += 1
+            else:
+                icon = "✓ "
+        
+        # Detection info
+        det_info = ""
+        if detections:
+            classes = [d["class_name"] for d in detections]
+            det_info = f" [{', '.join(classes)}]"
+        
+        print(f"  Frame {i:2d}: {icon} {status:8s} "
+              f"conf={confidence:.2f}{det_info}")
+        
+        # Wait for next frame
+        elapsed = time.time() - start_time
+        if i < num_frames and frame_interval > elapsed:
+            time.sleep(frame_interval - elapsed)
+    
+    # Stop session
+    print("\n⏹️  Stopping session...")
+    stats = stop_session(session_id)
+    
+    # Print results
+    print("\n" + "=" * 60)
+    print("📈 Session Statistics")
+    print("=" * 60)
+    print(f"  Frames processed: {stats['frames_processed']}")
+    print(f"  Actions triggered: {stats['actions_triggered']}")
+    print(f"  Actions suppressed: {suppressed}")
+    print(f"  Review queue: {stats['review_queue_size']}")
+    print(f"  Duration: {stats['duration_seconds']:.1f}s")
+    print(f"  Average FPS: {stats['avg_fps']:.2f}")
+    
+    # Summary
+    print("\n💡 Demo Summary:")
+    print(f"   • The first 'person' detection triggered an ACTION")
+    print(f"   • Subsequent detections within {cooldown}s were SUPPRESSED")
+    print(f"   • After cooldown expired, new ACTIONs could trigger")
+    print(f"   • This prevents alert fatigue in real-time monitoring")
+    
+    print("\n✨ Streaming demo complete!")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Streaming Detection Demo")
+    parser.add_argument("--frames", "-n", type=int, default=10,
+                       help="Number of frames to process")
+    parser.add_argument("--cooldown", "-c", type=float, default=3.0,
+                       help="Cooldown between actions (seconds)")
+    parser.add_argument("--interval", "-i", type=float, default=0.5,
+                       help="Interval between frames (seconds)")
+    args = parser.parse_args()
+    
+    try:
+        run_demo(args.frames, args.cooldown, args.interval)
+    except httpx.ConnectError:
+        print("❌ Could not connect to runtime!")
+        print("   Make sure the runtime is running:")
+        print("   cd runtimes/universal && uv run python server.py")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/demos/vision/demo_training.py
+++ b/demos/vision/demo_training.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""
+Demo: YOLO Fine-Tuning Pipeline
+
+Demonstrates:
+1. Creating a small training dataset
+2. Starting a fine-tuning job
+3. Monitoring training progress
+4. Testing the fine-tuned model
+
+Note: This demo creates a minimal dataset for demonstration.
+Real training requires more data (100+ images per class).
+"""
+
+import argparse
+import base64
+import json
+import os
+import shutil
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+import httpx
+import numpy as np
+
+API_URL = os.environ.get("LLAMAFARM_URL", "http://localhost:14345")
+RUNTIME_URL = API_URL
+
+# Sample images for mini-dataset
+SAMPLE_IMAGES = [
+    {"url": "https://ultralytics.com/images/zidane.jpg", "class": "person"},
+    {"url": "https://ultralytics.com/images/bus.jpg", "class": "vehicle"},
+]
+
+
+def download_image(url: str) -> bytes:
+    """Download image from URL."""
+    response = httpx.get(url, timeout=30.0)
+    response.raise_for_status()
+    return response.content
+
+
+def detect(image_b64: str, model: str = "yolov8n") -> dict:
+    """Run detection to get bounding boxes."""
+    response = httpx.post(
+        f"{RUNTIME_URL}/v1/vision/detect",
+        json={"model": model, "image": image_b64, "confidence_threshold": 0.3},
+        timeout=60.0,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def start_training(
+    dataset_path: str,
+    base_model: str = "yolov8n",
+    epochs: int = 3,
+    batch_size: int = 4,
+) -> dict:
+    """Start a training job."""
+    response = httpx.post(
+        f"{RUNTIME_URL}/v1/vision/training/start",
+        json={
+            "base_model": base_model,
+            "dataset_path": dataset_path,
+            "epochs": epochs,
+            "batch_size": batch_size,
+        },
+        timeout=30.0,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def get_training_status() -> dict:
+    """Get current training status."""
+    response = httpx.get(
+        f"{RUNTIME_URL}/v1/vision/training/status",
+        timeout=30.0,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def list_training_jobs() -> dict:
+    """List all training jobs."""
+    response = httpx.get(
+        f"{RUNTIME_URL}/v1/vision/training/jobs",
+        timeout=30.0,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def create_mini_dataset(output_dir: str) -> str:
+    """Create a minimal YOLO-format dataset.
+    
+    Creates:
+    output_dir/
+    ├── data.yaml
+    ├── train/
+    │   ├── images/
+    │   └── labels/
+    └── val/
+        ├── images/
+        └── labels/
+    """
+    print("\n📦 Creating mini training dataset...")
+    
+    output_path = Path(output_dir)
+    train_images = output_path / "train" / "images"
+    train_labels = output_path / "train" / "labels"
+    val_images = output_path / "val" / "images"
+    val_labels = output_path / "val" / "labels"
+    
+    # Create directories
+    for d in [train_images, train_labels, val_images, val_labels]:
+        d.mkdir(parents=True, exist_ok=True)
+    
+    # Download images and create labels
+    for i, sample in enumerate(SAMPLE_IMAGES):
+        print(f"  Processing: {sample['url']}")
+        
+        # Download image
+        image_data = download_image(sample["url"])
+        
+        # Detect objects to get bounding boxes
+        image_b64 = base64.b64encode(image_data).decode()
+        result = detect(image_b64)
+        
+        # Save to train (first) and val (duplicate for demo)
+        for subset, img_dir, lbl_dir in [
+            ("train", train_images, train_labels),
+            ("val", val_images, val_labels),
+        ]:
+            img_path = img_dir / f"sample_{i}.jpg"
+            lbl_path = lbl_dir / f"sample_{i}.txt"
+            
+            # Save image
+            with open(img_path, "wb") as f:
+                f.write(image_data)
+            
+            # Create YOLO-format labels
+            # Format: class_id center_x center_y width height (normalized)
+            img_size = result.get("image_size", {"width": 640, "height": 480})
+            w, h = img_size["width"], img_size["height"]
+            
+            labels = []
+            for det in result.get("detections", []):
+                # Map class to our simple schema (0=person, 1=vehicle)
+                cls_id = 0 if det["class"] in ["person"] else 1
+                
+                box = det["box"]
+                cx = ((box["x1"] + box["x2"]) / 2) / w
+                cy = ((box["y1"] + box["y2"]) / 2) / h
+                bw = (box["x2"] - box["x1"]) / w
+                bh = (box["y2"] - box["y1"]) / h
+                
+                labels.append(f"{cls_id} {cx:.6f} {cy:.6f} {bw:.6f} {bh:.6f}")
+            
+            with open(lbl_path, "w") as f:
+                f.write("\n".join(labels))
+    
+    # Create data.yaml
+    data_yaml = f"""
+# Mini dataset for training demo
+path: {output_path.absolute()}
+train: train/images
+val: val/images
+
+nc: 2
+names:
+  0: person
+  1: vehicle
+"""
+    
+    yaml_path = output_path / "data.yaml"
+    with open(yaml_path, "w") as f:
+        f.write(data_yaml.strip())
+    
+    print(f"  ✅ Dataset created at: {output_path}")
+    print(f"  Train images: {len(list(train_images.glob('*.jpg')))}")
+    print(f"  Val images: {len(list(val_images.glob('*.jpg')))}")
+    
+    return str(yaml_path)
+
+
+def run_demo(epochs: int = 3, skip_training: bool = False):
+    """Run the training demo."""
+    print("🎓 LlamaFarm Vision - Training Pipeline Demo")
+    print("=" * 60)
+    
+    # Create temporary directory for dataset
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Step 1: Create dataset
+        data_yaml_path = create_mini_dataset(tmpdir)
+        
+        print(f"\n📄 Dataset config: {data_yaml_path}")
+        with open(data_yaml_path) as f:
+            print(f"{'─' * 40}")
+            print(f"{f.read()}")
+            print(f"{'─' * 40}")
+        
+        if skip_training:
+            print("\n⏭️  Skipping training (--skip-training flag)")
+            print("  In a real scenario, training would:")
+            print("  1. Load the yolov8n base model")
+            print("  2. Fine-tune on the custom dataset")
+            print("  3. Save weights to runs/train/exp/weights/")
+            return
+        
+        # Step 2: Start training
+        print("\n🚀 Step 2: Starting Training")
+        print("-" * 40)
+        
+        try:
+            result = start_training(
+                dataset_path=data_yaml_path,
+                base_model="yolov8n",
+                epochs=epochs,
+                batch_size=2,
+            )
+            
+            if "job_id" in result:
+                job_id = result["job_id"]
+                print(f"  Job ID: {job_id}")
+                print(f"  Status: {result.get('status', 'unknown')}")
+                
+                # Step 3: Monitor training
+                print("\n⏳ Step 3: Monitoring Training")
+                print("-" * 40)
+                
+                for _ in range(30):  # Poll for up to 30 seconds
+                    status = get_training_status()
+                    active = status.get("active_jobs", [])
+                    
+                    if not active:
+                        print("  Training completed!")
+                        break
+                    
+                    for job in active:
+                        progress = job.get("progress", 0)
+                        epoch = job.get("current_epoch", 0)
+                        print(f"\r  Epoch {epoch}/{epochs} - {progress:.1%}", end="")
+                    
+                    time.sleep(1)
+                
+                print()
+            else:
+                print(f"  Result: {result}")
+                
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 501:
+                print("\n⚠️  Training endpoint not fully implemented")
+                print("  This demo shows the expected workflow:")
+                print("  1. Create YOLO-format dataset")
+                print("  2. Call /v1/vision/training/start")
+                print("  3. Monitor with /v1/vision/training/status")
+                print("  4. Get results with /v1/vision/training/jobs")
+            else:
+                raise
+        
+        # Step 4: Show what would happen
+        print("\n📊 Training Results (Example)")
+        print("-" * 40)
+        print("""
+  After training completes, you would see:
+  
+  ┌────────────────────────────────────────────┐
+  │  Training Complete!                        │
+  │                                            │
+  │  Metrics:                                  │
+  │    • mAP50: 0.85                          │
+  │    • mAP50-95: 0.62                       │
+  │    • Precision: 0.89                      │
+  │    • Recall: 0.78                         │
+  │                                            │
+  │  Model saved to:                          │
+  │    runs/train/exp/weights/best.pt         │
+  │    runs/train/exp/weights/last.pt         │
+  └────────────────────────────────────────────┘
+  
+  You can then use the fine-tuned model:
+  
+    curl -X POST http://localhost:14345/v1/vision/detect \\
+      -H "Content-Type: application/json" \\
+      -d '{
+        "model": "runs/train/exp/weights/best.pt",
+        "image": "..."
+      }'
+""")
+    
+    print("\n✨ Training demo complete!")
+    print("\n💡 For real training:")
+    print("   • Use 100+ images per class")
+    print("   • Train for 50-100 epochs")
+    print("   • Use data augmentation")
+    print("   • Monitor val metrics to prevent overfitting")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="YOLO Training Demo")
+    parser.add_argument("--epochs", "-e", type=int, default=3,
+                       help="Number of training epochs")
+    parser.add_argument("--skip-training", action="store_true",
+                       help="Skip actual training (just create dataset)")
+    args = parser.parse_args()
+    
+    try:
+        run_demo(args.epochs, args.skip_training)
+    except httpx.ConnectError:
+        print("❌ Could not connect to runtime!")
+        print("   Make sure the runtime is running:")
+        print("   cd runtimes/universal && uv run python server.py")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -1,0 +1,616 @@
+# LlamaFarm Vision System
+
+A comprehensive computer vision pipeline for object detection, image classification, embeddings, and real-time streaming analysis.
+
+## Overview
+
+The Vision system provides:
+
+- **Object Detection** - YOLO-based detection (v8/v11) with 80+ COCO classes
+- **Image Classification** - CLIP zero-shot classification with custom labels
+- **Image Embeddings** - CLIP embeddings for similarity search and RAG
+- **Streaming Detection** - Real-time video analysis with cooldown and review queues
+- **Training Pipeline** - Fine-tune YOLO on custom datasets
+- **Storage Layer** - SQLite-based image and detection storage with retention policies
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                           LlamaFarm Server (:14345)                     │
+│  ┌────────────────┐  ┌────────────────┐  ┌────────────────┐            │
+│  │ /vision/detect │  │/vision/classify│  │ /vision/embed  │            │
+│  └───────┬────────┘  └───────┬────────┘  └───────┬────────┘            │
+│          │                   │                   │                      │
+│          └───────────────────┴───────────────────┘                      │
+│                              │                                          │
+│                    ┌─────────▼─────────┐                               │
+│                    │  Vision Services  │                               │
+│                    └─────────┬─────────┘                               │
+└──────────────────────────────┼──────────────────────────────────────────┘
+                               │ HTTP
+┌──────────────────────────────▼──────────────────────────────────────────┐
+│                      Universal Runtime (:11540)                         │
+│                                                                         │
+│  ┌─────────────┐  ┌──────────────┐  ┌────────────────┐                │
+│  │ YOLO Model  │  │ CLIP Model   │  │ Streaming      │                │
+│  │ (Detection) │  │ (Class/Embed)│  │ Detector       │                │
+│  └──────┬──────┘  └──────┬───────┘  └───────┬────────┘                │
+│         │                │                   │                         │
+│  ┌──────▼────────────────▼───────────────────▼────────┐               │
+│  │              Vision Base Classes                    │               │
+│  │  DetectionModel | ClassificationModel | Embedding   │               │
+│  └────────────────────────────────────────────────────┘               │
+│                                                                         │
+│  ┌────────────────────────────────────────────────────┐               │
+│  │                   Storage Layer                     │               │
+│  │            ImageStore | RetentionManager            │               │
+│  └────────────────────────────────────────────────────┘               │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+## Quick Start
+
+### 1. Start the Runtime and Server
+
+```bash
+# Terminal 1: Start Universal Runtime
+cd runtimes/universal
+uv run python server.py
+
+# Terminal 2: Start LlamaFarm Server
+cd server
+uv run python main.py
+```
+
+### 2. Test Detection
+
+```bash
+# Detect objects in an image
+curl -X POST http://localhost:14345/v1/vision/detect \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "yolov8n",
+    "image_url": "https://ultralytics.com/images/zidane.jpg"
+  }'
+```
+
+### 3. Test Classification
+
+```bash
+# Zero-shot classify an image
+curl -X POST http://localhost:14345/v1/vision/classify \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "clip-vit-base",
+    "image_url": "https://example.com/cat.jpg",
+    "classes": ["cat", "dog", "bird", "fish"]
+  }'
+```
+
+### 4. Generate Embeddings
+
+```bash
+# Get image embedding
+curl -X POST http://localhost:14345/v1/vision/embed \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "clip-vit-base",
+    "images": ["base64_encoded_image_here"]
+  }'
+```
+
+## API Reference
+
+### Detection Endpoint
+
+**POST** `/v1/vision/detect`
+
+Detect objects in an image using YOLO.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| model | string | Yes | Model ID (yolov8n, yolov8s, etc.) |
+| image | string | Yes* | Base64-encoded image |
+| image_url | string | Yes* | URL to fetch image from |
+| confidence_threshold | float | No | Minimum confidence (default: 0.5) |
+| classes | string[] | No | Filter to specific classes |
+
+*One of `image` or `image_url` required
+
+**Response:**
+```json
+{
+  "object": "detection",
+  "model": "yolov8n",
+  "inference_time_ms": 45.2,
+  "image_size": {"width": 640, "height": 480},
+  "detections": [
+    {
+      "class": "person",
+      "confidence": 0.95,
+      "box": {"x1": 100, "y1": 50, "x2": 300, "y2": 400}
+    }
+  ]
+}
+```
+
+### Classification Endpoint
+
+**POST** `/v1/vision/classify`
+
+Zero-shot image classification using CLIP.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| model | string | Yes | Model ID (clip-vit-base, siglip-base) |
+| image | string | Yes* | Base64-encoded image |
+| image_url | string | Yes* | URL to fetch image from |
+| classes | string[] | Yes | Classes to classify against |
+| top_k | int | No | Number of top results (default: 5) |
+
+**Response:**
+```json
+{
+  "object": "classification",
+  "model": "clip-vit-base",
+  "inference_time_ms": 32.1,
+  "class": "cat",
+  "confidence": 0.89,
+  "scores": {
+    "cat": 0.89,
+    "dog": 0.08,
+    "bird": 0.03
+  }
+}
+```
+
+### Embedding Endpoint
+
+**POST** `/v1/vision/embed`
+
+Generate embeddings for images or text.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| model | string | Yes | Model ID |
+| images | string[] | Yes* | Base64-encoded images |
+| texts | string[] | Yes* | Text strings to embed |
+
+*One of `images` or `texts` required
+
+**Response:**
+```json
+{
+  "object": "embedding",
+  "model": "clip-vit-base",
+  "inference_time_ms": 25.0,
+  "dimensions": 512,
+  "embeddings": [
+    [0.023, -0.156, 0.089, ...]
+  ]
+}
+```
+
+### Streaming Endpoints
+
+**POST** `/v1/vision/stream/start`
+
+Start a streaming detection session.
+
+```json
+{
+  "model": "yolov8n",
+  "config": {
+    "target_fps": 1.0,
+    "confidence_threshold": 0.7,
+    "action_classes": ["person", "car"],
+    "cooldown_seconds": 5.0,
+    "cascade": {
+      "secondary_model_id": "yolov8m",
+      "cascade_chain": ["yolov8n", "yolov8m"],
+      "enrich_on_escalation": true
+    }
+  }
+}
+```
+
+**POST** `/v1/vision/stream/frame`
+
+Process a single frame in an active session. Body: `{"session_id": "...", "image": "base64..."}`.
+
+**POST** `/v1/vision/stream/stop`
+
+Stop a session and get statistics. Body: `{"session_id": "..."}`.
+
+**GET** `/v1/vision/stream/sessions`
+
+List all active sessions.
+
+**GET** `/v1/vision/stream/sessions/{session_id}/stats`
+
+Get cascade statistics for a session.
+
+### Training Endpoints
+
+**POST** `/v1/vision/train`
+
+Start a YOLO fine-tuning job.
+
+```json
+{
+  "model": "yolov8n",
+  "dataset": "/path/to/dataset",
+  "task": "detection",
+  "epochs": 10,
+  "batch_size": 16
+}
+```
+
+**GET** `/v1/vision/train/{job_id}`
+
+Get training job status.
+
+**GET** `/v1/vision/train`
+
+List all training jobs.
+
+**DELETE** `/v1/vision/train/{job_id}`
+
+Cancel a training job.
+
+**GET** `/v1/vision/auto-train/status`
+
+Get auto-training status.
+
+**POST** `/v1/vision/auto-train/trigger`
+
+Manually trigger auto-training.
+
+### Export Endpoints
+
+**POST** `/v1/vision/models/export`
+
+Export a model to ONNX with quantization.
+
+```json
+{
+  "model_id": "yolov8n",
+  "format": "onnx",
+  "quantization": "fp16"
+}
+```
+
+## Model Variants
+
+### YOLO Detection Models
+
+| Model | Size | Speed | Accuracy | Use Case |
+|-------|------|-------|----------|----------|
+| yolov8n | 6MB | Fast | Good | Real-time, edge devices |
+| yolov8s | 22MB | Fast | Better | General purpose |
+| yolov8m | 52MB | Medium | High | Balanced |
+| yolov8l | 87MB | Slow | Higher | Accuracy critical |
+| yolov8x | 137MB | Slowest | Best | Maximum accuracy |
+| yolov11n | 5MB | Fastest | Good | Latest architecture |
+| yolov11s | 18MB | Fast | Better | Latest, general |
+| yolov11m | 38MB | Medium | High | Latest, balanced |
+
+### CLIP Classification Models
+
+| Model | Embedding Dim | Speed | Accuracy |
+|-------|---------------|-------|----------|
+| clip-vit-base | 512 | Fast | Good |
+| clip-vit-base-16 | 512 | Fast | Good |
+| clip-vit-large | 768 | Medium | Better |
+| siglip-base | 768 | Fast | Better (for classification) |
+| siglip-large | 1024 | Medium | Best |
+
+## Streaming Detection
+
+The streaming system is designed for real-time video analysis with intelligent filtering:
+
+### Session Lifecycle
+
+```
+┌─────────────┐     ┌──────────────┐     ┌─────────────┐
+│   START     │────▶│   PROCESS    │────▶│    STOP     │
+│  session    │     │   frames     │     │  session    │
+└─────────────┘     └──────────────┘     └─────────────┘
+                          │
+              ┌───────────┼───────────┐
+              ▼           ▼           ▼
+         ┌────────┐ ┌──────────┐ ┌─────────┐
+         │   OK   │ │  ACTION  │ │ REVIEW  │
+         │(ignore)│ │(trigger) │ │(queue)  │
+         └────────┘ └──────────┘ └─────────┘
+```
+
+### Status Types
+
+- **OK** - No significant detections or cooldown active
+- **ACTION** - High-confidence detection, trigger automation
+- **REVIEW** - Uncertain detection, queue for human review
+
+### Cooldown Logic
+
+Prevents alert fatigue by suppressing repeated triggers:
+
+```python
+# Example: Person detection with 5-second cooldown
+config = StreamingConfig(
+    action_classes=["person"],
+    confidence_threshold=0.7,
+    cooldown_seconds=5.0,
+)
+
+# Frame 1 (t=0): Person detected (0.9) → ACTION
+# Frame 2 (t=1): Person detected (0.85) → OK (suppressed)
+# Frame 3 (t=6): Person detected (0.88) → ACTION (cooldown expired)
+```
+
+## Training Pipeline
+
+### Dataset Format
+
+YOLO training requires datasets in this structure:
+
+```
+dataset/
+├── data.yaml          # Dataset config
+├── train/
+│   ├── images/        # Training images
+│   └── labels/        # YOLO format labels
+├── val/
+│   ├── images/        # Validation images
+│   └── labels/        # Validation labels
+└── test/              # Optional test set
+    ├── images/
+    └── labels/
+```
+
+**data.yaml:**
+```yaml
+path: /path/to/dataset
+train: train/images
+val: val/images
+test: test/images
+
+names:
+  0: cat
+  1: dog
+  2: bird
+```
+
+**Label format (one .txt per image):**
+```
+# class_id center_x center_y width height (normalized 0-1)
+0 0.5 0.5 0.4 0.6
+1 0.2 0.3 0.15 0.2
+```
+
+### Incremental Training
+
+Fine-tune from a checkpoint:
+
+```python
+# Start with pre-trained model
+result = await training_service.start_training(
+    base_model="yolov8n",
+    dataset_path="/data/custom",
+    epochs=10,
+)
+
+# Later: continue training
+result = await training_service.start_training(
+    base_model="/runs/train/exp/weights/last.pt",  # Previous checkpoint
+    dataset_path="/data/custom_v2",
+    epochs=5,
+)
+```
+
+## Storage Layer
+
+### Image Store
+
+SQLite-based storage for images and detections:
+
+```python
+from storage.image_store import ImageStore
+
+store = ImageStore(db_path="vision.db")
+store.initialize()
+
+# Store image
+image_id = store.store_image(
+    image_data=frame_bytes,
+    source="front_camera",
+    metadata={"timestamp": time.time()}
+)
+
+# Store detection
+store.store_detection(
+    image_id=image_id,
+    class_name="person",
+    confidence=0.95,
+    box={"x1": 100, "y1": 50, "x2": 300, "y2": 400},
+    model_id="yolov8n"
+)
+
+# Human label
+store.store_label(
+    image_id=image_id,
+    class_name="employee",
+    annotator="reviewer_1",
+    box={"x1": 100, "y1": 50, "x2": 300, "y2": 400}
+)
+```
+
+### Retention Policies
+
+Automatic cleanup of old data:
+
+```python
+from storage.retention import RetentionManager
+
+manager = RetentionManager(store)
+
+# Delete images older than 7 days
+manager.apply_max_age(max_hours=168)
+
+# Keep only most recent 10,000 images
+manager.apply_max_count(max_count=10000)
+
+# Limit storage to 1GB
+manager.apply_max_size(max_bytes=1024*1024*1024)
+
+# Run all policies
+result = manager.run_all(
+    max_hours=168,
+    max_count=10000,
+    max_bytes=1024*1024*1024,
+)
+```
+
+## Integration Examples
+
+### Security Camera Pipeline
+
+```python
+import asyncio
+from llamafarm import VisionClient
+
+async def security_monitor():
+    client = VisionClient("http://localhost:14345")
+    
+    # Start streaming session
+    session = await client.start_stream(
+        model="yolov8n",
+        action_classes=["person"],
+        cooldown_seconds=30.0,
+        confidence_threshold=0.8,
+    )
+    
+    async for frame in camera.stream():
+        result = await client.process_frame(session.id, frame)
+        
+        if result.status == "action":
+            await send_alert(f"Person detected: {result.detections}")
+        elif result.status == "review":
+            await queue_for_review(result.image_id)
+```
+
+### Image Search with RAG
+
+```python
+# Build index from images
+embeddings = []
+for image_path in image_paths:
+    with open(image_path, "rb") as f:
+        result = await client.embed(images=[f.read()])
+        embeddings.append(result.embeddings[0])
+
+# Save to vector store
+vector_store.add(embeddings, image_paths)
+
+# Search by text
+query_embedding = await client.embed(texts=["a red sports car"])
+similar = vector_store.search(query_embedding, k=10)
+```
+
+### Active Learning Loop
+
+```python
+# 1. Run detection on unlabeled images
+for image in unlabeled_images:
+    result = await client.detect(image, model="custom_model")
+    
+    for det in result.detections:
+        if det.confidence < 0.7:
+            # Queue uncertain detections for review
+            await review_queue.add(image, det)
+
+# 2. Human reviews and labels
+labels = await review_queue.get_labeled()
+
+# 3. Add to training dataset
+dataset.add_samples(labels)
+
+# 4. Retrain model
+await client.train(
+    base_model="custom_model",
+    dataset_path=dataset.path,
+    epochs=5,
+)
+```
+
+## Performance Tips
+
+### Batch Processing
+
+Process multiple images in one call for better throughput:
+
+```python
+# Instead of:
+for img in images:
+    await client.embed(images=[img])
+
+# Do:
+results = await client.embed(images=images)  # All at once
+```
+
+### Model Selection
+
+- Use **yolov8n** for real-time (<30ms inference)
+- Use **yolov8m** for accuracy/speed balance
+- Use **siglip-base** for classification (better than CLIP)
+
+### Device Selection
+
+```python
+# Automatic device selection (recommended)
+model = YOLOModel("yolov8n", device="auto")
+
+# Force specific device
+model = YOLOModel("yolov8n", device="mps")  # Apple Silicon
+model = YOLOModel("yolov8n", device="cuda")  # NVIDIA GPU
+model = YOLOModel("yolov8n", device="cpu")   # CPU only
+```
+
+## Troubleshooting
+
+### Common Issues
+
+**"Model not found"**
+- First detection call downloads the model (~6MB for yolov8n)
+- Check internet connection and disk space
+
+**"CUDA out of memory"**
+- Reduce batch size
+- Use smaller model (yolov8n instead of yolov8x)
+- Process images one at a time
+
+**"Slow inference"**
+- Check device is using GPU: `model.get_model_info()["device"]`
+- Install CUDA/MPS support: `pip install torch --index-url https://download.pytorch.org/whl/cu118`
+
+**"Classification always same class"**
+- Ensure classes are semantically meaningful
+- Try more specific prompts: "a photo of a {}" template
+- Use siglip model for better accuracy
+
+### Logs
+
+Enable debug logging:
+
+```python
+import logging
+logging.getLogger("models.yolo_model").setLevel(logging.DEBUG)
+logging.getLogger("models.clip_model").setLevel(logging.DEBUG)
+```
+
+## Next Steps
+
+- See [demos/](../demos/) for runnable examples
+- Check [examples/vision/](../examples/vision/) for integration patterns
+- Read [Plan.md](../Plan.md) for full implementation details

--- a/docs/website/docs/api/index.md
+++ b/docs/website/docs/api/index.md
@@ -173,6 +173,48 @@ Common HTTP status codes:
 - `POST /v1/vision/ocr` - OCR text extraction (accepts file upload or base64)
 - `POST /v1/vision/documents/extract` - Document extraction/VQA (accepts file upload or base64)
 
+### Vision (Detection, Classification & Streaming)
+
+**Single-Frame Inference:**
+- `POST /v1/vision/detect` - Object detection (YOLO)
+- `POST /v1/vision/classify` - Image classification (CLIP zero-shot)
+- `POST /v1/vision/segment` - Instance/semantic segmentation
+- `POST /v1/vision/embed` - Image/text CLIP embeddings
+
+**Streaming Pipeline:**
+- `POST /v1/vision/stream/start` - Start streaming session with cascade
+- `POST /v1/vision/stream/frame` - Process a video frame
+- `POST /v1/vision/stream/stop` - Stop streaming session
+- `GET /v1/vision/stream/sessions` - List active sessions
+- `GET /v1/vision/stream/sessions/{session_id}/stats` - Session statistics
+- `POST /v1/vision/corrections` - Submit human correction
+- `GET /v1/vision/replay-buffer` - Replay buffer status
+- `POST /v1/vision/replay-buffer/clear` - Clear replay buffer
+
+**Training:**
+- `POST /v1/vision/train` - Start training job
+- `GET /v1/vision/train/{job_id}` - Training job status
+- `GET /v1/vision/train` - List training jobs
+- `DELETE /v1/vision/train/{job_id}` - Cancel training job
+- `GET /v1/vision/auto-train/status` - Auto-training status
+- `POST /v1/vision/auto-train/trigger` - Trigger auto-training
+
+**Model Management:**
+- `GET /v1/vision/models` - List vision models
+- `POST /v1/vision/models/save` - Save model to disk
+- `POST /v1/vision/models/load` - Load saved model
+- `DELETE /v1/vision/models/{task}/{name}` - Delete saved model
+
+**Federation:**
+- `GET /v1/vision/federation/peers` - List federation peers
+- `POST /v1/vision/federation/peers` - Register peer
+- `DELETE /v1/vision/federation/peers/{name}` - Remove peer
+- `GET /v1/vision/federation/status` - Federation health
+- `POST /v1/vision/federation/escalate` - Inbound escalation from peer
+- `GET /v1/vision/federation/packages` - List model packages
+- `POST /v1/vision/federation/packages` - Create model package
+- `POST /v1/vision/federation/packages/import` - Import model package
+
 ### ML (Custom Classifiers & Anomaly Detection)
 
 **Text Classification (SetFit):**
@@ -3101,6 +3143,142 @@ curl -X POST http://localhost:14345/v1/vision/documents/extract \
 
 ---
 
+## Vision API (Detection, Classification & Streaming)
+
+The Vision Pipeline provides object detection, classification, segmentation, CLIP embeddings, and real-time streaming with automatic model improvement. These endpoints are available through the LlamaFarm server (port 14345).
+
+**Base URL:** `http://localhost:14345/v1/vision`
+
+:::tip Full Documentation
+For architecture details, cascade configuration, and the learning loop, see the [Vision Pipeline guide](../vision/index.md).
+:::
+
+### Object Detection
+
+**Endpoint:** `POST /v1/vision/detect`
+
+```bash
+curl -X POST http://localhost:14345/v1/vision/detect \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "yolov8n",
+    "images": ["data:image/png;base64,..."],
+    "confidence_threshold": 0.5,
+    "classes": ["person", "car"]
+  }'
+```
+
+### Image Classification (CLIP)
+
+**Endpoint:** `POST /v1/vision/classify`
+
+```bash
+curl -X POST http://localhost:14345/v1/vision/classify \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "openai/clip-vit-base-patch32",
+    "images": ["data:image/png;base64,..."],
+    "labels": ["cat", "dog", "bird"]
+  }'
+```
+
+### Segmentation
+
+**Endpoint:** `POST /v1/vision/segment`
+
+```bash
+curl -X POST http://localhost:14345/v1/vision/segment \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "yolov8n-seg",
+    "images": ["data:image/png;base64,..."],
+    "confidence_threshold": 0.5
+  }'
+```
+
+### CLIP Embeddings
+
+**Endpoint:** `POST /v1/vision/embed`
+
+```bash
+curl -X POST http://localhost:14345/v1/vision/embed \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "openai/clip-vit-base-patch32",
+    "images": ["data:image/png;base64,..."],
+    "texts": ["a photo of a bird"]
+  }'
+```
+
+### Streaming Session Management
+
+```bash
+# Start session with cascade
+curl -X POST http://localhost:14345/v1/vision/stream/start \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "yolov8n",
+    "cascade": {
+      "enabled": true,
+      "cascade_chain": ["yolov8n", "yolov8m"],
+      "confidence_threshold": 0.7
+    }
+  }'
+
+# Process frame
+curl -X POST http://localhost:14345/v1/vision/stream/frame \
+  -H "Content-Type: application/json" \
+  -d '{"session_id": "abc123", "image": "data:image/png;base64,..."}'
+
+# Stop session
+curl -X POST http://localhost:14345/v1/vision/stream/stop \
+  -H "Content-Type: application/json" \
+  -d '{"session_id": "abc123"}'
+```
+
+### Training
+
+```bash
+# Start training
+curl -X POST http://localhost:14345/v1/vision/train \
+  -H "Content-Type: application/json" \
+  -d '{"model": "yolov8n", "dataset_path": "/path/to/dataset", "epochs": 10}'
+
+# Check status
+curl http://localhost:14345/v1/vision/train/job_abc123
+
+# Auto-train status and trigger
+curl http://localhost:14345/v1/vision/auto-train/status
+curl -X POST http://localhost:14345/v1/vision/auto-train/trigger
+```
+
+### Federation
+
+```bash
+# Register peer
+curl -X POST http://localhost:14345/v1/vision/federation/peers \
+  -H "Content-Type: application/json" \
+  -d '{"name": "gpu-server", "url": "http://192.168.1.100:14345", "models": ["yolov8x"]}'
+
+# Create model package
+curl -X POST http://localhost:14345/v1/vision/federation/packages \
+  -H "Content-Type: application/json" \
+  -d '{"model_id": "my-detector", "model_path": "/path/to/best.pt"}'
+
+# Import model package
+curl -X POST http://localhost:14345/v1/vision/federation/packages/import \
+  -H "Content-Type: application/json" \
+  -d '{"source": "/path/to/package.tar.gz"}'
+```
+
+For the complete API with request/response schemas, see:
+- [Detection & Classification](../vision/detection.md)
+- [Streaming & Cascade](../vision/streaming.md)
+- [Training & Validation](../vision/training.md)
+- [Federation & Distribution](../vision/federation.md)
+
+---
+
 ## ML API (Custom Classifiers & Anomaly Detection)
 
 The ML API provides custom text classification and anomaly detection capabilities through the main LlamaFarm API server. These endpoints proxy to the Universal Runtime with automatic model versioning support.
@@ -3618,6 +3796,19 @@ nx start universal-runtime
 | **Anomaly** | `POST /v1/anomaly/load` | Load saved model |
 | **Anomaly** | `GET /v1/anomaly/models` | List saved models |
 | **Anomaly** | `DELETE /v1/anomaly/models/{filename}` | Delete saved model |
+| **Vision: Detection** | `POST /v1/vision/detect` | Detect objects (YOLO) |
+| **Vision: Classification** | `POST /v1/vision/classify` | Classify images (CLIP) |
+| **Vision: Segmentation** | `POST /v1/vision/segment` | Instance/semantic segmentation |
+| **Vision: Embeddings** | `POST /v1/vision/embed` | CLIP image/text embeddings |
+| **Vision: Streaming** | `POST /v1/vision/stream/start` | Start streaming session |
+| **Vision: Streaming** | `POST /v1/vision/stream/frame` | Process video frame |
+| **Vision: Streaming** | `POST /v1/vision/stream/stop` | Stop streaming session |
+| **Vision: Training** | `POST /v1/vision/train` | Start training job |
+| **Vision: Training** | `GET /v1/vision/train/{job_id}` | Training job status |
+| **Vision: Models** | `GET /v1/vision/models` | List vision models |
+| **Vision: Federation** | `GET /v1/vision/federation/peers` | List federation peers |
+| **Vision: Federation** | `POST /v1/vision/federation/escalate` | Inbound escalation |
+| **Vision: Federation** | `GET /v1/vision/federation/packages` | List model packages |
 
 :::info Classification Endpoints
 - **`/v1/classify`** (Universal Runtime only) - Use pre-trained HuggingFace models for sentiment, spam detection, etc. This endpoint is NOT proxied through the main LlamaFarm server.
@@ -3681,6 +3872,7 @@ For complete documentation, see:
 
 ## Next Steps
 
+- Explore the [Vision Pipeline](../vision/index.md) for detection, streaming, and auto-training
 - Learn about [Configuration](../configuration/index.md)
 - Explore [RAG concepts](../rag/index.md)
 - Review [Examples](../examples/index.md)

--- a/docs/website/docs/models/specialized-ml.md
+++ b/docs/website/docs/models/specialized-ml.md
@@ -18,6 +18,10 @@ Beyond text generation, the Universal Runtime provides a comprehensive suite of 
 | [Named Entity Recognition](#named-entity-recognition-ner) | `POST /v1/ner` | Extract people, places, organizations |
 | [Reranking](#reranking-cross-encoder) | `POST /v1/rerank` | Improve RAG retrieval accuracy |
 | [Anomaly Detection](#anomaly-detection) | `POST /v1/ml/anomaly/*` | Detect outliers in numeric/mixed data |
+| [Object Detection](../vision/detection) | `POST /v1/vision/detect` | Detect objects with YOLO models |
+| [Image Classification](../vision/detection#image-classification) | `POST /v1/vision/classify` | CLIP zero-shot classification |
+| [Segmentation](../vision/detection#segmentation) | `POST /v1/vision/segment` | Instance/semantic segmentation |
+| [CLIP Embeddings](../vision/detection#clip-embeddings) | `POST /v1/vision/embed` | Multimodal image/text embeddings |
 
 ## Starting the Universal Runtime
 
@@ -680,6 +684,7 @@ Files are stored temporarily (5-minute TTL by default).
 
 ## Next Steps
 
+- [Vision Pipeline](../vision/index.md) - Object detection, streaming cascade, auto-training, and federation
 - [Anomaly Detection Guide](./anomaly-detection.md) - Complete anomaly detection documentation
 - [Universal Runtime Overview](./index.md#universal-runtime) - General runtime configuration
 - [API Reference](../api/index.md) - Full API documentation

--- a/docs/website/docs/vision/detection.md
+++ b/docs/website/docs/vision/detection.md
@@ -1,0 +1,153 @@
+---
+title: Detection, Classification & Embeddings
+sidebar_position: 1
+sidebar_label: Detection & Classification
+---
+
+# Detection, Classification & Embeddings
+
+Single-frame inference endpoints for object detection, image classification, segmentation, and CLIP embeddings. All endpoints are available through the LlamaFarm server (port 14345).
+
+## Object Detection
+
+Detect objects in images using YOLO models.
+
+**Endpoint:** `POST /v1/vision/detect`
+
+```bash
+curl -X POST http://localhost:14345/v1/vision/detect \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "yolov8n",
+    "images": ["data:image/png;base64,..."],
+    "confidence_threshold": 0.5,
+    "classes": ["person", "car"]
+  }'
+```
+
+**Parameters:**
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `model` | string | Yes | - | YOLO model ID (e.g., `yolov8n`, `yolov8m`, `yolov8x`) |
+| `images` | list[string] | Yes | - | Base64-encoded images |
+| `confidence_threshold` | float | No | `0.5` | Minimum detection confidence |
+| `classes` | list[string] | No | all | Filter to specific class names |
+
+**Response:**
+
+```json
+{
+  "detections": [
+    {
+      "class_name": "person",
+      "confidence": 0.92,
+      "bbox": [120.5, 80.3, 340.2, 410.7]
+    }
+  ],
+  "model": "yolov8n",
+  "inference_time_ms": 12.4
+}
+```
+
+### Supported Models
+
+Any YOLO-compatible model works. Common choices:
+
+| Model | Size | Speed | Accuracy | Use Case |
+|-------|------|-------|----------|----------|
+| `yolov8n` | 6 MB | ~5ms | Good | Real-time, edge devices |
+| `yolov8s` | 22 MB | ~10ms | Better | Balanced |
+| `yolov8m` | 50 MB | ~25ms | High | General purpose |
+| `yolov8l` | 83 MB | ~50ms | Higher | When accuracy matters |
+| `yolov8x` | 131 MB | ~80ms | Highest | Audit, validation |
+
+## Image Classification
+
+Zero-shot image classification using CLIP models. Classify images into arbitrary categories without training.
+
+**Endpoint:** `POST /v1/vision/classify`
+
+```bash
+curl -X POST http://localhost:14345/v1/vision/classify \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "openai/clip-vit-base-patch32",
+    "images": ["data:image/png;base64,..."],
+    "labels": ["cat", "dog", "bird", "fish"]
+  }'
+```
+
+**Parameters:**
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `model` | string | Yes | - | CLIP model ID from HuggingFace |
+| `images` | list[string] | Yes | - | Base64-encoded images |
+| `labels` | list[string] | Yes | - | Candidate class labels |
+
+## Segmentation
+
+Instance and semantic segmentation to get pixel-level object boundaries.
+
+**Endpoint:** `POST /v1/vision/segment`
+
+```bash
+curl -X POST http://localhost:14345/v1/vision/segment \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "yolov8n-seg",
+    "images": ["data:image/png;base64,..."],
+    "confidence_threshold": 0.5
+  }'
+```
+
+Segmentation masks are returned as polygon coordinates or run-length encoded (RLE) format. In the streaming pipeline, segmentation masks automatically attach to detections when `enrich_on_escalation` is enabled.
+
+## CLIP Embeddings
+
+Generate embeddings for images and/or text using CLIP models. Useful for multimodal RAG, image search, and similarity matching.
+
+**Endpoint:** `POST /v1/vision/embed`
+
+```bash
+# Embed images
+curl -X POST http://localhost:14345/v1/vision/embed \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "openai/clip-vit-base-patch32",
+    "images": ["data:image/png;base64,..."]
+  }'
+
+# Embed text
+curl -X POST http://localhost:14345/v1/vision/embed \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "openai/clip-vit-base-patch32",
+    "texts": ["a photo of a cat", "a painting of a dog"]
+  }'
+```
+
+Image and text embeddings live in the same vector space, so you can search images by text description and vice versa.
+
+## Model Management
+
+List, load, save, and delete vision models.
+
+```bash
+# List available models
+curl http://localhost:14345/v1/vision/models
+
+# Save a model to disk
+curl -X POST http://localhost:14345/v1/vision/models/save \
+  -H "Content-Type: application/json" \
+  -d '{"model": "yolov8n", "task": "detection", "name": "my-detector"}'
+
+# Load a saved model
+curl -X POST http://localhost:14345/v1/vision/models/load \
+  -H "Content-Type: application/json" \
+  -d '{"task": "detection", "name": "my-detector"}'
+
+# Delete a saved model
+curl -X DELETE http://localhost:14345/v1/vision/models/detection/my-detector
+```

--- a/docs/website/docs/vision/federation.md
+++ b/docs/website/docs/vision/federation.md
@@ -1,0 +1,150 @@
+---
+title: Federation & Distribution
+sidebar_position: 4
+---
+
+# Federation & Distribution
+
+Federation connects multiple LlamaFarm instances so they can share model inference, distribute trained models, and route vision work to the best available GPU.
+
+## Concepts
+
+**Peers** -- Other LlamaFarm instances that can run vision models. On standalone, you configure peers manually. On mesh (Atmosphere), peers are discovered automatically.
+
+**Remote Model Proxy** -- A `DetectionModel` that calls `/v1/vision/federation/escalate` on a remote LlamaFarm instance. The cascade chain doesn't know or care whether a model is local or remote.
+
+**Model Packages** -- Portable `.tar.gz` bundles containing model weights, metadata, class maps, and validation metrics. Used to distribute trained models across nodes.
+
+## Peer Management
+
+```bash
+# List federation peers
+curl http://localhost:14345/v1/vision/federation/peers
+
+# Register a peer
+curl -X POST http://localhost:14345/v1/vision/federation/peers \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "gpu-server",
+    "url": "http://192.168.1.100:14345",
+    "models": ["yolov8x"],
+    "gpu_vram_gb": 24,
+    "priority": 0,
+    "timeout": 30.0
+  }'
+
+# Remove a peer
+curl -X DELETE http://localhost:14345/v1/vision/federation/peers/gpu-server
+
+# Check federation health
+curl http://localhost:14345/v1/vision/federation/status
+```
+
+## Inbound Escalation
+
+When another LlamaFarm instance is uncertain about a detection, it sends the full escalation envelope to this endpoint. The local node runs its model and returns its opinion.
+
+**Endpoint:** `POST /v1/vision/federation/escalate`
+
+```bash
+curl -X POST http://localhost:14345/v1/vision/federation/escalate \
+  -H "Content-Type: application/json" \
+  -d '{
+    "image": "<base64-encoded>",
+    "model": "yolov8x",
+    "confidence_threshold": 0.5,
+    "opinions": [
+      {
+        "model_id": "yolov8n",
+        "node_id": "edge-device-1",
+        "class_name": "bird",
+        "confidence": 0.45
+      }
+    ]
+  }'
+```
+
+**Response:**
+
+```json
+{
+  "model": "yolov8x",
+  "detections": [
+    {
+      "class_name": "eagle",
+      "confidence": 0.91,
+      "bbox": [100, 50, 300, 250]
+    }
+  ],
+  "inference_time_ms": 82.3,
+  "node_id": "gpu-server"
+}
+```
+
+## Using Remote Models in the Cascade
+
+Add remote models to a streaming session's cascade chain by prefixing with `remote:`:
+
+```bash
+curl -X POST http://localhost:14345/v1/vision/stream/start \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "yolov8n",
+    "cascade": {
+      "enabled": true,
+      "cascade_chain": [
+        "yolov8n",
+        "remote:gpu-server/yolov8x"
+      ],
+      "confidence_threshold": 0.7
+    }
+  }'
+```
+
+The `RemoteModelProxy` implements the same `DetectionModel` interface as local models. The cascade loop calls `.detect()` on each -- it doesn't distinguish local from remote.
+
+## Model Packages
+
+Package trained models for distribution to other nodes.
+
+### List Packages
+
+```bash
+curl http://localhost:14345/v1/vision/federation/packages
+```
+
+### Create a Package
+
+```bash
+curl -X POST http://localhost:14345/v1/vision/federation/packages \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model_id": "bird-detector-v3",
+    "model_path": "/path/to/best.pt",
+    "description": "Fine-tuned bird detector"
+  }'
+```
+
+### Import a Package
+
+```bash
+curl -X POST http://localhost:14345/v1/vision/federation/packages/import \
+  -H "Content-Type: application/json" \
+  -d '{
+    "source": "/path/to/bird-detector-v3.tar.gz"
+  }'
+```
+
+### Package Format
+
+Packages are `.tar.gz` archives containing:
+
+```
+package.tar.gz
+├── model.pt                  # Model weights
+├── metadata.json             # Model ID, version, base model, class names, etc.
+├── class_map.json            # {class_name: index} mapping
+└── validation_metrics.json   # Accuracy, mAP, per-class metrics
+```
+
+Packages are created automatically when the validation gate promotes a new model. On mesh deployments, packages are announced via Atmosphere gossip so peers can pull updated models.

--- a/docs/website/docs/vision/index.md
+++ b/docs/website/docs/vision/index.md
@@ -1,0 +1,113 @@
+---
+title: Vision Pipeline
+sidebar_position: 8
+---
+
+# Vision Pipeline
+
+LlamaFarm includes a complete vision pipeline for object detection, image classification, segmentation, CLIP embeddings, and OCR. The pipeline supports real-time streaming with an automatic learning loop that improves models over time with minimal human intervention.
+
+## Capabilities
+
+| Capability | Endpoint | Description |
+|-----------|----------|-------------|
+| [Object Detection](./detection.md) | `POST /v1/vision/detect` | Detect objects with YOLO models |
+| [Image Classification](./detection.md#image-classification) | `POST /v1/vision/classify` | Classify images with CLIP zero-shot |
+| [Segmentation](./detection.md#segmentation) | `POST /v1/vision/segment` | Instance/semantic segmentation |
+| [CLIP Embeddings](./detection.md#clip-embeddings) | `POST /v1/vision/embed` | Image and text embeddings for multimodal RAG |
+| [OCR](../models/specialized-ml.md#ocr-text-extraction) | `POST /v1/vision/ocr` | Extract text from images and PDFs |
+| [Streaming](./streaming.md) | `POST /v1/vision/stream/*` | Real-time frame processing with cascade |
+| [Training](./training.md) | `POST /v1/vision/train` | Fine-tune detection models |
+| [Federation](./federation.md) | `/v1/vision/federation/*` | Multi-node model distribution |
+
+## Architecture Overview
+
+The vision system is organized into layers:
+
+```
+                        ┌─────────────────────────┐
+                        │   Vision API Endpoints   │
+                        │  detect / classify / ocr │
+                        └────────────┬────────────┘
+                                     │
+                        ┌────────────▼────────────┐
+                        │   Streaming Pipeline     │
+                        │  cascade chain + enrich  │
+                        └────────────┬────────────┘
+                                     │
+              ┌──────────────────────┼──────────────────────┐
+              │                      │                      │
+    ┌─────────▼─────────┐ ┌─────────▼─────────┐ ┌─────────▼─────────┐
+    │   Local Models     │ │   Remote Models    │ │   Review Queue     │
+    │  YOLO / CLIP / SAM │ │  RemoteModelProxy  │ │  Human feedback    │
+    └─────────┬─────────┘ └─────────┬─────────┘ └─────────┬─────────┘
+              │                      │                      │
+              └──────────────────────┼──────────────────────┘
+                                     │
+                        ┌────────────▼────────────┐
+                        │    Replay Buffer         │
+                        │  SQLite-backed samples   │
+                        └────────────┬────────────┘
+                                     │
+              ┌──────────────────────┼──────────────────────┐
+              │                      │                      │
+    ┌─────────▼─────────┐ ┌─────────▼─────────┐ ┌─────────▼─────────┐
+    │   Auto Trainer     │ │   Audit Pipeline   │ │  Validation Gate   │
+    │  periodic retrain  │ │  model-checks-model│ │  blue/green swap   │
+    └───────────────────┘ └───────────────────┘ └───────────────────┘
+```
+
+## Deployment Modes
+
+The vision pipeline works identically in two deployment modes:
+
+**Standalone (laptop/desktop):** All models run locally. The cascade chain tries progressively larger models (e.g., yolov8n -> yolov8m -> yolov8x). Training happens on your GPU/CPU.
+
+**Mesh/Edge (Atmosphere):** A tiny model runs on the edge device. Uncertain detections escalate to GPU peers discovered via mesh service discovery. The `RemoteModelProxy` wraps remote LlamaFarm instances with the same `DetectionModel` interface -- the cascade loop doesn't know or care whether a model is local or remote.
+
+## The Learning Loop
+
+The system is designed to be 99% automatic. The only human task is occasionally reviewing uncertain detections in the review queue.
+
+1. **Detect** -- Fast model runs on every frame
+2. **Escalate** -- Uncertain detections cascade to bigger models with full context (bounding boxes, segmentation masks, prior opinions)
+3. **Feedback** -- Resolved detections automatically become training samples in the replay buffer
+4. **Train** -- Auto-trainer fires when the replay buffer hits a threshold (default: 50 samples)
+5. **Validate** -- Candidate model must beat current model on a held-out validation set
+6. **Promote** -- Blue/green swap with automatic rollback if needed
+7. **Audit** -- A bigger model periodically spot-checks the fast model's predictions, catching systematic errors
+
+## Quick Start
+
+```bash
+# Start the Universal Runtime
+nx start universal-runtime
+
+# Detect objects in an image
+curl -X POST http://localhost:14345/v1/vision/detect \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "yolov8n",
+    "images": ["data:image/png;base64,..."],
+    "confidence_threshold": 0.5
+  }'
+
+# Start a streaming session with cascade
+curl -X POST http://localhost:14345/v1/vision/stream/start \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "yolov8n",
+    "cascade": {
+      "enabled": true,
+      "cascade_chain": ["yolov8n", "yolov8m"],
+      "confidence_threshold": 0.7
+    }
+  }'
+```
+
+## Next Steps
+
+- [Detection, Classification & Embeddings](./detection.md) -- Single-frame inference endpoints
+- [Streaming & Cascade](./streaming.md) -- Real-time processing with automatic learning
+- [Training & Validation](./training.md) -- Auto-training, validation gate, model management
+- [Federation & Distribution](./federation.md) -- Multi-node deployment and model packaging

--- a/docs/website/docs/vision/streaming.md
+++ b/docs/website/docs/vision/streaming.md
@@ -1,0 +1,179 @@
+---
+title: Streaming & Cascade
+sidebar_position: 2
+---
+
+# Streaming & Cascade
+
+The streaming pipeline processes video frames in real-time with an automatic multi-hop cascade. When a model is uncertain, the detection escalates to bigger models with full context -- bounding boxes, segmentation masks, and every prior model's opinion.
+
+## Streaming Sessions
+
+### Start a Session
+
+**Endpoint:** `POST /v1/vision/stream/start`
+
+```bash
+curl -X POST http://localhost:14345/v1/vision/stream/start \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "yolov8n",
+    "cascade": {
+      "enabled": true,
+      "cascade_chain": ["yolov8n", "yolov8m"],
+      "confidence_threshold": 0.7,
+      "enrich_on_escalation": true,
+      "segmentation_model_id": "yolov8n-seg",
+      "classification_model_id": "openai/clip-vit-base-patch32"
+    }
+  }'
+```
+
+**Cascade Configuration:**
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `false` | Enable multi-hop cascade |
+| `cascade_chain` | list[string] | `[]` | Ordered list of model IDs to try |
+| `confidence_threshold` | float | `0.7` | Minimum confidence to accept a detection |
+| `enrich_on_escalation` | bool | `true` | Attach segmentation masks and CLIP labels before escalating |
+| `segmentation_model_id` | string | `null` | Model for bbox segmentation enrichment |
+| `classification_model_id` | string | `null` | CLIP model for classification enrichment |
+
+### Process Frames
+
+**Endpoint:** `POST /v1/vision/stream/frame`
+
+```bash
+curl -X POST http://localhost:14345/v1/vision/stream/frame \
+  -H "Content-Type: application/json" \
+  -d '{
+    "session_id": "abc123",
+    "image": "data:image/png;base64,..."
+  }'
+```
+
+**Response:**
+
+```json
+{
+  "detections": [
+    {
+      "class_name": "bird",
+      "confidence": 0.85,
+      "bbox": [100, 50, 300, 250],
+      "model": "yolov8m"
+    }
+  ],
+  "hop_count": 2,
+  "cascade_resolved_by": "yolov8m",
+  "inference_time_ms": 45.2
+}
+```
+
+### Stop a Session
+
+**Endpoint:** `POST /v1/vision/stream/stop`
+
+```bash
+curl -X POST http://localhost:14345/v1/vision/stream/stop \
+  -H "Content-Type: application/json" \
+  -d '{"session_id": "abc123"}'
+```
+
+### List Sessions and Stats
+
+```bash
+# List active sessions
+curl http://localhost:14345/v1/vision/stream/sessions
+
+# Get session statistics
+curl http://localhost:14345/v1/vision/stream/sessions/abc123/stats
+```
+
+## How the Cascade Works
+
+When a detection's confidence falls below the threshold, the pipeline escalates through the cascade chain:
+
+```
+Frame arrives
+  │
+  ├── Hop 0: yolov8n (fast, ~5ms)
+  │   confidence >= 0.7 → DONE (return result)
+  │   confidence < 0.7  → enrich bbox with seg + CLIP → Hop 1
+  │
+  ├── Hop 1: yolov8m (medium, ~25ms)
+  │   confidence >= 0.7 → DONE + auto-feedback to replay buffer
+  │   confidence < 0.7  → Hop 2
+  │
+  ├── Hop 2: yolov8x or remote model (~80ms+)
+  │   confidence >= 0.5 → DONE + feedback to hop 0 AND hop 1
+  │   confidence < 0.5  → REVIEW QUEUE (needs human eyes)
+  │
+  └── Max 3 hops (circuit breaker)
+```
+
+At each hop, the pipeline builds a `ModelOpinion` recording what that model saw. All opinions flow forward so the next model has full context.
+
+### Cross-Modal Enrichment
+
+When `enrich_on_escalation` is enabled, before escalating to the next model the pipeline:
+
+1. Crops the bounding box region from the full image
+2. Runs segmentation to get a pixel-level mask of the object
+3. Runs CLIP classification to get candidate class labels
+4. Packages everything into the escalation so the next model gets precise visual context
+
+### Escalation Envelope
+
+The data structure flowing through the cascade:
+
+```
+EscalationEnvelope
+├── image_bytes          # Original full frame
+├── image_hash           # For dedup
+├── source_id            # Camera/source identifier
+├── opinions[]           # What each model predicted
+│   ├── model_id         # "yolov8n" or "remote:gpu-server/yolov8x"
+│   ├── node_id          # "local" or Atmosphere node ID
+│   ├── class_name       # What it thinks this is
+│   ├── confidence       # How sure it is
+│   ├── bbox             # Bounding box coordinates
+│   └── mask_polygon     # Segmentation mask (if available)
+├── detections[]         # Bounding boxes with crops and masks
+├── hops                 # How many models have seen this
+└── max_hops             # Circuit breaker (default: 3)
+```
+
+## Corrections and Replay Buffer
+
+Submit human corrections for detections and inspect the replay buffer.
+
+```bash
+# Submit a correction
+curl -X POST http://localhost:14345/v1/vision/corrections \
+  -H "Content-Type: application/json" \
+  -d '{
+    "image_id": "img_abc123",
+    "corrected_class": "eagle",
+    "box": [100, 50, 300, 250]
+  }'
+
+# Check replay buffer status
+curl http://localhost:14345/v1/vision/replay-buffer
+
+# Clear replay buffer
+curl -X POST http://localhost:14345/v1/vision/replay-buffer/clear
+```
+
+The replay buffer stores training samples with priority weighting:
+
+| Source | Priority | Description |
+|--------|----------|-------------|
+| Human correction | 2.0 | Manual review queue feedback |
+| Audit disagreement | 2.0 | Bigger model disagrees with small model |
+| Cascade resolved (hop 2+) | 1.8 | Multiple models needed to resolve |
+| Escalation resolved (hop 1) | 1.5 | Single escalation resolved it |
+| Low confidence | ~0.4 | Detection below threshold |
+
+Samples persist to SQLite so they survive restarts. When the buffer hits the training threshold (default: 50 samples), the auto-trainer fires automatically.

--- a/docs/website/docs/vision/training.md
+++ b/docs/website/docs/vision/training.md
@@ -1,0 +1,122 @@
+---
+title: Training & Validation
+sidebar_position: 3
+---
+
+# Training & Validation
+
+The vision pipeline includes automatic model retraining with a validation gate that prevents regressions. Models must prove they're better before going live.
+
+## Auto-Training
+
+When the replay buffer accumulates enough training samples (default: 50), the auto-trainer fires automatically. No manual intervention needed.
+
+### How It Works
+
+1. **Collect** -- Cascade resolutions, human corrections, and audit disagreements fill the replay buffer
+2. **Dataset** -- Auto-trainer builds a YOLO-format dataset with proper class maps and 80/20 train/val split
+3. **Train** -- Fine-tunes a candidate model for a few epochs with EWC (Elastic Weight Consolidation) to prevent catastrophic forgetting
+4. **Validate** -- Candidate runs against a held-out validation set of human-verified and audit-verified images
+5. **Promote or Reject** -- If the candidate beats the current model, blue/green swap. Otherwise, reject and keep current.
+
+### Check Auto-Train Status
+
+```bash
+curl http://localhost:14345/v1/vision/auto-train/status
+```
+
+### Trigger Training Manually
+
+```bash
+curl -X POST http://localhost:14345/v1/vision/auto-train/trigger
+```
+
+## Training API
+
+For manual training control:
+
+```bash
+# Start a training job
+curl -X POST http://localhost:14345/v1/vision/train \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "yolov8n",
+    "dataset_path": "/path/to/dataset",
+    "epochs": 10,
+    "batch_size": 16
+  }'
+
+# Check training status
+curl http://localhost:14345/v1/vision/train/job_abc123
+
+# List all training jobs
+curl http://localhost:14345/v1/vision/train
+
+# Cancel a training job
+curl -X DELETE http://localhost:14345/v1/vision/train/job_abc123
+```
+
+## Validation Gate
+
+The validation gate is the safety net between training and deployment. A candidate model must demonstrate improvement on known-good images before it replaces the current model.
+
+### Validation Set Sources
+
+The gate automatically builds a validation set from two sources:
+
+- **Human-verified images** -- Images where a human confirmed the correct label via the review queue (highest trust)
+- **Audit-verified images** -- Images where the audit pipeline's larger model agreed with the primary model's prediction
+
+### Blue/Green Promotion
+
+When validation passes:
+
+1. The current model is backed up as `{model_id}_v{N}.pt`
+2. The candidate is installed as the new current model
+3. A few live frames run through both models as a final check
+4. The old model stays available for rollback
+
+### Rollback
+
+If a promoted model misbehaves, the system can roll back to the previous version:
+
+- Automatic rollback if live-frame validation fails during promotion
+- Manual rollback via the model management API
+
+## Audit Pipeline
+
+A bigger model periodically reviews what the fast model has been classifying with high confidence. This catches systematic errors the cascade missed.
+
+### How It Works
+
+1. Sample N recent high-confidence predictions (the ones that were NOT escalated)
+2. Re-run through a larger model (local or remote via `RemoteModelProxy`)
+3. Compare results:
+   - **Agreement** -- Mark as verified (becomes validation data)
+   - **Disagreement** -- Add to replay buffer as training sample (priority 2.0)
+
+The audit model can be any model -- a larger local YOLO model, or a `RemoteModelProxy` pointing at a GPU server. The pipeline doesn't distinguish between local and remote.
+
+## Dataset Format
+
+The auto-trainer produces YOLO-format datasets:
+
+```
+dataset/
+├── data.yaml          # Class names, paths
+├── class_map.json     # {class_name: index}
+├── train/
+│   ├── images/        # Training images
+│   └── labels/        # YOLO-format .txt labels
+└── val/
+    ├── images/        # Validation images (20%)
+    └── labels/        # YOLO-format .txt labels
+```
+
+Each label file contains one line per detection:
+
+```
+# class_index center_x center_y width height (all normalized 0-1)
+0 0.45 0.52 0.30 0.60
+1 0.72 0.31 0.15 0.25
+```

--- a/docs/website/package-lock.json
+++ b/docs/website/package-lock.json
@@ -28,7 +28,7 @@
         "typescript": "~5.6.2"
       },
       "engines": {
-        "node": ">=18.0"
+        "node": ">=20.0"
       }
     },
     "node_modules/@ai-sdk/gateway": {

--- a/docs/website/sidebars.ts
+++ b/docs/website/sidebars.ts
@@ -84,6 +84,17 @@ const sidebars: SidebarsConfig = {
     },
     {
       type: 'category',
+      label: 'Vision Pipeline',
+      link: { type: 'doc', id: 'vision/index' },
+      items: [
+        { type: 'doc', id: 'vision/detection', label: 'Detection & Classification' },
+        { type: 'doc', id: 'vision/streaming', label: 'Streaming & Cascade' },
+        { type: 'doc', id: 'vision/training', label: 'Training & Validation' },
+        { type: 'doc', id: 'vision/federation', label: 'Federation & Distribution' },
+      ],
+    },
+    {
+      type: 'category',
       label: 'Models & Runtime',
       link: { type: 'doc', id: 'models/index' },
       items: [

--- a/docs/website/static/llms-full.txt
+++ b/docs/website/static/llms-full.txt
@@ -28,15 +28,15 @@ Run sophisticated AI workloads on your own hardware:
 
 LlamaFarm isn't just a wrapper—it's a complete AI development platform:
 
-| Capability | What It Does |
-|-----------|--------------|
+| Capability                               | What It Does                                                                                |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------- |
 | **RAG (Retrieval-Augmented Generation)** | Ingest PDFs, docs, CSVs and query them with AI. Your documents become searchable knowledge. |
-| **Multi-Model Runtime** | Switch between Ollama, OpenAI, vLLM, or local GGUF models in one config file. |
-| **Custom Classifiers** | Train text classifiers with 8-16 examples using SetFit. No ML expertise required. |
-| **Anomaly Detection** | Detect outliers in logs, metrics, or transactions with one API call. |
-| **OCR & Document Extraction** | Extract text and structured data from images and PDFs. |
-| **Named Entity Recognition** | Find people, organizations, and locations in your text. |
-| **Agentic Tools (MCP)** | Give AI models access to filesystems, databases, and APIs. |
+| **Multi-Model Runtime**                  | Switch between Ollama, OpenAI, vLLM, or local GGUF models in one config file.               |
+| **Custom Classifiers**                   | Train text classifiers with 8-16 examples using SetFit. No ML expertise required.           |
+| **Anomaly Detection**                    | Detect outliers in logs, metrics, or transactions with one API call.                        |
+| **OCR & Document Extraction**            | Extract text and structured data from images and PDFs.                                      |
+| **Named Entity Recognition**             | Find people, organizations, and locations in your text.                                     |
+| **Agentic Tools (MCP)**                  | Give AI models access to filesystems, databases, and APIs.                                  |
 
 ### ⚡ Developer Experience
 
@@ -60,19 +60,23 @@ The desktop app bundles everything: server, Universal Runtime, and the Designer 
 Install the `lf` command-line tool:
 
 **macOS / Linux:**
+
 ```bash
 curl -fsSL https://raw.githubusercontent.com/llama-farm/llamafarm/main/install.sh | bash
 ```
 
 **Windows (PowerShell):**
+
 ```powershell
 irm https://raw.githubusercontent.com/llama-farm/llamafarm/main/install.ps1 | iex
 ```
 
 **Or download directly:**
+
 - [Latest Release](https://github.com/llama-farm/llamafarm/releases/latest) — Download `lf` binary for your platform
 
 Verify installation:
+
 ```bash
 lf --help
 ```
@@ -90,7 +94,9 @@ lf --help
 ## What Can You Build?
 
 ### Document Q&A
+
 Upload your company's documents and ask questions in natural language:
+
 ```bash
 lf datasets upload knowledge-base ./contracts/*.pdf
 lf datasets process knowledge-base
@@ -98,7 +104,9 @@ lf chat "What are our standard payment terms?"
 ```
 
 ### Custom Intent Classification
+
 Train a classifier to route support tickets:
+
 ```python
 # Train with just 8 examples per category
 POST /v1/ml/classifier/fit
@@ -113,7 +121,9 @@ POST /v1/ml/classifier/fit
 ```
 
 ### Real-Time Anomaly Detection
+
 Monitor API logs for suspicious activity:
+
 ```python
 # Train on normal traffic
 POST /v1/ml/anomaly/fit
@@ -125,7 +135,9 @@ POST /v1/ml/anomaly/detect
 ```
 
 ### Document Processing Pipeline
+
 Extract structured data from invoices and forms:
+
 ```bash
 curl -X POST http://localhost:14345/v1/vision/ocr \
   -F "file=@invoice.pdf" \
@@ -136,11 +148,11 @@ curl -X POST http://localhost:14345/v1/vision/ocr \
 
 ## Choose Your Path
 
-| Get Started | Go Deeper | Build Your Own |
-|-------------|-----------|----------------|
-| [Quickstart](./quickstart/index.md) — Install, init, chat, ingest your first dataset | [Core Concepts](./concepts/index.md) — Architecture, sessions, and components | [Extending LlamaFarm](./extending/index.md) — Add runtimes, stores, parsers |
-| [Designer Web UI](./designer/index.md) — Visual interface for project management | [Configuration Guide](./configuration/index.md) — Schema-driven project settings | [RAG Guide](./rag/index.md) — Strategies, processing pipelines |
-| [CLI Reference](./cli/index.md) — Command matrix and examples | [Models & Runtime](./models/index.md) — Configure AI models and providers | [API Reference](./api/index.md) — Full REST API documentation |
+| Get Started                                                                          | Go Deeper                                                                        | Build Your Own                                                              |
+| ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| [Quickstart](./quickstart/index.md) — Install, init, chat, ingest your first dataset | [Core Concepts](./concepts/index.md) — Architecture, sessions, and components    | [Extending LlamaFarm](./extending/index.md) — Add runtimes, stores, parsers |
+| [Designer Web UI](./designer/index.md) — Visual interface for project management     | [Configuration Guide](./configuration/index.md) — Schema-driven project settings | [RAG Guide](./rag/index.md) — Strategies, processing pipelines              |
+| [CLI Reference](./cli/index.md) — Command matrix and examples                        | [Models & Runtime](./models/index.md) — Configure AI models and providers        | [API Reference](./api/index.md) — Full REST API documentation               |
 
 ---
 
@@ -164,7 +176,7 @@ mcp:
     - name: filesystem
       transport: stdio
       command: npx
-      args: ['-y', '@modelcontextprotocol/server-filesystem', '/path/to/dir']
+      args: ["-y", "@modelcontextprotocol/server-filesystem", "/path/to/dir"]
 
 runtime:
   models:
@@ -196,23 +208,25 @@ Get LlamaFarm installed, ingest a dataset, and run your first RAG-powered chat i
 
 Download the all-in-one desktop application:
 
-| Platform | Download |
-|----------|----------|
-| **Mac (Universal)** | [⬇️ Download](https://github.com/llama-farm/llamafarm/releases/latest/download/LlamaFarm-desktop-app-mac-universal.dmg) |
-| **Windows (x86_64)** | [⬇️ Download](https://github.com/llama-farm/llamafarm/releases/latest/download/LlamaFarm-desktop-app-windows.exe) |
-| **Linux (x86_64)** | [⬇️ Download](https://github.com/llama-farm/llamafarm/releases/latest/download/LlamaFarm-desktop-app-linux-x86_64.AppImage) |
-| **Linux (arm64)** | [⬇️ Download](https://github.com/llama-farm/llamafarm/releases/latest/download/LlamaFarm-desktop-app-linux-arm64.AppImage) |
+| Platform            | Download                                                                                                                    |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| **Mac (Universal)** | [⬇️ Download](https://github.com/llama-farm/llamafarm/releases/latest/download/LlamaFarm-desktop-app-mac-universal.dmg)     |
+| **Windows**         | [⬇️ Download](https://github.com/llama-farm/llamafarm/releases/latest/download/LlamaFarm-desktop-app-windows.exe)           |
+| **Linux (x86_64)**  | [⬇️ Download](https://github.com/llama-farm/llamafarm/releases/latest/download/LlamaFarm-desktop-app-linux-x86_64.AppImage) |
+| **Linux (arm64)**   | [⬇️ Download](https://github.com/llama-farm/llamafarm/releases/latest/download/LlamaFarm-desktop-app-linux-arm64.AppImage)  |
 
 The desktop app bundles everything you need—no additional installation required.
 
 ### Option B: CLI Installation
 
 **macOS / Linux:**
+
 ```bash
 curl -fsSL https://raw.githubusercontent.com/llama-farm/llamafarm/main/install.sh | bash
 ```
 
 **Windows (PowerShell):**
+
 ```powershell
 irm https://raw.githubusercontent.com/llama-farm/llamafarm/main/install.ps1 | iex
 ```
@@ -221,26 +235,28 @@ irm https://raw.githubusercontent.com/llama-farm/llamafarm/main/install.ps1 | ie
 
 Download the `lf` binary directly from the [releases page](https://github.com/llama-farm/llamafarm/releases/latest):
 
-| Platform | Binary |
-|----------|--------|
-| macOS (Apple Silicon) | `lf-darwin-arm64` |
-| macOS (Intel) | `lf-darwin-amd64` |
-| Linux (x86_64) | `lf-linux-amd64` |
-| Linux (arm64) | `lf-linux-arm64` |
-| Windows (x86_64) | `lf-windows-amd64.exe` |
+| Platform              | Binary                 |
+| --------------------- | ---------------------- |
+| macOS (Apple Silicon) | `lf-darwin-arm64`      |
+| macOS (Intel)         | `lf-darwin-amd64`      |
+| Linux (x64)           | `lf-linux-amd64`       |
+| Linux (arm64)         | `lf-linux-arm64`       |
+| Windows (x86_64)      | `lf-windows-amd64.exe` |
 
 After downloading, make it executable and add to your PATH:
+
 ```bash
 chmod +x lf-darwin-arm64
 sudo mv lf-darwin-arm64 /usr/local/bin/lf
 ```
 
 Verify installation:
+
 ```bash
 lf --help
 ```
 
-## 3. Configure Your Runtime (only if you plan to use Ollama)
+## 3. Configure Your Runtime (Ollama)
 
 For best RAG results with longer documents, increase the Ollama context window:
 
@@ -249,6 +265,7 @@ For best RAG results with longer documents, increase the Ollama context window:
 3. Adjust the context window size (recommended: 32K+ for documents)
 
 Pull a model if you haven't already:
+
 ```bash
 ollama pull llama3.2
 ollama pull nomic-embed-text  # For embeddings
@@ -270,6 +287,7 @@ lf start
 ```
 
 This command:
+
 - Starts the API server and Universal Runtime natively
 - Opens the interactive chat TUI
 - Launches the Designer web UI at `http://localhost:14345`
@@ -311,6 +329,7 @@ lf chat "What can you do?"
 ```
 
 Useful options:
+
 - `--no-rag` — Bypass retrieval, hit the model directly
 - `--database`, `--retrieval-strategy` — Override RAG behavior
 - `--curl` — Print the equivalent curl command
@@ -321,14 +340,16 @@ Useful options:
 # Create a dataset
 lf datasets create -s pdf_ingest -b main_db research-notes
 
-# Upload documents (supports globs/directories)
+# Upload documents (supports globs/directories); auto-processes by default
 lf datasets upload research-notes ./examples/fda_rag/files/*.pdf
+# For batching without processing:
+# lf datasets upload research-notes ./examples/fda_rag/files/*.pdf --no-process
 ```
 
 ## 8. Process Documents
 
 ```bash
-lf datasets process research-notes
+lf datasets process research-notes    # Only needed if you skipped auto-processing
 ```
 
 This sends documents through the RAG pipeline—parsing, chunking, embedding, and indexing.
@@ -342,6 +363,7 @@ lf rag query --database main_db "What are the key findings?"
 ```
 
 Useful flags:
+
 - `--top-k 10` — Number of results
 - `--filter "file_type:pdf"` — Metadata filtering
 - `--include-metadata` — Show document sources
@@ -490,6 +512,37 @@ Common symptoms, their causes, and how to resolve them when working with LlamaFa
 | `lf` command not found after installation | Binary not in system PATH | Ensure `/usr/local/bin` (or custom install directory) is in your PATH. Run `echo $PATH` to verify. |
 | Installation script fails | Permissions issue or unsupported platform | Try with `sudo` or check platform compatibility (macOS/Linux supported). Windows users should download `lf.exe` manually. |
 
+## GPU & CUDA Issues
+
+| Issue | Cause | Fix |
+| ----- | ----- | --- |
+| CUDA 11 falls back to CPU | Upstream llama.cpp (b7694+) no longer provides CUDA 11 binaries | Upgrade to CUDA 12+, or build llama.cpp from source with CUDA 11 support (see below). |
+| GPU not detected | CUDA/Vulkan drivers not installed or not in PATH | Install appropriate GPU drivers. For CUDA, ensure `nvidia-smi` works. |
+| Metal not used on macOS | Running on Intel Mac | Metal acceleration is only available on Apple Silicon (M1/M2/M3). Intel Macs use CPU. |
+
+### Building llama.cpp with CUDA 11
+
+If you need CUDA 11 support, you must build llama.cpp from source:
+
+```bash
+# Clone llama.cpp
+git clone https://github.com/ggml-org/llama.cpp
+cd llama.cpp
+git checkout b7694
+
+# Build with CUDA 11
+mkdir build && cd build
+cmake .. -DGGML_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES="native"
+cmake --build . --config Release
+
+# Copy the library to LlamaFarm cache
+mkdir -p ~/.cache/llamafarm-llama/b7694
+cp bin/libllama.so ~/.cache/llamafarm-llama/b7694/  # Linux
+# or: cp bin/llama.dll ~/.cache/llamafarm-llama/b7694/  # Windows
+```
+
+Set `LLAMAFARM_BACKEND=cpu` to force CPU mode if GPU detection causes issues.
+
 ## Sessions & State
 
 - Delete `.llamafarm/projects/<namespace>/<project>/dev/context` to reset dev chat history.
@@ -501,7 +554,7 @@ Common symptoms, their causes, and how to resolve them when working with LlamaFa
 | Issue | Cause | Fix |
 | ----- | ----- | --- |
 | `nx build docs` sqlite I/O error | Nx cache database lock or permission issue | Remove `.nx/` cache directory or run with `NX_SKIP_NX_CACHE=1`. |
-| Docker containers fail to start | Port conflicts or missing dependencies | Check if ports 8000/6379/5432 are available. Run `lf services stop` first, then `lf services start`. |
+| Docker containers fail to start | Port conflicts or missing dependencies | Check if ports 14345/6379/5432 are available. Run `lf services stop` first, then `lf services start`. |
 | Python module import errors | Virtual environment not activated or dependencies not installed | Run `cd server && uv sync` or `cd rag && uv sync` to install dependencies. |
 
 ## Extensibility Pitfalls
@@ -531,7 +584,7 @@ The LlamaFarm Desktop App provides a complete local AI environment with visual p
 
 To run the desktop app with small models (1-3B parameters like Qwen 1.7B):
 
-| Component | Mac | Windows | Linux |
+| Component | Mac (M1+) | Windows | Linux |
 |-----------|-----------|---------|-------|
 | **CPU** | Apple M1 or newer | Intel i5 / AMD Ryzen 5 (8th gen+) | Intel i5 / AMD Ryzen 5 (8th gen+) |
 | **RAM** | 8 GB | 8 GB | 8 GB |
@@ -543,13 +596,13 @@ To run the desktop app with small models (1-3B parameters like Qwen 1.7B):
 
 For larger models (7-8B parameters) and better performance:
 
-| Component | Mac | Windows | Linux |
+| Component | Mac (M1+) | Windows | Linux |
 |-----------|-----------|---------|-------|
-| **CPU** | Apple M2 Pro or better | Intel i7 / AMD Ryzen 7 | Intel i7 / AMD Ryzen 7 |
-| **RAM** | 32 GB+ | 32 GB+ | 32 GB+ |
+| **CPU** | Apple M1 Pro/Max or M2+ | Intel i7 / AMD Ryzen 7 | Intel i7 / AMD Ryzen 7 |
+| **RAM** | 16 GB+ | 16 GB+ | 16 GB+ |
 | **Storage** | 50 GB+ SSD | 50 GB+ SSD | 50 GB+ SSD |
 | **OS** | macOS 13+ (Ventura) | Windows 11 | Ubuntu 22.04+ |
-| **GPU** | Unified Memory (Metal) | NVIDIA RTX 3090+ (24GB+ VRAM) | NVIDIA RTX 3090+ (24GB+ VRAM) |
+| **GPU** | Unified Memory (Metal) | NVIDIA RTX 3060+ (8GB+ VRAM) | NVIDIA RTX 3060+ (8GB+ VRAM) |
 
 ---
 
@@ -1159,7 +1212,7 @@ lf start
 # Option 2: Manual server start
 cd ../server
 uv sync
-uv run uvicorn server.main:app --reload --host 0.0.0.0 --port 8000
+uv run uvicorn server.main:app --reload --host 0.0.0.0 --port 14345
 ```
 
 Verify the server is running:
@@ -1597,10 +1650,10 @@ lf rag stats --auto-start=false
 ```yaml
 - name: Start services
   run: lf start &
-
+  
 - name: Wait for health
   run: timeout 60 bash -c 'until curl -f http://localhost:14345/health; do sleep 2; done'
-
+  
 - name: Run tests
   run: |
     lf datasets create --auto-start=false -s pdf_ingest -b main_db test-data
@@ -1672,7 +1725,7 @@ lf services stop server        # Stop specific service
 
 | Service | Description | Default Port |
 |---------|-------------|--------------|
-| `server` | Main FastAPI server | 8000 |
+| `server` | Main FastAPI server | 14345 |
 | `rag` | RAG/Celery worker | N/A |
 | `universal-runtime` | Universal Runtime server | 11540 |
 
@@ -2140,7 +2193,7 @@ lf services <subcommand> [service-name] [flags]
 
 | Service | Description | Default Port |
 |---------|-------------|--------------|
-| `server` | Main FastAPI server | 8000 |
+| `server` | Main FastAPI server | 14345 |
 | `rag` | RAG/Celery worker | N/A |
 | `universal-runtime` | Universal Runtime server for HuggingFace models | 11540 |
 
@@ -2398,6 +2451,7 @@ runtime: { ... }
 prompts: [...]
 rag: { ... }
 datasets: [...]
+voice: { ... }
 ```
 
 ### Metadata
@@ -2508,7 +2562,7 @@ runtime:
 
 ### Prompts
 
-Prompts are named sets of messages that seed instructions for each session.
+Prompts are named sets of messages that seed instructions for each session. Prompts support **dynamic variable substitution** using Jinja2-style `{{variable}}` syntax.
 
 ```yaml
 prompts:
@@ -2524,25 +2578,110 @@ prompts:
 - Models can select which prompt sets to use via `prompts: [list of names]`; if omitted, all prompts stack in definition order.
 - Prompts are appended before user input; combine with RAG context via the RAG guide.
 
+#### Dynamic Variable Substitution
+
+Use Jinja2-style `{{variable}}` syntax to inject values at request time:
+
+```yaml
+prompts:
+  - name: personalized
+    messages:
+      - role: system
+        content: |
+          You are a customer service assistant for {{company_name | Acme Corp}}.
+          The customer's name is {{user_name | Valued Customer}}.
+          Account tier: {{account_tier | standard}}
+```
+
+**Syntax:**
+
+| Pattern | Description | Example |
+|---------|-------------|---------|
+| `{{variable}}` | Required variable | `Hello {{name}}` → Error if `name` not provided |
+| `{{variable \| default}}` | Variable with default | `Hello {{name \| Guest}}` → `Hello Guest` if missing |
+| `{{ variable }}` | Whitespace allowed | Same as above |
+
+**Passing variables via API:**
+
+```bash
+curl -X POST http://localhost:14345/v1/projects/ns/project/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "messages": [{"role": "user", "content": "Hi"}],
+    "variables": {
+      "company_name": "TechCorp",
+      "user_name": "Alice",
+      "account_tier": "premium"
+    }
+  }'
+```
+
+Variables can be used in:
+- **Prompt message content** - Personalize system instructions
+- **Tool descriptions** - Customize tool behavior per request
+- **Tool parameter descriptions** - Dynamic parameter help text
+
+See the [Prompts Guide](../prompts/index.md) for detailed examples.
+
 ### RAG Configuration
 
 The `rag` section mirrors [`rag/schema.yaml`](/rag/schema.yaml). It defines databases and data-processing strategies.
 
 ```yaml
+components:
+  embedding_strategies:
+    - name: default_embeddings
+      type: UniversalEmbedder
+      config:
+        model: sentence-transformers/all-MiniLM-L6-v2
+  retrieval_strategies:
+    - name: semantic_search
+      type: BasicSimilarityStrategy
+      config:
+        top_k: 5
+  parsers:
+    - name: pdf_parser
+      type: PDFParser_LlamaIndex
+      config:
+        chunk_size: 1500
+        chunk_overlap: 200
+  defaults:
+    embedding_strategy: default_embeddings
+    retrieval_strategy: semantic_search
+    parser: pdf_parser
+
 rag:
   databases:
     - name: main_db
       type: ChromaStore
+      # Reuse components by reference (defaults also apply when fields are omitted)
+      embedding_strategy: default_embeddings
+      retrieval_strategy: semantic_search
+  data_processing_strategies:
+    - name: pdf_ingest
+      parsers:
+        - pdf_parser         # reference to components.parsers
+      extractors:
+        - type: HeadingExtractor
+        - type: ContentStatisticsExtractor
+```
+
+Inline (legacy) configs are still supported:
+
+```yaml
+rag:
+  databases:
+    - name: inline_db
+      type: ChromaStore
       default_embedding_strategy: default_embeddings
-      default_retrieval_strategy: semantic_search
       embedding_strategies:
         - name: default_embeddings
-          type: OllamaEmbedder
+          type: UniversalEmbedder
           config:
-            model: nomic-embed-text:latest
+            model: sentence-transformers/all-MiniLM-L6-v2
       retrieval_strategies:
         - name: semantic_search
-          type: VectorRetriever
+          type: BasicSimilarityStrategy
           config:
             top_k: 5
   data_processing_strategies:
@@ -2562,7 +2701,12 @@ Key points:
 - `databases` map to vector stores; choose from `ChromaStore` or `QdrantStore` by default.
 - `embedding_strategies` and `retrieval_strategies` let you define hybrid or metadata-aware search.
 - `data_processing_strategies` describe parser/extractor pipelines applied during ingestion.
+- Inline parsers can omit `name` (only `type`/`config` are required); `name` is required only for reusable parsers declared under `components.parsers` so they can be referenced by string or set as defaults. This keeps older inline configs valid while allowing named, reusable components.
 - For a complete field reference, see the [RAG Guide](../rag/index.md).
+
+Defaults and persistence:
+- `components.defaults` are used when a database or processing strategy omits a field.
+- Server resolves references at load time and persists fully inlined configs; GET responses return the expanded strategies (no reference strings).
 
 ### Memory Configuration
 
@@ -2665,6 +2809,119 @@ datasets:
 
 - `files` are SHA256 hashes tracked by the server.
 - Not required, but useful for syncing dataset metadata across environments.
+
+### Voice
+
+The `voice` section configures real-time voice chat via WebSocket. This enables a full-duplex voice assistant pipeline: Speech In → STT → LLM → TTS → Speech Out.
+
+```yaml
+voice:
+  enabled: true
+  llm_model: chat-model      # Reference to runtime.models[].name
+
+  tts:
+    model: kokoro            # TTS model ID
+    voice: af_heart          # Voice ID
+    speed: 1.0               # Speed multiplier (0.5-2.0)
+
+  stt:
+    model: base              # Whisper model size
+    language: en             # Language code
+```
+
+#### Voice Fields
+
+| Field       | Type    | Default | Description                                                              |
+| ----------- | ------- | ------- | ------------------------------------------------------------------------ |
+| `enabled`   | boolean | `true`  | Enable or disable the voice chat endpoint                                |
+| `llm_model` | string  | —       | Reference to a model name in `runtime.models[]` for voice conversations  |
+| `tts`       | object  | —       | Text-to-speech configuration                                             |
+| `stt`       | object  | —       | Speech-to-text configuration                                             |
+
+#### TTS (Text-to-Speech)
+
+| Field   | Type   | Default     | Description                                     |
+| ------- | ------ | ----------- | ----------------------------------------------- |
+| `model` | string | `kokoro`    | TTS model ID                                    |
+| `voice` | string | `af_heart`  | Voice ID (see available voices below)           |
+| `speed` | number | `1.0`       | Speech speed multiplier (0.5-2.0)               |
+
+**Available Voices:**
+
+| Voice ID      | Description               |
+| ------------- | ------------------------- |
+| `af_heart`    | Heart (American Female) - default |
+| `af_bella`    | Bella (American Female)   |
+| `af_nicole`   | Nicole (American Female)  |
+| `af_sarah`    | Sarah (American Female)   |
+| `af_sky`      | Sky (American Female)     |
+| `am_adam`     | Adam (American Male)      |
+| `am_michael`  | Michael (American Male)   |
+| `bf_emma`     | Emma (British Female)     |
+| `bf_isabella` | Isabella (British Female) |
+| `bm_george`   | George (British Male)     |
+| `bm_lewis`    | Lewis (British Male)      |
+
+#### STT (Speech-to-Text)
+
+| Field      | Type   | Default | Description                                         |
+| ---------- | ------ | ------- | --------------------------------------------------- |
+| `model`    | string | `base`  | Whisper model size: `tiny`, `base`, `small`, `medium`, `large-v3` |
+| `language` | string | `en`    | Language code for transcription                     |
+
+**STT Model Comparison:**
+
+| Model      | Size   | Speed    | Accuracy |
+| ---------- | ------ | -------- | -------- |
+| `tiny`     | 39M    | Fastest  | Lower    |
+| `base`     | 74M    | Fast     | Good     |
+| `small`    | 244M   | Medium   | Better   |
+| `medium`   | 769M   | Slower   | High     |
+| `large-v3` | 1.5B   | Slowest  | Highest  |
+
+#### Example: Complete Voice Configuration
+
+```yaml
+version: v1
+name: voice-assistant
+namespace: default
+
+prompts:
+  - name: voice_system
+    messages:
+      - role: system
+        content: |
+          You are a friendly voice assistant. Keep responses concise
+          and conversational. Avoid long lists or complex formatting
+          since your output will be spoken aloud.
+
+runtime:
+  default_model: voice-model
+  models:
+    - name: voice-model
+      provider: universal
+      model: unsloth/Qwen3-4B-GGUF:Q4_K_M
+      base_url: http://localhost:11540/v1
+      prompts: [voice_system]
+      model_api_parameters:
+        temperature: 0.7
+        max_tokens: 256
+
+voice:
+  enabled: true
+  llm_model: voice-model
+  tts:
+    model: kokoro
+    voice: am_adam
+    speed: 1.1
+  stt:
+    model: small
+    language: en
+```
+
+The prompts attached to the referenced LLM model are automatically applied to voice conversations.
+
+---
 
 ## Validation & Errors
 
@@ -3275,6 +3532,116 @@ datasets:
     data_processing_strategy: universal_processor
 ```
 
+## Dynamic Variables in Prompts and Tools
+
+Use Jinja2-style `{{variable | default}}` syntax to customize prompts and tools at request time:
+
+```yaml
+version: v1
+name: dynamic-demo
+namespace: default
+
+runtime:
+  default_model: assistant
+  models:
+    - name: assistant
+      provider: universal
+      model: llama3.2:3b
+      default: true
+      tool_call_strategy: native_api
+      prompts:
+        - system
+        - context
+      tools:
+        - type: function
+          name: search_knowledge_base
+          description: "Search the {{company_name | Company}} knowledge base"
+          parameters:
+            type: object
+            properties:
+              query:
+                type: string
+                description: "Search query for {{department | General}} topics"
+            required:
+              - query
+        - type: function
+          name: create_ticket
+          description: "Create a support ticket for {{user_name | a customer}}"
+          parameters:
+            type: object
+            properties:
+              title:
+                type: string
+              priority:
+                type: string
+                enum: ["low", "medium", "high"]
+            required:
+              - title
+
+prompts:
+  - name: system
+    messages:
+      - role: system
+        content: |
+          You are a helpful assistant for {{company_name | Acme Corp}}.
+          You work in the {{department | General}} department.
+          Current date: {{current_date | today}}
+
+  - name: context
+    messages:
+      - role: system
+        content: |
+          ## Customer Information
+          - Name: {{user_name | Valued Customer}}
+          - Account Tier: {{account_tier | standard}}
+          - Language: {{language | English}}
+
+          Adjust responses based on tier:
+          - basic: Focus on self-service
+          - standard: Provide helpful guidance
+          - premium: Offer personalized assistance
+```
+
+**Usage with full variables:**
+
+```bash
+curl -X POST http://localhost:14345/v1/projects/default/dynamic-demo/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "messages": [{"role": "user", "content": "Hi, what can you help me with?"}],
+    "variables": {
+      "company_name": "TechCorp Solutions",
+      "department": "Technical Support",
+      "user_name": "Alice Johnson",
+      "account_tier": "premium",
+      "current_date": "2024-01-15"
+    }
+  }'
+```
+
+**Usage with defaults (minimal variables):**
+
+```bash
+curl -X POST http://localhost:14345/v1/projects/default/dynamic-demo/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "messages": [{"role": "user", "content": "Hello!"}],
+    "variables": {
+      "user_name": "Bob"
+    }
+  }'
+```
+
+Unprovided variables use their defaults (e.g., `company_name` becomes "Acme Corp").
+
+**Variable syntax:**
+
+| Pattern | Description |
+|---------|-------------|
+| `{{variable}}` | Required - error if not provided |
+| `{{variable \| default}}` | Uses default if not provided |
+| `{{ variable }}` | Whitespace is allowed |
+
 ## Qdrant Production Setup
 
 Production-ready configuration with Qdrant vector database:
@@ -3521,21 +3888,88 @@ Common HTTP status codes:
 - `POST /v1/vision/ocr` - OCR text extraction (accepts file upload or base64)
 - `POST /v1/vision/documents/extract` - Document extraction/VQA (accepts file upload or base64)
 
+### Vision (Detection, Classification & Streaming)
+
+**Single-Frame Inference:**
+- `POST /v1/vision/detect` - Object detection (YOLO)
+- `POST /v1/vision/classify` - Image classification (CLIP zero-shot)
+- `POST /v1/vision/segment` - Instance/semantic segmentation
+- `POST /v1/vision/embed` - Image/text CLIP embeddings
+
+**Streaming Pipeline:**
+- `POST /v1/vision/stream/start` - Start streaming session with cascade
+- `POST /v1/vision/stream/frame` - Process a video frame
+- `POST /v1/vision/stream/stop` - Stop streaming session
+- `GET /v1/vision/stream/sessions` - List active sessions
+- `GET /v1/vision/stream/sessions/{session_id}/stats` - Session statistics
+- `POST /v1/vision/corrections` - Submit human correction
+- `GET /v1/vision/replay-buffer` - Replay buffer status
+- `POST /v1/vision/replay-buffer/clear` - Clear replay buffer
+
+**Training:**
+- `POST /v1/vision/train` - Start training job
+- `GET /v1/vision/train/{job_id}` - Training job status
+- `GET /v1/vision/train` - List training jobs
+- `DELETE /v1/vision/train/{job_id}` - Cancel training job
+- `GET /v1/vision/auto-train/status` - Auto-training status
+- `POST /v1/vision/auto-train/trigger` - Trigger auto-training
+
+**Model Management:**
+- `GET /v1/vision/models` - List vision models
+- `POST /v1/vision/models/save` - Save model to disk
+- `POST /v1/vision/models/load` - Load saved model
+- `DELETE /v1/vision/models/{task}/{name}` - Delete saved model
+
+**Federation:**
+- `GET /v1/vision/federation/peers` - List federation peers
+- `POST /v1/vision/federation/peers` - Register peer
+- `DELETE /v1/vision/federation/peers/{name}` - Remove peer
+- `GET /v1/vision/federation/status` - Federation health
+- `POST /v1/vision/federation/escalate` - Inbound escalation from peer
+- `GET /v1/vision/federation/packages` - List model packages
+- `POST /v1/vision/federation/packages` - Create model package
+- `POST /v1/vision/federation/packages/import` - Import model package
+
 ### ML (Custom Classifiers & Anomaly Detection)
 
+**Text Classification (SetFit):**
 - `POST /v1/ml/classifier/fit` - Train custom text classifier (SetFit few-shot)
 - `POST /v1/ml/classifier/predict` - Classify texts using trained model
 - `POST /v1/ml/classifier/save` - Save trained classifier to disk
 - `POST /v1/ml/classifier/load` - Load classifier from disk
 - `GET /v1/ml/classifier/models` - List saved classifiers
 - `DELETE /v1/ml/classifier/models/{name}` - Delete saved classifier
+
+**Batch Anomaly Detection:**
 - `POST /v1/ml/anomaly/fit` - Train anomaly detector
 - `POST /v1/ml/anomaly/score` - Score data points for anomalies
 - `POST /v1/ml/anomaly/detect` - Detect anomalies (returns only anomalous points)
 - `POST /v1/ml/anomaly/save` - Save trained anomaly model
 - `POST /v1/ml/anomaly/load` - Load anomaly model from disk
 - `GET /v1/ml/anomaly/models` - List saved anomaly models
+- `GET /v1/ml/anomaly/backends` - List all 12 PyOD backends with metadata
 - `DELETE /v1/ml/anomaly/models/{filename}` - Delete saved anomaly model
+
+**Streaming Anomaly Detection:**
+- `POST /v1/ml/anomaly/stream` - Process streaming data with auto-retraining
+- `GET /v1/ml/anomaly/stream/detectors` - List active streaming detectors
+- `GET /v1/ml/anomaly/stream/{model_id}` - Get detector statistics
+- `POST /v1/ml/anomaly/stream/{model_id}/reset` - Reset detector to cold start
+- `DELETE /v1/ml/anomaly/stream/{model_id}` - Delete streaming detector
+
+**Polars Data Buffers:**
+- `POST /v1/ml/polars/buffers` - Create named data buffer
+- `GET /v1/ml/polars/buffers` - List all buffers with statistics
+- `GET /v1/ml/polars/buffers/{buffer_id}` - Get buffer statistics
+- `DELETE /v1/ml/polars/buffers/{buffer_id}` - Delete buffer
+- `POST /v1/ml/polars/buffers/{buffer_id}/clear` - Clear buffer data
+- `POST /v1/ml/polars/append` - Append data to buffer
+- `POST /v1/ml/polars/features` - Compute rolling features
+- `GET /v1/ml/polars/buffers/{buffer_id}/data` - Get raw buffer data
+
+### Voice Chat (Real-time Voice Assistant)
+
+- `WebSocket /v1/{namespace}/{project}/voice/chat` - Full-duplex voice chat (Speech → STT → LLM → TTS → Speech)
 
 ### Health
 
@@ -3602,6 +4036,8 @@ Send a chat message to the LLM. This endpoint is compatible with OpenAI's chat c
 - `rag_queries` (optional): Array of custom queries for RAG retrieval, overriding the user message. Can be a single query `["my query"]` or multiple queries `["query1", "query2"]` - results from multiple queries are executed concurrently, merged, and deduplicated
 - `think` (optional): Enable thinking/reasoning mode for supported models like Qwen3 (default: `false`)
 - `thinking_budget` (optional): Maximum tokens for thinking process when `think: true` (default: `1024`)
+- `variables` (optional): Object of key-value pairs for dynamic template substitution in prompts and tools. See [Dynamic Variables](#dynamic-variables) below
+- `tools` (optional): Array of tool definitions (OpenAI format). Tools can also contain `{{variable}}` placeholders
 
 **Response (Non-Streaming):**
 
@@ -3787,6 +4223,143 @@ curl -X POST http://localhost:14345/v1/projects/my-org/chatbot/chat/completions 
 ```
 
 Results from multiple queries are automatically executed concurrently, merged, deduplicated by content, sorted by relevance score, and limited to `rag_top_k` total results.
+
+### Dynamic Variables
+
+LlamaFarm supports dynamic variable substitution in prompts and tools using Jinja2-style `{{variable}}` syntax. Pass variable values in the `variables` field of your request, and they are resolved before the request is processed.
+
+**Example (Basic Variables):**
+
+If your `llamafarm.yaml` contains prompts with variables:
+
+```yaml
+prompts:
+  - name: personalized
+    messages:
+      - role: system
+        content: |
+          You are a customer service assistant for {{company_name | Acme Corp}}.
+          Customer name: {{user_name | Valued Customer}}
+          Account tier: {{account_tier | standard}}
+```
+
+Pass the values at request time:
+
+```bash
+curl -X POST http://localhost:14345/v1/projects/my-org/chatbot/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "messages": [
+      {"role": "user", "content": "What can you help me with?"}
+    ],
+    "variables": {
+      "company_name": "TechCorp Solutions",
+      "user_name": "Alice Johnson",
+      "account_tier": "premium"
+    }
+  }'
+```
+
+The system prompt becomes: "You are a customer service assistant for TechCorp Solutions. Customer name: Alice Johnson. Account tier: premium."
+
+**Example (Variables in Tools):**
+
+Tool definitions in your config can also use variables:
+
+```yaml
+runtime:
+  models:
+    - name: assistant
+      tools:
+        - type: function
+          name: search_kb
+          description: "Search the {{company_name | Company}} knowledge base"
+          parameters:
+            type: object
+            properties:
+              query:
+                type: string
+                description: "Search query for {{department | General}} topics"
+```
+
+Pass values to customize the tool:
+
+```bash
+curl -X POST http://localhost:14345/v1/projects/my-org/chatbot/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "messages": [{"role": "user", "content": "Search for shipping policies"}],
+    "variables": {
+      "company_name": "Acme Corp",
+      "department": "Customer Support"
+    }
+  }'
+```
+
+**Example (Request-Level Tools with Variables):**
+
+You can also pass tools directly in the request with variables:
+
+```bash
+curl -X POST http://localhost:14345/v1/projects/my-org/chatbot/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "messages": [{"role": "user", "content": "What tools do you have?"}],
+    "tools": [
+      {
+        "type": "function",
+        "function": {
+          "name": "lookup",
+          "description": "Look up data in {{data_source | the database}}",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "id": {"type": "string", "description": "ID to look up"}
+            },
+            "required": ["id"]
+          }
+        }
+      }
+    ],
+    "variables": {
+      "data_source": "the CRM system"
+    }
+  }'
+```
+
+**Variable Syntax:**
+
+| Pattern | Behavior |
+|---------|----------|
+| `{{variable}}` | Required - returns error 400 if not provided |
+| `{{variable \| default}}` | Optional - uses default if not provided |
+| `{{ variable }}` | Whitespace is allowed |
+
+**Supported Value Types:**
+
+- `string` - Inserted as-is
+- `int`, `float` - Converted to string
+- `boolean` - Converted to `True` or `False` (Python-style)
+- `null` - Converted to empty string
+
+Complex types (arrays, objects) are not supported and will return an error.
+
+**Error Handling:**
+
+If a required variable (no default) is missing, the API returns:
+
+```json
+{
+  "detail": "Template resolution failed: Template variable '{{ user_id }}' not found in provided variables. Available variables: ['company_name']. Add a default with '{{ user_id | default_value }}'."
+}
+```
+
+**Use Cases:**
+
+- **Multi-tenant apps** - Customize branding per customer
+- **Personalization** - Inject user names, roles, preferences
+- **A/B testing** - Swap prompt variants without config changes
+- **Dynamic context** - Pass dates, session IDs, account info
 
 ### Get Chat History
 
@@ -4976,6 +5549,199 @@ curl -X POST http://localhost:14345/v1/examples/fda_rag/import-data \
 
 ---
 
+## Voice Chat API
+
+The Voice Chat API provides a full-duplex WebSocket endpoint for real-time voice assistant functionality. It orchestrates Speech-to-Text (STT), LLM inference, and Text-to-Speech (TTS) into a seamless voice conversation pipeline.
+
+### Configuration (llamafarm.yaml)
+
+Voice settings can be configured in your project's `llamafarm.yaml` file. Query parameters override config defaults.
+
+```yaml
+# Voice chat configuration
+voice:
+  enabled: true                    # Enable/disable voice chat (default: true)
+  llm_model: chat-model            # Reference to runtime.models[].name
+
+  tts:
+    model: kokoro                  # TTS model ID
+    voice: af_heart                # Voice ID (see available voices below)
+    speed: 1.0                     # Speed multiplier (0.5-2.0)
+
+  stt:
+    model: base                    # Whisper model (tiny/base/small/medium/large-v3)
+    language: en                   # Language code
+
+# The llm_model references a model in runtime.models[]
+# Prompts attached to that model apply to voice conversations
+runtime:
+  models:
+    - name: chat-model
+      provider: universal
+      model: unsloth/Qwen3-4B-GGUF:Q4_K_M
+      prompts: [voice_assistant]   # System prompts apply to voice chat
+
+prompts:
+  - name: voice_assistant
+    messages:
+      - role: system
+        content: |
+          You are a friendly voice assistant. Keep responses concise
+          and conversational for spoken output.
+```
+
+**Available TTS Voices:**
+
+| Voice ID | Description |
+|----------|-------------|
+| `af_heart` | Heart (American Female) - default |
+| `af_bella`, `af_nicole`, `af_sarah`, `af_sky` | American Female voices |
+| `am_adam`, `am_michael` | American Male voices |
+| `bf_emma`, `bf_isabella` | British Female voices |
+| `bm_george`, `bm_lewis` | British Male voices |
+
+**STT Model Sizes:**
+
+| Model | Size | Speed | Accuracy |
+|-------|------|-------|----------|
+| `tiny` | 39M | Fastest | Lower |
+| `base` | 74M | Fast | Good (default) |
+| `small` | 244M | Medium | Better |
+| `medium` | 769M | Slower | High |
+| `large-v3` | 1.5B | Slowest | Highest |
+
+### Voice Chat WebSocket
+
+Real-time voice chat with stateful conversation sessions.
+
+**Endpoint:** `WebSocket /v1/{namespace}/{project}/voice/chat`
+
+**Path Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `namespace` | string | Project namespace |
+| `project` | string | Project name |
+
+**Query Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `session_id` | string | auto | Resume existing session (optional) |
+| `stt_model` | string | `"base"` | Whisper model size (overrides config) |
+| `tts_model` | string | `"kokoro"` | TTS model ID (overrides config) |
+| `tts_voice` | string | `"af_heart"` | TTS voice ID (overrides config) |
+| `llm_model` | string | from config | LLM model ID (required if not in config) |
+| `language` | string | `"en"` | STT language code (overrides config) |
+| `speed` | float | `1.0` | TTS speed multiplier (overrides config) |
+| `system_prompt` | string | none | System prompt for LLM (optional) |
+
+**Client → Server Messages:**
+
+| Type | Format | Description |
+|------|--------|-------------|
+| Audio | Binary | PCM 16kHz 16-bit mono, or WebM/Opus |
+| Interrupt | `{"type": "interrupt"}` | Stop current TTS playback (barge-in) |
+| End | `{"type": "end"}` | Process accumulated audio |
+| Config | `{"type": "config", ...}` | Update session settings |
+
+**Server → Client Messages:**
+
+| Type | Format | Description |
+|------|--------|-------------|
+| Session Info | `{"type": "session_info", "session_id": "..."}` | Session created/resumed |
+| Transcription | `{"type": "transcription", "text": "...", "is_final": bool}` | STT result |
+| LLM Text | `{"type": "llm_text", "text": "...", "is_final": bool}` | LLM response phrase (for display) |
+| TTS Audio | Binary | PCM 24kHz 16-bit mono audio chunks |
+| TTS Start | `{"type": "tts_start", "phrase_index": N}` | Phrase synthesis starting |
+| TTS Done | `{"type": "tts_done", "phrase_index": N, "duration": N}` | Phrase synthesis complete |
+| Status | `{"type": "status", "state": "..."}` | Pipeline state change |
+| Error | `{"type": "error", "message": "..."}` | Error occurred |
+| Closed | `{"type": "closed"}` | Session ended |
+
+**Pipeline States:**
+
+- `idle` - Waiting for input
+- `listening` - Receiving audio input
+- `processing` - STT + LLM in progress
+- `speaking` - TTS output playing
+- `interrupted` - Barge-in occurred
+
+**Example (JavaScript):**
+
+```javascript
+// Connect using project config (voice settings from llamafarm.yaml)
+const ws = new WebSocket(
+  'ws://localhost:14345/v1/default/my-voice-app/voice/chat'
+);
+
+// Override specific settings via query params
+const ws2 = new WebSocket(
+  'ws://localhost:14345/v1/default/my-voice-app/voice/chat?' +
+  'tts_voice=am_adam&' +  // Override voice from config
+  'speed=1.2'             // Override speed from config
+);
+
+// Handle session info
+ws.onopen = () => console.log('Connected');
+
+// Handle messages
+ws.onmessage = (event) => {
+  if (event.data instanceof Blob) {
+    // Binary TTS audio chunk - play it
+    playAudioChunk(event.data);
+  } else {
+    const msg = JSON.parse(event.data);
+    switch (msg.type) {
+      case 'session_info':
+        console.log('Session:', msg.session_id);
+        break;
+      case 'transcription':
+        console.log('You said:', msg.text);
+        break;
+      case 'llm_text':
+        console.log('Assistant:', msg.text);
+        break;
+      case 'status':
+        console.log('State:', msg.state);
+        break;
+      case 'error':
+        console.error('Error:', msg.message);
+        break;
+    }
+  }
+};
+
+// Send audio from microphone
+navigator.mediaDevices.getUserMedia({audio: true}).then(stream => {
+  const mediaRecorder = new MediaRecorder(stream, {mimeType: 'audio/webm'});
+  mediaRecorder.ondataavailable = (e) => ws.send(e.data);
+  mediaRecorder.start(100); // Send chunks every 100ms
+});
+
+// Signal end of speech (triggers processing)
+function endSpeech() {
+  ws.send(JSON.stringify({type: 'end'}));
+}
+
+// Barge-in: interrupt current TTS
+function interrupt() {
+  ws.send(JSON.stringify({type: 'interrupt'}));
+}
+```
+
+**Features:**
+
+- **Config-Driven**: Define voice settings in `llamafarm.yaml` for reproducible deployments
+- **Stateful Sessions**: Conversation history is maintained across turns
+- **Barge-in Support**: User can interrupt TTS playback to speak
+- **Low-Latency Streaming**: TTS starts as soon as LLM generates complete phrases
+- **Phrase Boundary Detection**: Natural speech pacing with intelligent text segmentation
+- **Session Resume**: Reconnect with `session_id` to continue conversations
+- **Prompt Inheritance**: System prompts from the LLM model config apply to voice chat
+
+---
+
 ## Health API
 
 ### Overall Health Check
@@ -5900,6 +6666,141 @@ curl -X POST http://localhost:14345/v1/vision/documents/extract \
 
 ---
 
+## Vision API (Detection, Classification & Streaming)
+
+The Vision Pipeline provides object detection, classification, segmentation, CLIP embeddings, and real-time streaming with automatic model improvement. These endpoints are available through the LlamaFarm server (port 14345).
+
+**Base URL:** `http://localhost:14345/v1/vision`
+
+**TIP: Full Documentation**
+For architecture details, cascade configuration, and the learning loop, see the [Vision Pipeline guide](../vision/index.md).
+
+### Object Detection
+
+**Endpoint:** `POST /v1/vision/detect`
+
+```bash
+curl -X POST http://localhost:14345/v1/vision/detect \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "yolov8n",
+    "images": ["data:image/png;base64,..."],
+    "confidence_threshold": 0.5,
+    "classes": ["person", "car"]
+  }'
+```
+
+### Image Classification (CLIP)
+
+**Endpoint:** `POST /v1/vision/classify`
+
+```bash
+curl -X POST http://localhost:14345/v1/vision/classify \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "openai/clip-vit-base-patch32",
+    "images": ["data:image/png;base64,..."],
+    "labels": ["cat", "dog", "bird"]
+  }'
+```
+
+### Segmentation
+
+**Endpoint:** `POST /v1/vision/segment`
+
+```bash
+curl -X POST http://localhost:14345/v1/vision/segment \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "yolov8n-seg",
+    "images": ["data:image/png;base64,..."],
+    "confidence_threshold": 0.5
+  }'
+```
+
+### CLIP Embeddings
+
+**Endpoint:** `POST /v1/vision/embed`
+
+```bash
+curl -X POST http://localhost:14345/v1/vision/embed \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "openai/clip-vit-base-patch32",
+    "images": ["data:image/png;base64,..."],
+    "texts": ["a photo of a bird"]
+  }'
+```
+
+### Streaming Session Management
+
+```bash
+# Start session with cascade
+curl -X POST http://localhost:14345/v1/vision/stream/start \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "yolov8n",
+    "cascade": {
+      "enabled": true,
+      "cascade_chain": ["yolov8n", "yolov8m"],
+      "confidence_threshold": 0.7
+    }
+  }'
+
+# Process frame
+curl -X POST http://localhost:14345/v1/vision/stream/frame \
+  -H "Content-Type: application/json" \
+  -d '{"session_id": "abc123", "image": "data:image/png;base64,..."}'
+
+# Stop session
+curl -X POST http://localhost:14345/v1/vision/stream/stop \
+  -H "Content-Type: application/json" \
+  -d '{"session_id": "abc123"}'
+```
+
+### Training
+
+```bash
+# Start training
+curl -X POST http://localhost:14345/v1/vision/train \
+  -H "Content-Type: application/json" \
+  -d '{"model": "yolov8n", "dataset_path": "/path/to/dataset", "epochs": 10}'
+
+# Check status
+curl http://localhost:14345/v1/vision/train/job_abc123
+
+# Auto-train status and trigger
+curl http://localhost:14345/v1/vision/auto-train/status
+curl -X POST http://localhost:14345/v1/vision/auto-train/trigger
+```
+
+### Federation
+
+```bash
+# Register peer
+curl -X POST http://localhost:14345/v1/vision/federation/peers \
+  -H "Content-Type: application/json" \
+  -d '{"name": "gpu-server", "url": "http://192.168.1.100:14345", "models": ["yolov8x"]}'
+
+# Create model package
+curl -X POST http://localhost:14345/v1/vision/federation/packages \
+  -H "Content-Type: application/json" \
+  -d '{"model_id": "my-detector", "model_path": "/path/to/best.pt"}'
+
+# Import model package
+curl -X POST http://localhost:14345/v1/vision/federation/packages/import \
+  -H "Content-Type: application/json" \
+  -d '{"source": "/path/to/package.tar.gz"}'
+```
+
+For the complete API with request/response schemas, see:
+- [Detection & Classification](../vision/detection.md)
+- [Streaming & Cascade](../vision/streaming.md)
+- [Training & Validation](../vision/training.md)
+- [Federation & Distribution](../vision/federation.md)
+
+---
+
 ## ML API (Custom Classifiers & Anomaly Detection)
 
 The ML API provides custom text classification and anomaly detection capabilities through the main LlamaFarm API server. These endpoints proxy to the Universal Runtime with automatic model versioning support.
@@ -5908,6 +6809,12 @@ The ML API provides custom text classification and anomaly detection capabilitie
 
 **TIP: Model Versioning**
 When `overwrite: false` (default), models are saved with timestamps like `my-model_20251215_155054`. Use the `-latest` suffix (e.g., `my-model-latest`) to automatically resolve to the newest version.
+
+**Endpoints supporting `-latest` resolution:**
+- `/v1/ml/classifier/predict`, `/v1/ml/classifier/load`
+- `/v1/ml/anomaly/score`, `/v1/ml/anomaly/detect`, `/v1/ml/anomaly/load`
+
+Note: The `fit` endpoints do NOT support `-latest` since they create new models.
 
 ### Custom Text Classification (SetFit)
 
@@ -5949,6 +6856,9 @@ Train a new text classifier.
 | `num_iterations` | int | No | 20 | Contrastive learning iterations |
 | `batch_size` | int | No | 16 | Training batch size |
 | `overwrite` | bool | No | false | If false, version with timestamp |
+
+**NOTE: Description Field**
+To add a description to a model, use the `/v1/ml/classifier/save` endpoint after fitting. The `description` parameter in fit requests is not persisted.
 
 **Response:**
 
@@ -6131,6 +7041,8 @@ Load a previously saved classifier.
 
 **Endpoint:** `DELETE /v1/ml/classifier/models/{model_name}`
 
+The `model_name` is the directory name (e.g., `intent-classifier_20251215_155054`). SetFit classifiers are stored as directories under `~/.llamafarm/models/classifier/`.
+
 ---
 
 ### Anomaly Detection
@@ -6186,7 +7098,7 @@ Train an anomaly detection model.
 | `backend` | string | No | "isolation_forest" | Algorithm: `isolation_forest`, `one_class_svm`, `local_outlier_factor`, `autoencoder` |
 | `data` | array | Yes | - | Training data (numeric arrays or dicts) |
 | `schema` | object | No | - | Feature encoding schema (required for dict data) |
-| `contamination` | float | No | 0.1 | Expected proportion of anomalies (0-0.5) |
+| `contamination` | float | No | 0.1 | Expected proportion of anomalies (must be >0 and ≤0.5) |
 | `overwrite` | bool | No | false | If false, version with timestamp |
 
 **Response:**
@@ -6351,6 +7263,8 @@ The anomalies detected are:
 
 **Endpoint:** `DELETE /v1/ml/anomaly/models/{filename}`
 
+The `filename` includes the file extension (e.g., `sensor-detector_isolation_forest.pkl`). Anomaly models are stored as `.pkl` files under `~/.llamafarm/models/anomaly/`.
+
 ---
 
 ## Universal Runtime API
@@ -6401,6 +7315,23 @@ nx start universal-runtime
 | **Anomaly** | `POST /v1/anomaly/load` | Load saved model |
 | **Anomaly** | `GET /v1/anomaly/models` | List saved models |
 | **Anomaly** | `DELETE /v1/anomaly/models/{filename}` | Delete saved model |
+| **Vision: Detection** | `POST /v1/vision/detect` | Detect objects (YOLO) |
+| **Vision: Classification** | `POST /v1/vision/classify` | Classify images (CLIP) |
+| **Vision: Segmentation** | `POST /v1/vision/segment` | Instance/semantic segmentation |
+| **Vision: Embeddings** | `POST /v1/vision/embed` | CLIP image/text embeddings |
+| **Vision: Streaming** | `POST /v1/vision/stream/start` | Start streaming session |
+| **Vision: Streaming** | `POST /v1/vision/stream/frame` | Process video frame |
+| **Vision: Streaming** | `POST /v1/vision/stream/stop` | Stop streaming session |
+| **Vision: Training** | `POST /v1/vision/train` | Start training job |
+| **Vision: Training** | `GET /v1/vision/train/{job_id}` | Training job status |
+| **Vision: Models** | `GET /v1/vision/models` | List vision models |
+| **Vision: Federation** | `GET /v1/vision/federation/peers` | List federation peers |
+| **Vision: Federation** | `POST /v1/vision/federation/escalate` | Inbound escalation |
+| **Vision: Federation** | `GET /v1/vision/federation/packages` | List model packages |
+
+**INFO: Classification Endpoints**
+- **`/v1/classify`** (Universal Runtime only) - Use pre-trained HuggingFace models for sentiment, spam detection, etc. This endpoint is NOT proxied through the main LlamaFarm server.
+- **`/v1/ml/classifier/*`** (LlamaFarm Server) - Train and use custom classifiers with your own categories via SetFit. Available at `http://localhost:14345`.
 
 ### Quick Examples
 
@@ -6459,6 +7390,7 @@ For complete documentation, see:
 
 ## Next Steps
 
+- Explore the [Vision Pipeline](../vision/index.md) for detection, streaming, and auto-training
 - Learn about [Configuration](../configuration/index.md)
 - Explore [RAG concepts](../rag/index.md)
 - Review [Examples](../examples/index.md)
@@ -6498,17 +7430,36 @@ For detailed configuration options, see these reference guides:
 Each database entry declares a store type (default `ChromaStore` or `QdrantStore`) and the embedding/retrieval strategies available.
 
 ```yaml
+components:
+  embedding_strategies:
+    - name: default_embeddings
+      type: UniversalEmbedder
+      config:
+        model: sentence-transformers/all-MiniLM-L6-v2
+  retrieval_strategies:
+    - name: semantic_search
+      type: BasicSimilarityStrategy
+      config:
+        top_k: 5
+  defaults:
+    embedding_strategy: default_embeddings
+    retrieval_strategy: semantic_search
+
 rag:
   databases:
     - name: main_db
+      type: ChromaStore
+      embedding_strategy: default_embeddings   # reference to components
+      retrieval_strategy: semantic_search      # reference to components
+    - name: hybrid_db
       type: ChromaStore
       default_embedding_strategy: default_embeddings
       default_retrieval_strategy: semantic_search
       embedding_strategies:
         - name: default_embeddings
-          type: OllamaEmbedder
+          type: UniversalEmbedder
           config:
-            model: nomic-embed-text:latest
+            model: sentence-transformers/all-MiniLM-L6-v2
       retrieval_strategies:
         - name: semantic_search
           type: VectorRetriever
@@ -6524,6 +7475,10 @@ rag:
 - Add multiple strategies for different workloads (semantic, keyword, reranked).
 - Set `default_*` fields to control CLI defaults.
 - Extend store/types by editing `rag/schema.yaml` and following the [Extending guide](../extending/index.md#extend-rag-components).
+- References vs inline:
+  - Use references (`embedding_strategy`, `retrieval_strategy`) to DRY configs; defaults apply when fields are omitted.
+  - Inline arrays (`embedding_strategies`, `retrieval_strategies`) still work for one-off configs.
+  - The server resolves references at load time and returns fully inlined configs on GET.
 
 ## Define Processing Strategies
 
@@ -6557,8 +7512,8 @@ rag:
    ```bash
    lf datasets create -s pdf_ingest -b main_db research-notes
    ```
-2. **Upload** files via `lf datasets upload` (supports globs and directories). The CLI stores file hashes for dedupe.
-3. **Process** documents with `lf datasets process research-notes`. The server schedules a Celery job; monitor progress in the CLI output and server logs.
+2. **Upload** files via `lf datasets upload` (supports globs and directories). Auto-processing runs by default; use `--no-process` or `--bulk` for batch uploads.
+3. **Process** documents with `lf datasets process research-notes` only when you skipped auto-processing. The server schedules a Celery job; monitor progress in the CLI output and server logs.
 4. **Query** with `lf rag query` to validate retrieval quality.
 
 ## Querying & Retrieval Strategies
@@ -9477,7 +10432,43 @@ LlamaFarm selects an agent handler based on configuration:
 - **RAG chat** – augments prompts with retrieved context, citations, and guardrails.
 - **Classifier / Custom** – future handlers for specialized workflows.
 
-Choose handler behaviour in your project configuration (e.g., advanced agents defined by the server). Ensure the model supports the required features—some small models (TinyLlama) don’t handle tools, so stick with simple chat.
+Choose handler behaviour in your project configuration (e.g., advanced agents defined by the server). Ensure the model supports the required features—some small models (TinyLlama) don't handle tools, so stick with simple chat.
+
+## Inline Tools with Dynamic Variables
+
+Models can define tools inline in the config, and these tools support dynamic variable substitution:
+
+```yaml
+runtime:
+  models:
+    - name: assistant
+      provider: universal
+      model: llama3.2:3b
+      tool_call_strategy: native_api
+      tools:
+        - type: function
+          name: search_docs
+          description: "Search {{company_name | the company}} documentation"
+          parameters:
+            type: object
+            properties:
+              query:
+                type: string
+                description: "Search query for {{department | general}} topics"
+            required:
+              - query
+```
+
+Pass values at request time via the `variables` field:
+
+```bash
+curl -X POST .../chat/completions -d '{
+  "messages": [{"role": "user", "content": "Find shipping info"}],
+  "variables": {"company_name": "Acme Corp", "department": "logistics"}
+}'
+```
+
+See [Dynamic Variables](../prompts/index.md#dynamic-variables) for full syntax documentation.
 
 ## Lemonade Runtime
 
@@ -9527,7 +10518,7 @@ runtime:
 - **Hardware acceleration**: Automatically detects and uses Metal (macOS), CUDA (NVIDIA), Vulkan (AMD/Intel), or CPU
 - **Multiple backends**: llamacpp (GGUF models), ONNX, or Transformers (PyTorch)
 - **OpenAI-compatible API**: Drop-in replacement for OpenAI-compatible endpoints
-- **Port 11534**: Default port (different from LlamaFarm's 8000 and Ollama's 11434)
+- **Port 11534**: Default port (different from LlamaFarm's 14345 and Ollama's 11434)
 
 ### Multi-Model with Lemonade
 
@@ -9577,11 +10568,90 @@ The Universal Runtime is LlamaFarm's most versatile runtime provider, supporting
 **Current Support (Production):**
 - **HuggingFace Transformers** – All PyTorch text models (GPT-2, Llama, Mistral, Qwen, Phi, BERT, etc.)
 - **HuggingFace Diffusers** – All PyTorch diffusion models (Stable Diffusion, SDXL, FLUX)
+- **GGUF Models** – Quantized models via llama.cpp (supports offline loading from HuggingFace cache)
 - **Model Types**: Text Generation, Embeddings, Image Generation, Vision Classification, Audio Processing, Multimodal
 
 **Coming Soon:**
 - **ONNX Runtime** – 2-5x faster inference with automatic model conversion
 - **TensorRT** – GPU-optimized inference for NVIDIA hardware
+
+### GGUF Model Configuration
+
+Universal Runtime supports GGUF models via llama.cpp with full parameter control. This is especially useful for **memory-constrained devices** like Jetson Orin Nano (8GB shared memory).
+
+**Key Features:**
+- **Offline Loading**: Models cached locally are used without network calls
+- **Memory Guard**: Automatic batch size reduction when available memory is low
+- **Full Parameter Passthrough**: Configure all llama.cpp parameters via `extra_body`
+
+#### GGUF Parameters Reference
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `n_ctx` | int | Context window size. Lower = less memory. Auto-detected if not set. |
+| `n_batch` | int | Batch size for prompt processing. Lower values (512) reduce memory. |
+| `n_gpu_layers` | int | GPU layer count. `-1` = all layers on GPU. |
+| `n_threads` | int | CPU thread count. Auto-detected if not set. |
+| `flash_attn` | bool | Enable flash attention for faster inference. |
+| `use_mmap` | bool | Memory-map model file. Recommended for large models. |
+| `use_mlock` | bool | Lock model in RAM. Set `false` on constrained devices. |
+| `cache_type_k` | string | KV cache key quantization: `f32`, `f16`, `q8_0`, `q4_0`, etc. |
+| `cache_type_v` | string | KV cache value quantization. `q4_0` reduces cache by ~4x. |
+
+#### Example: Jetson Orin Nano Configuration
+
+```yaml
+runtime:
+  models:
+    - name: qwen3-8b
+      provider: universal
+      model: unsloth/Qwen3-8B-GGUF:Q4_K_M
+      base_url: http://127.0.0.1:11540
+      extra_body:
+        n_ctx: 2048          # Small context to save KV cache memory
+        n_batch: 512         # Reduced batch for smaller compute buffer
+        n_gpu_layers: -1     # Full GPU offload
+        flash_attn: true     # Enable flash attention
+        use_mmap: true       # Memory-map for efficient swapping
+        use_mlock: false     # Allow OS memory management
+        cache_type_k: q4_0   # Quantize KV cache keys
+        cache_type_v: q4_0   # Quantize KV cache values
+```
+
+#### Memory Estimation
+
+| Parameter | Memory Impact |
+|-----------|--------------|
+| `n_ctx: 2048` | ~256MB KV cache |
+| `n_ctx: 8192` | ~1GB KV cache |
+| `n_batch: 2048` | ~1.2GB compute buffer |
+| `n_batch: 512` | ~300MB compute buffer |
+| `cache_type: q4_0` | ~4x reduction vs f16 |
+
+#### Memory Guard (Automatic)
+
+When available memory drops below 3GB, Universal Runtime automatically:
+1. Reduces `n_batch` from 2048 to 512
+2. Logs a warning with the adjustment
+
+This prevents out-of-memory crashes on constrained devices.
+
+#### Offline Operation
+
+GGUF models support fully offline operation:
+1. Download model once (requires network)
+2. Model is cached in `~/.cache/huggingface/hub/`
+3. Subsequent loads use cache without network
+4. Works on air-gapped systems
+
+```bash
+# First run downloads the model
+curl -X POST http://localhost:11540/v1/chat/completions \
+  -d '{"model": "unsloth/Qwen3-1.7B-GGUF:Q4_K_M", "messages": [...]}'
+
+# Subsequent runs work offline
+# (disconnect network and it still works)
+```
 
 ### Quick Setup
 
@@ -9870,16 +10940,20 @@ Beyond text generation, the Universal Runtime provides specialized ML capabiliti
 | **Text Classification** | `POST /v1/classify` | Sentiment analysis, routing |
 | **Named Entity Recognition** | `POST /v1/ner` | Extract people, places, organizations |
 | **Reranking** | `POST /v1/rerank` | Improve RAG retrieval accuracy |
-| **Anomaly Detection** | `POST /v1/anomaly/*` | Detect outliers in data |
+| **Anomaly Detection** | `POST /v1/ml/anomaly/*` | Detect outliers in data |
 
 See the detailed guides:
 - [Specialized ML Models](./specialized-ml.md) - OCR, document extraction, classification, NER, reranking
-- [Anomaly Detection Guide](./anomaly-detection.md) - Complete anomaly detection documentation
+- [Anomaly Detection Guide](./anomaly-detection.md) - Batch anomaly detection for training and scoring
+- [Streaming Anomaly Detection](./streaming-anomaly-detection.md) - Real-time streaming with auto-retraining
+- [Polars Buffer API](./polars-buffers.md) - High-performance data buffers for feature engineering
 
 ## Next Steps
 
 - [Specialized ML Models](./specialized-ml.md) – OCR, document extraction, and more.
 - [Anomaly Detection](./anomaly-detection.md) – detect outliers in your data.
+- [Streaming Anomaly Detection](./streaming-anomaly-detection.md) – real-time streaming detection.
+- [Polars Buffer API](./polars-buffers.md) – direct access to Polars data buffers.
 - [Configuration Guide](../configuration/index.md) – runtime schema details.
 - [Extending runtimes](../extending/index.md#extend-runtimes) – step-by-step provider integration.
 - [Prompts](../prompts/index.md) – control how system prompts interact with runtime capabilities.
@@ -9900,7 +10974,11 @@ Beyond text generation, the Universal Runtime provides a comprehensive suite of 
 | [Custom Classification](#custom-text-classification-setfit) | `POST /v1/classifier/*` | Train your own classifier with few examples |
 | [Named Entity Recognition](#named-entity-recognition-ner) | `POST /v1/ner` | Extract people, places, organizations |
 | [Reranking](#reranking-cross-encoder) | `POST /v1/rerank` | Improve RAG retrieval accuracy |
-| [Anomaly Detection](#anomaly-detection) | `POST /v1/anomaly/*` | Detect outliers in numeric/mixed data |
+| [Anomaly Detection](#anomaly-detection) | `POST /v1/ml/anomaly/*` | Detect outliers in numeric/mixed data |
+| [Object Detection](../vision/detection) | `POST /v1/vision/detect` | Detect objects with YOLO models |
+| [Image Classification](../vision/detection#image-classification) | `POST /v1/vision/classify` | CLIP zero-shot classification |
+| [Segmentation](../vision/detection#segmentation) | `POST /v1/vision/segment` | Instance/semantic segmentation |
+| [CLIP Embeddings](../vision/detection#clip-embeddings) | `POST /v1/vision/embed` | Multimodal image/text embeddings |
 
 ## Starting the Universal Runtime
 
@@ -9913,6 +10991,19 @@ LF_RUNTIME_PORT=8080 nx start universal-runtime
 ```
 
 The server runs on `http://localhost:11540` by default.
+
+### Model Caching
+
+The Universal Runtime caches loaded models in memory for faster inference on repeated requests:
+
+- **Default TTL:** 5 minutes (300 seconds) of inactivity before unloading
+- **Environment variable:** Set `MODEL_UNLOAD_TIMEOUT` to customize (in seconds)
+- **Flash Attention 2:** Automatically enabled on CUDA devices for compatible models
+
+```bash
+# Keep models loaded for 30 minutes
+MODEL_UNLOAD_TIMEOUT=1800 nx start universal-runtime
+```
 
 ---
 
@@ -10116,6 +11207,9 @@ Use **pre-trained HuggingFace models** for common classification tasks like sent
 | `facebook/bart-large-mnli` | Zero-shot classification |
 | `cardiffnlp/twitter-roberta-base-sentiment-latest` | Social media sentiment |
 
+**TIP: Model Quantization**
+You can use quantized models for faster inference by appending a quantization suffix: `model:Q4_K_M`. For example: `distilbert-base-uncased-finetuned-sst-2-english:Q4_K_M`
+
 ### Basic Classification
 
 ```bash
@@ -10127,9 +11221,18 @@ curl -X POST http://localhost:11540/v1/classify \
       "I love this product!",
       "This is terrible and broken.",
       "It works okay I guess."
-    ]
+    ],
+    "max_length": 512
   }'
 ```
+
+**Request Fields:**
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `model` | string | Yes | - | HuggingFace model ID |
+| `texts` | array | Yes | - | Texts to classify |
+| `max_length` | int | No | auto | Max sequence length (auto-detects: 8192 for ModernBERT, 512 for classic BERT) |
 
 ### Response Format
 
@@ -10175,15 +11278,18 @@ SetFit uses contrastive learning to fine-tune a sentence-transformer model on yo
 The LlamaFarm API (`/v1/ml/classifier/*`) provides the same functionality as the Universal Runtime with added features:
 - **Model Versioning**: Automatic timestamped versions when `overwrite: false`
 - **Latest Resolution**: Use `model-name-latest` to auto-resolve to the newest version
-- **File Upload Support**: Direct file handling without base64 encoding
 
 ```bash
-# Via LlamaFarm API (port 8000)
+# Via LlamaFarm API (port 14345)
 curl -X POST http://localhost:14345/v1/ml/classifier/fit ...
 
 # Via Universal Runtime (port 11540)
 curl -X POST http://localhost:11540/v1/classifier/fit ...
 ```
+
+**WARNING: Server vs Universal Runtime**
+- **`/v1/classify`** (pre-trained models) is **only available on Universal Runtime** (port 11540). It is NOT proxied through the LlamaFarm server.
+- **`/v1/ml/classifier/*`** (custom SetFit classifiers) is available on the LlamaFarm server (port 14345) and proxies to Universal Runtime.
 
 ### Step 1: Train Your Classifier
 
@@ -10270,6 +11376,13 @@ curl -X POST http://localhost:11540/v1/classifier/save \
   "status": "saved"
 }
 ```
+
+**NOTE: Storage Structure**
+SetFit classifiers are stored as **directories** (not files) under `~/.llamafarm/models/classifier/`. Each directory contains:
+- Model weights and config
+- `labels.txt` - Class labels for the classifier
+
+**Note:** Models are auto-saved immediately after fitting, so explicit save is optional but recommended for adding descriptions.
 
 ### Loading Saved Models
 
@@ -10455,11 +11568,11 @@ Detect outliers and anomalies in numeric and mixed data using multiple algorithm
 
 See the dedicated [Anomaly Detection Guide](./anomaly-detection.md) for complete documentation.
 
-### Quick Example
+### Quick Example (LlamaFarm API - Recommended)
 
 ```bash
 # 1. Train on normal data
-curl -X POST http://localhost:11540/v1/anomaly/fit \
+curl -X POST http://localhost:14345/v1/ml/anomaly/fit \
   -H "Content-Type: application/json" \
   -d '{
     "model": "api-monitor",
@@ -10469,7 +11582,7 @@ curl -X POST http://localhost:11540/v1/anomaly/fit \
   }'
 
 # 2. Detect anomalies in new data
-curl -X POST http://localhost:11540/v1/anomaly/detect \
+curl -X POST http://localhost:14345/v1/ml/anomaly/detect \
   -H "Content-Type: application/json" \
   -d '{
     "model": "api-monitor",
@@ -10522,6 +11635,7 @@ Files are stored temporarily (5-minute TTL by default).
 
 ## Next Steps
 
+- [Vision Pipeline](../vision/index.md) - Object detection, streaming cascade, auto-training, and federation
 - [Anomaly Detection Guide](./anomaly-detection.md) - Complete anomaly detection documentation
 - [Universal Runtime Overview](./index.md#universal-runtime) - General runtime configuration
 - [API Reference](../api/index.md) - Full API documentation
@@ -10549,7 +11663,7 @@ The LlamaFarm API (`/v1/ml/anomaly/*`) provides the same functionality as the Un
 - **Latest Resolution**: Use `model-name-latest` to auto-resolve to the newest version
 
 ```bash
-# Via LlamaFarm API (port 8000) - with versioning
+# Via LlamaFarm API (port 14345) - with versioning
 curl -X POST http://localhost:14345/v1/ml/anomaly/fit \
   -H "Content-Type: application/json" \
   -d '{"model": "sensor-monitor", "backend": "isolation_forest", "data": [...], "overwrite": false}'
@@ -10565,7 +11679,7 @@ curl -X POST http://localhost:14345/v1/ml/anomaly/detect \
 ### 1. Train on Normal Data
 
 ```bash
-curl -X POST http://localhost:11540/v1/anomaly/fit \
+curl -X POST http://localhost:14345/v1/ml/anomaly/fit \
   -H "Content-Type: application/json" \
   -d '{
     "model": "sensor-monitor",
@@ -10582,7 +11696,7 @@ curl -X POST http://localhost:11540/v1/anomaly/fit \
 ### 2. Detect Anomalies
 
 ```bash
-curl -X POST http://localhost:11540/v1/anomaly/detect \
+curl -X POST http://localhost:14345/v1/ml/anomaly/detect \
   -H "Content-Type: application/json" \
   -d '{
     "model": "sensor-monitor",
@@ -10907,6 +12021,33 @@ Neural network learns to compress (encode) and reconstruct (decode) normal data.
 | Complex patterns | Medium | Medium | Medium | Excellent |
 | GPU support | No | No | No | Yes |
 
+### All Available Backends (PyOD)
+
+LlamaFarm supports 12 anomaly detection backends powered by PyOD. Use `GET /v1/ml/anomaly/backends` to list all with metadata.
+
+| Backend | Category | Speed | Memory | Best For |
+|---------|----------|-------|--------|----------|
+| `isolation_forest` | Legacy | Fast | Low | General purpose (recommended default) |
+| `one_class_svm` | Legacy | Slow | Medium | Small datasets, tight boundaries |
+| `local_outlier_factor` | Legacy | Medium | Medium | Local/density-based anomalies |
+| `autoencoder` | Deep Learning | Slow | High | Complex patterns, large datasets |
+| `ecod` | Fast | Very Fast | Low | **Recommended for new projects** - parameter-free |
+| `hbos` | Fast | Very Fast | Low | Fastest algorithm, high dimensions |
+| `copod` | Fast | Very Fast | Low | Parameter-free, interpretable |
+| `knn` | Distance | Medium | Medium | When density matters |
+| `mcd` | Distance | Medium | Medium | Gaussian-distributed data |
+| `cblof` | Clustering | Medium | Medium | Clustered data |
+| `suod` | Ensemble | Medium | Medium | Most robust, combines multiple algorithms |
+| `loda` | Streaming | Fast | Low | Online/streaming scenarios |
+
+**Backend Categories:**
+- **Legacy**: Original 4 backends with backward compatibility
+- **Fast**: Parameter-free or minimal tuning, good for quick experiments
+- **Distance**: Use distance metrics for anomaly scoring
+- **Clustering**: Leverage cluster structure in data
+- **Ensemble**: Combine multiple algorithms
+- **Deep Learning**: Neural network approaches
+
 ---
 
 ## Understanding Contamination
@@ -10968,11 +12109,11 @@ Training data: [normal, normal, normal, anomaly, normal, ...]
 
 ```bash
 # Start conservative (assume clean training data)
-curl -X POST http://localhost:11540/v1/anomaly/fit \
+curl -X POST http://localhost:14345/v1/ml/anomaly/fit \
   -d '{"model": "test", "data": [...], "contamination": 0.05}'
 
 # Test on data with known anomalies
-curl -X POST http://localhost:11540/v1/anomaly/score \
+curl -X POST http://localhost:14345/v1/ml/anomaly/score \
   -d '{"model": "test", "data": [known_normal, known_anomaly, ...]}'
 
 # If too many false positives → increase contamination
@@ -11000,7 +12141,7 @@ Real-world data often includes both numeric and categorical features. Use the `s
 
 ```bash
 # Train with mixed data
-curl -X POST http://localhost:11540/v1/anomaly/fit \
+curl -X POST http://localhost:14345/v1/ml/anomaly/fit \
   -H "Content-Type: application/json" \
   -d '{
     "model": "api-log-detector",
@@ -11024,7 +12165,7 @@ curl -X POST http://localhost:11540/v1/anomaly/fit \
 
 ```bash
 # Detect anomalies (schema already learned)
-curl -X POST http://localhost:11540/v1/anomaly/detect \
+curl -X POST http://localhost:14345/v1/ml/anomaly/detect \
   -H "Content-Type: application/json" \
   -d '{
     "model": "api-log-detector",
@@ -11048,7 +12189,7 @@ The encoder is automatically cached with the model - no need to pass the schema 
 After training, save the model for production use:
 
 ```bash
-curl -X POST http://localhost:11540/v1/anomaly/save \
+curl -X POST http://localhost:14345/v1/ml/anomaly/save \
   -H "Content-Type: application/json" \
   -d '{
     "model": "api-log-detector",
@@ -11076,7 +12217,7 @@ Models are saved to `~/.llamafarm/models/anomaly/` with auto-generated filenames
 Load a pre-trained model (e.g., after server restart):
 
 ```bash
-curl -X POST http://localhost:11540/v1/anomaly/load \
+curl -X POST http://localhost:14345/v1/ml/anomaly/load \
   -H "Content-Type: application/json" \
   -d '{
     "model": "api-log-detector",
@@ -11089,7 +12230,7 @@ The model is loaded from the standard location based on its name. The encoder an
 ### List Saved Models
 
 ```bash
-curl http://localhost:11540/v1/anomaly/models
+curl http://localhost:14345/v1/ml/anomaly/models
 ```
 
 Response:
@@ -11108,14 +12249,213 @@ Response:
 ### Delete Model
 
 ```bash
-curl -X DELETE http://localhost:11540/v1/anomaly/models/api_detector_v1.joblib
+curl -X DELETE http://localhost:14345/v1/ml/anomaly/models/api_detector_v1.joblib
+```
+
+---
+
+## Streaming Anomaly Detection
+
+For real-time data streams, LlamaFarm provides a streaming API that handles:
+- **Cold start**: Collects samples before first training
+- **Auto-retraining**: Periodically retrains on new data
+- **Sliding window**: Maintains recent history for context
+- **Tick-Tock pattern**: Seamless model updates without downtime
+
+### Quick Start
+
+```bash
+# Send streaming data points
+curl -X POST http://localhost:14345/v1/ml/anomaly/stream \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "live-sensor",
+    "data": {"temperature": 72.5, "humidity": 45.2},
+    "backend": "ecod",
+    "min_samples": 50,
+    "retrain_interval": 100,
+    "window_size": 1000,
+    "threshold": 0.5
+  }'
+```
+
+### Streaming Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `model` | "default-stream" | Unique detector identifier |
+| `data` | required | Single dict or batch of dicts |
+| `backend` | "ecod" | PyOD backend (ecod recommended for streaming) |
+| `min_samples` | 50 | Samples before first training (cold start) |
+| `retrain_interval` | 100 | Retrain after this many new samples |
+| `window_size` | 1000 | Sliding window size (keeps recent N samples) |
+| `threshold` | 0.5 | Anomaly score threshold |
+| `contamination` | 0.1 | Expected outlier proportion |
+| `rolling_windows` | null | Optional: [5, 10, 20] for rolling features |
+| `include_lags` | false | Include lag features |
+
+### Response Statuses
+
+- **collecting**: Cold start phase, building initial dataset
+- **ready**: Model trained, returning anomaly scores
+- **retraining**: Background retrain in progress (still scoring)
+
+```json
+{
+  "object": "streaming_result",
+  "model": "live-sensor",
+  "status": "ready",
+  "results": [
+    {
+      "index": 0,
+      "score": 0.42,
+      "is_anomaly": false,
+      "raw_score": 0.38,
+      "samples_until_ready": 0
+    }
+  ],
+  "model_version": 3,
+  "samples_collected": 350,
+  "samples_until_ready": 0,
+  "threshold": 0.5
+}
+```
+
+### Managing Streaming Detectors
+
+```bash
+# List all active detectors
+curl http://localhost:14345/v1/ml/anomaly/stream/detectors
+
+# Get specific detector stats
+curl http://localhost:14345/v1/ml/anomaly/stream/live-sensor
+
+# Reset detector (clears data, restarts cold start)
+curl -X POST http://localhost:14345/v1/ml/anomaly/stream/live-sensor/reset
+
+# Delete detector
+curl -X DELETE http://localhost:14345/v1/ml/anomaly/stream/live-sensor
+```
+
+### Recommended Backends for Streaming
+
+| Backend | Why |
+|---------|-----|
+| `ecod` | **Recommended** - Fast, parameter-free, handles drift |
+| `hbos` | Fastest, good for high-throughput streams |
+| `loda` | Designed for streaming, lightweight |
+| `isolation_forest` | Reliable, good baseline |
+
+---
+
+## Polars Buffer API
+
+For advanced use cases, LlamaFarm exposes direct access to Polars-based data buffers. These provide:
+- **High-performance columnar storage** using Polars DataFrames
+- **Automatic sliding window** truncation
+- **Rolling feature computation** (mean, std, min, max)
+- **Lag features** for temporal patterns
+
+**TIP: When to Use Polars Buffers**
+Most users should use the streaming anomaly detection API, which manages Polars buffers automatically. Use the direct Polars API when you need:
+- Custom feature engineering pipelines
+- Integration with other ML systems
+- Manual control over data lifecycle
+
+### Create a Buffer
+
+```bash
+curl -X POST http://localhost:14345/v1/ml/polars/buffers \
+  -H "Content-Type: application/json" \
+  -d '{"buffer_id": "sensor-data", "window_size": 1000}'
+```
+
+### Append Data
+
+```bash
+# Single record
+curl -X POST http://localhost:14345/v1/ml/polars/append \
+  -H "Content-Type: application/json" \
+  -d '{
+    "buffer_id": "sensor-data",
+    "data": {"temperature": 72.5, "humidity": 45.2}
+  }'
+
+# Batch append
+curl -X POST http://localhost:14345/v1/ml/polars/append \
+  -H "Content-Type: application/json" \
+  -d '{
+    "buffer_id": "sensor-data",
+    "data": [
+      {"temperature": 72.5, "humidity": 45.2},
+      {"temperature": 73.1, "humidity": 44.8},
+      {"temperature": 71.9, "humidity": 46.0}
+    ]
+  }'
+```
+
+### Compute Rolling Features
+
+```bash
+curl -X POST http://localhost:14345/v1/ml/polars/features \
+  -H "Content-Type: application/json" \
+  -d '{
+    "buffer_id": "sensor-data",
+    "rolling_windows": [5, 10, 20],
+    "include_rolling_stats": ["mean", "std", "min", "max"],
+    "include_lags": true,
+    "lag_periods": [1, 2, 3],
+    "tail": 10
+  }'
+```
+
+Response includes computed columns like:
+- `temperature_rolling_mean_5`, `temperature_rolling_std_10`
+- `humidity_rolling_min_20`, `humidity_rolling_max_5`
+- `temperature_lag_1`, `humidity_lag_2`
+
+### Buffer Management
+
+```bash
+# List all buffers
+curl http://localhost:14345/v1/ml/polars/buffers
+
+# Get buffer stats
+curl http://localhost:14345/v1/ml/polars/buffers/sensor-data
+
+# Get raw data
+curl "http://localhost:14345/v1/ml/polars/buffers/sensor-data/data?tail=10"
+
+# Get data with features
+curl "http://localhost:14345/v1/ml/polars/buffers/sensor-data/data?with_features=true&tail=10"
+
+# Clear buffer (keep structure)
+curl -X POST http://localhost:14345/v1/ml/polars/buffers/sensor-data/clear
+
+# Delete buffer
+curl -X DELETE http://localhost:14345/v1/ml/polars/buffers/sensor-data
+```
+
+### Buffer Statistics
+
+```json
+{
+  "buffer_id": "sensor-data",
+  "size": 500,
+  "window_size": 1000,
+  "columns": ["temperature", "humidity"],
+  "numeric_columns": ["temperature", "humidity"],
+  "memory_bytes": 8000,
+  "append_count": 500,
+  "avg_append_ms": 0.15
+}
 ```
 
 ---
 
 ## API Reference
 
-### POST /v1/anomaly/fit
+### POST /v1/ml/anomaly/fit
 
 Train an anomaly detector on data assumed to be mostly normal.
 
@@ -11152,7 +12492,7 @@ Train an anomaly detector on data assumed to be mostly normal.
 }
 ```
 
-### POST /v1/anomaly/score
+### POST /v1/ml/anomaly/score
 
 Score data points for anomalies. Returns all points with scores.
 
@@ -11185,11 +12525,11 @@ Score data points for anomalies. Returns all points with scores.
 }
 ```
 
-### POST /v1/anomaly/detect
+### POST /v1/ml/anomaly/detect
 
 Detect anomalies (returns only anomalous points).
 
-Same request format as `/score`, but response only includes points classified as anomalies.
+Same request format as `/v1/ml/anomaly/score`, but response only includes points classified as anomalies.
 The response does not include an `is_anomaly` field since all returned points are anomalies.
 
 **Response:**
@@ -11207,7 +12547,7 @@ The response does not include an `is_anomaly` field since all returned points ar
 }
 ```
 
-### POST /v1/anomaly/save
+### POST /v1/ml/anomaly/save
 
 Save a fitted model to disk. Models are saved to `~/.llamafarm/models/anomaly/` with auto-generated filenames.
 
@@ -11219,7 +12559,7 @@ Save a fitted model to disk. Models are saved to `~/.llamafarm/models/anomaly/` 
 }
 ```
 
-### POST /v1/anomaly/load
+### POST /v1/ml/anomaly/load
 
 Load a pre-trained model from disk. The file is automatically located based on model name and backend.
 
@@ -11231,11 +12571,11 @@ Load a pre-trained model from disk. The file is automatically located based on m
 }
 ```
 
-### GET /v1/anomaly/models
+### GET /v1/ml/anomaly/models
 
 List all saved models.
 
-### DELETE /v1/anomaly/models/\{filename\}
+### DELETE /v1/ml/anomaly/models/\{filename\}
 
 Delete a saved model.
 
@@ -11384,7 +12724,7 @@ Detect malicious network activity:
 ### Threshold Tuning
 
 1. **Use the learned threshold**: The runtime automatically computes a threshold during training based on the `contamination` parameter (percentile of normalized scores). This learned threshold is returned in the fit response and used by default.
-2. **Override when needed**: You can pass a custom `threshold` parameter to `/v1/anomaly/score` or `/v1/anomaly/detect` endpoints.
+2. **Override when needed**: You can pass a custom `threshold` parameter to `/v1/ml/anomaly/score` or `/v1/ml/anomaly/detect` endpoints.
 3. **Match normalization to threshold**:
    - `standardization`: threshold 0.5-0.9
    - `zscore`: threshold 2.0-4.0
@@ -11465,7 +12805,7 @@ LF_DATA_DIR=/path/to/llamafarm/data
 
 # Prompts
 
-Prompts in LlamaFarm are simple but powerful: you define static instructions in `llamafarm.yaml`, and the runtime merges them with chat history and (optionally) RAG context. This section outlines current capabilities and roadmap plans.
+Prompts in LlamaFarm are simple but powerful: you define instructions in `llamafarm.yaml`, and the runtime merges them with chat history and (optionally) RAG context. Prompts support **dynamic variable substitution** using Jinja2-style `{{variable}}` syntax, allowing you to customize behavior per-request.
 
 ## Prompt Configuration
 
@@ -11486,22 +12826,114 @@ prompts:
 - Models can specify which prompt sets to use via `prompts: [list of names]`; if omitted, all prompts stack in definition order.
 - Combine with RAG by including instructions explaining how to use context snippets (the server injects them automatically).
 
+## Dynamic Variables
+
+Use Jinja2-style template syntax to inject values at request time. This is ideal for personalizing prompts per user, session, or context.
+
+### Syntax
+
+```yaml
+# Required variable (error if not provided)
+content: "Hello {{user_name}}"
+
+# Variable with default (uses default if not provided)
+content: "Welcome to {{company | Our Service}}"
+
+# Whitespace is allowed
+content: "Hello {{ user_name }}"
+```
+
+### Example: Personalized Customer Service
+
+```yaml
+prompts:
+  - name: system
+    messages:
+      - role: system
+        content: |
+          You are a helpful customer service assistant for {{company_name | Acme Corp}}.
+          You work in the {{department | General}} department.
+          Current date: {{current_date | today}}
+          Be professional, helpful, and concise in your responses.
+
+  - name: context
+    messages:
+      - role: system
+        content: |
+          ## Customer Information
+          - Name: {{user_name | Valued Customer}}
+          - Account Tier: {{account_tier | standard}}
+          - Preferred Language: {{language | English}}
+
+          Adjust your responses based on the customer's tier:
+          - basic: Focus on self-service options
+          - standard: Provide helpful guidance
+          - premium: Offer personalized, detailed assistance
+```
+
+### Passing Variables via API
+
+Variables are passed in the `variables` field of the chat request:
+
+```bash
+curl -X POST http://localhost:14345/v1/projects/my-org/chatbot/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "messages": [{"role": "user", "content": "Hello!"}],
+    "variables": {
+      "company_name": "TechCorp Solutions",
+      "user_name": "Alice Johnson",
+      "account_tier": "premium",
+      "current_date": "2024-01-15"
+    }
+  }'
+```
+
+### Variable Behavior
+
+| Scenario | Syntax | Result |
+|----------|--------|--------|
+| Variable provided | `{{name}}` with `{"name": "Alice"}` | `Alice` |
+| Variable with default, not provided | `{{name \| Guest}}` with `{}` | `Guest` |
+| Required variable missing | `{{name}}` with `{}` | **Error 400** |
+| Null value | `{{name}}` with `{"name": null}` | Empty string |
+| Non-string types | `{{count}}` with `{"count": 42}` | `42` (converted) |
+
+### Supported Types
+
+Variable values can be:
+- **String** - Inserted as-is
+- **Integer** - Converted to string (e.g., `42` → `"42"`)
+- **Float** - Converted to string (e.g., `3.14` → `"3.14"`)
+- **Boolean** - Converted to `True` or `False` (Python-style)
+- **None/null** - Converted to empty string
+
+Complex types (lists, dicts) are **not supported** and will raise an error.
+
 ## Best Practices
 
-- **Explain context usage**: remind the model that context chunks contain citations or metadata.
-- **Handle non-RAG scenarios**: mention what to do when no documents are retrieved (“answer from general knowledge” or “state that no information was found”).
-- **Keep prompts concise**: long system instructions can reduce available tokens on smaller models.
-- **Avoid conflicting instructions**: align prompts with agent handler expectations (structured vs. simple chat).
+- **Use defaults for optional context**: Always provide defaults for variables that might not be passed in every request.
+- **Keep required variables minimal**: Only mark variables as required (no default) when they're truly essential.
+- **Explain context usage**: Remind the model that context chunks contain citations or metadata.
+- **Handle non-RAG scenarios**: Mention what to do when no documents are retrieved.
+- **Keep prompts concise**: Long system instructions can reduce available tokens on smaller models.
+- **Avoid conflicting instructions**: Align prompts with agent handler expectations (structured vs. simple chat).
 
-## Roadmap & Limitations
+## Use Cases
 
-- Prompt templates, versioning, and evaluation tooling are in development. Track progress in the roadmap.
-- For now, dynamic templating (Jinja, variables) is not built-in—generate prompts upstream if needed.
+Dynamic variables are ideal for:
+
+- **Multi-tenant applications** - Customize branding per customer (`{{company_name}}`)
+- **Personalization** - Inject user names, preferences, or roles
+- **A/B testing** - Swap prompt variants without config changes
+- **Context injection** - Pass session-specific data (dates, account tiers)
+- **Internationalization** - Set language preferences per request
 
 ## Related Guides
 
-- [Configuration Guide](../configuration/index.md)
-- [RAG Guide](../rag/index.md) (for context injection tips)
+- [Configuration Guide](../configuration/index.md) - Full variable syntax reference
+- [API Reference](../api/index.md#send-chat-message-openai-compatible) - Using `variables` in requests
+- [RAG Guide](../rag/index.md) - Context injection tips
 - [Extending agent handlers](../extending/index.md#extend-runtimes)
 
 ---
@@ -12274,53 +13706,14 @@ mcp:
 
 LlamaFarm is designed for native deployment without containers. The application runs directly on your system using native binaries and the UV package manager for Python dependencies.
 
-## Local Development
-
-### Option A: `lf start` (Recommended)
-
-The easiest path is the integrated dev stack:
-
-```bash
-lf start
-```
-
-This command:
-- Starts the server and Universal Runtime natively
-- Watches `llamafarm.yaml` for changes
-- Opens the Designer web UI at `http://localhost:14345`
-
-### Option B: Manual control
-
-Open separate terminals for each service:
-
-```bash
-# Terminal 1 – API Server
-nx start server
-
-# Terminal 2 – Universal Runtime (for ML, OCR, embeddings)
-nx start universal-runtime
-```
-
-Then run CLI commands against the default server at `http://localhost:14345`.
-
-## Desktop Application
-
-The easiest way to run LlamaFarm is with the **Desktop App**, which bundles everything you need:
-
-- **Mac (Universal)**: [Download](https://github.com/llama-farm/llamafarm/releases/latest/download/LlamaFarm-desktop-app-mac-universal.dmg)
-- **Windows**: [Download](https://github.com/llama-farm/llamafarm/releases/latest/download/LlamaFarm-desktop-app-windows.exe)
-- **Linux (x86_64)**: [Download](https://github.com/llama-farm/llamafarm/releases/latest/download/LlamaFarm-desktop-app-linux-x86_64.AppImage)
-- **Linux (arm64)**: [Download](https://github.com/llama-farm/llamafarm/releases/latest/download/LlamaFarm-desktop-app-linux-arm64.AppImage)
-
-The desktop app includes the server, Universal Runtime, and Designer UI in a single package.
-
 ## Production Deployment
 
 ### Native Process Management
 
-For production, use process supervisors to keep services running:
+For production, use process supervisors to start services
 
 **systemd (Linux)**:
+
 ```ini
 [Unit]
 Description=LlamaFarm Server
@@ -12330,7 +13723,7 @@ After=network.target
 Type=simple
 User=llamafarm
 WorkingDirectory=/opt/llamafarm
-ExecStart=/opt/llamafarm/lf start
+ExecStart=/opt/llamafarm/lf services start
 Restart=always
 Environment=LF_DATA_DIR=/var/lib/llamafarm
 
@@ -12339,12 +13732,14 @@ WantedBy=multi-user.target
 ```
 
 **PM2 (Node.js)**:
+
 ```bash
-pm2 start "lf start" --name llamafarm
+pm2 start "lf services start" --name llamafarm
 pm2 save
 ```
 
 **launchd (macOS)**:
+
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -12355,6 +13750,7 @@ pm2 save
     <key>ProgramArguments</key>
     <array>
         <string>/usr/local/bin/lf</string>
+        <string>services</string>
         <string>start</string>
     </array>
     <key>RunAtLoad</key>
@@ -12370,7 +13766,7 @@ pm2 save
 - **Environment variables**: Store API keys (OpenAI, Together, etc.) in `.env` files or secret managers. Update `runtime.api_key` to reference them.
 - **Data directory**: Set `LF_DATA_DIR` to a persistent location with adequate storage for models and vector databases.
 - **Firewall**: Restrict access to ports 14345 (API) and 11540 (Universal Runtime) as needed.
-- **TLS termination**: Use a reverse proxy (nginx, Caddy) for HTTPS in production.
+- **TLS termination**: Use a reverse proxy (Traefik, nginx, Caddy) for HTTPS in production.
 - **Monitoring**: Enable logging and set up health checks against `/health` endpoint.
 
 ### Reverse Proxy Example (nginx)
@@ -12423,6 +13819,10 @@ curl http://localhost:14345/health
 curl http://localhost:14345/health/liveness
 ```
 
+## Platform-Specific Guides
+
+- [NVIDIA Jetson](./jetson.md) – Deploy on Jetson Orin, Xavier, TX2, Nano with CUDA acceleration
+
 ## Resources
 
 - [Quickstart](../quickstart/index.md) – Local installation steps
@@ -12434,7 +13834,7 @@ curl http://localhost:14345/health/liveness
 
 # Industry Use Cases
 
-LlamaFarm is designed to solve real-world problems across various industries. This section showcases how organizations are using LlamaFarm to streamline workflows, analyze complex documents, and extract actionable insights from their data.
+LlamaFarm is designed to solve real-world problems across various industries. This section showcases how organizations are using LlamaFarm to streamline workflows, analyze complex documents, detect anomalies, and extract actionable insights from their data.
 
 ## Featured Use Cases
 
@@ -12447,6 +13847,26 @@ Learn how pharmaceutical and therapeutics companies use LlamaFarm to analyze FDA
 - Cross-reference answers against existing correspondence databases
 - Confidence scoring for answer validation
 - Significant time savings in regulatory compliance workflows
+
+### [IoT Sensor Monitoring](./iot-sensor-monitoring.md)
+
+Build a real-time IoT monitoring system that detects equipment malfunctions, handles concept drift, and alerts operators within seconds.
+
+**Key Benefits:**
+- Real-time streaming anomaly detection with automatic retraining
+- Rolling features for trend and volatility detection
+- Edge-device optimized with minimal resource usage
+- Automatic handling of seasonal drift and calibration changes
+
+### [Financial Fraud Detection](./financial-fraud-detection.md)
+
+Implement a production-ready fraud detection pipeline that processes thousands of transactions per second with multi-stage analysis.
+
+**Key Benefits:**
+- Real-time pre-screening with sub-10ms latency
+- Rich feature engineering with Polars buffers
+- Ensemble models for high-accuracy fraud detection
+- Velocity, geographic, and behavioral pattern detection
 
 ---
 
@@ -13181,7 +14601,7 @@ eventSource.onmessage = (event) => {
 **Solutions:**
 - Verify LlamaFarm is running: `lf start`
 - Check API endpoint in `.env.local`
-- Ensure correct port (default: 8000)
+- Ensure correct port (default: 14345)
 - Check firewall settings
 - Review LlamaFarm logs for errors
 
@@ -13364,6 +14784,317 @@ Re-run relevant tests to ensure generated code compiles and integrations still w
 - Weekly sync details are pinned in Discord.
 
 Thanks for helping grow LlamaFarm!
+
+---
+
+# NVIDIA Jetson
+
+LlamaFarm runs natively on NVIDIA Jetson devices (Orin, Xavier, TX2, Nano) with CUDA acceleration. This guide covers setup, optimization, and troubleshooting for Jetson deployments.
+
+## Supported Devices
+
+| Device | Compute Capability | Memory | Performance |
+|--------|-------------------|--------|-------------|
+| Jetson Orin Nano | 8.7 | 8GB shared | 35+ tok/s |
+| Jetson Orin NX | 8.7 | 8-16GB shared | 35+ tok/s |
+| Jetson AGX Orin | 8.7 | 32-64GB shared | 40+ tok/s |
+| Jetson Xavier NX | 7.2 | 8-16GB shared | 25+ tok/s |
+| Jetson AGX Xavier | 7.2 | 16-32GB shared | 30+ tok/s |
+
+## Quick Start (Automated)
+
+LlamaFarm includes setup scripts that automate the Jetson configuration:
+
+```bash
+# 1. Start the Jetson container
+docker run -it --rm --runtime=nvidia --network host \
+  -v $HOME/.cache:/root/.cache \
+  -v /path/to/llamafarm:/data/llamafarm \
+  dustynv/l4t-pytorch:r36.2.0 \
+  bash
+
+# 2. Install UV package manager
+curl -LsSf https://astral.sh/uv/install.sh | sh
+source $HOME/.cargo/env
+
+# 3. Run the automated setup
+cd /data/llamafarm
+./deployment/jetson/setup.sh
+
+# 4. Start the server
+./deployment/jetson/start.sh
+```
+
+The setup script automatically:
+- Detects Jetson hardware
+- Finds system Python with CUDA PyTorch
+- Creates venv with `--system-site-packages` to inherit CUDA torch
+- Installs dependencies and removes conflicting PyPI packages
+- Creates `.env.jetson` with optimized environment variables
+
+For custom model or context size:
+
+```bash
+./deployment/jetson/start.sh 'unsloth/Qwen3-0.6B-GGUF:Q4_K_M' 4096
+```
+
+## Prerequisites
+
+1. **JetPack SDK** installed (includes CUDA, cuDNN, TensorRT)
+2. **Python 3.10+** with UV package manager
+3. **Custom llama.cpp build** (see below)
+
+## Building llama.cpp for Jetson
+
+Pre-built llama.cpp binaries don't include ARM64 CUDA. You must build from source:
+
+```bash
+git clone https://github.com/ggml-org/llama.cpp.git
+cd llama.cpp
+
+# CRITICAL: Disable CUDA graphs for Tegra stability
+cmake -B build \
+    -DGGML_CUDA=ON \
+    -DGGML_CUDA_GRAPHS=OFF \
+    -DCMAKE_CUDA_ARCHITECTURES="87" \
+    -DCMAKE_BUILD_TYPE=Release
+
+cmake --build build --config Release -j$(nproc)
+```
+
+### Why GGML_CUDA_GRAPHS=OFF?
+
+CUDA graphs provide performance benefits on discrete GPUs but cause stability issues on Jetson's unified memory architecture:
+- Graph compilation overhead exceeds benefits for small batch sizes
+- Memory pressure from graph captures
+- Unpredictable behavior on unified memory systems
+
+### Architecture Flags
+
+| Device | Flag |
+|--------|------|
+| Orin (Nano/NX/AGX) | `-DCMAKE_CUDA_ARCHITECTURES="87"` |
+| Xavier (NX/AGX) | `-DCMAKE_CUDA_ARCHITECTURES="72"` |
+| TX2 | `-DCMAKE_CUDA_ARCHITECTURES="62"` |
+| Nano | `-DCMAKE_CUDA_ARCHITECTURES="53"` |
+
+## Docker Container Setup (Recommended)
+
+The easiest way to run LlamaFarm on Jetson is using NVIDIA's PyTorch container which includes CUDA-enabled PyTorch:
+
+```bash
+docker run -it --rm --runtime=nvidia --network host \
+  -v /home/$USER/.cache:/root/.cache \
+  -v /path/to/llamafarm:/data/llamafarm \
+  dustynv/l4t-pytorch:r36.2.0 \
+  bash
+```
+
+### Install UV Package Manager
+
+Inside the container:
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+source $HOME/.cargo/env
+```
+
+### Setup Universal Runtime with CUDA PyTorch
+
+The container has CUDA-enabled PyTorch (Python 3.10), but the venv must be configured to use it:
+
+```bash
+cd /data/llamafarm/runtimes/universal
+
+# Create venv with system site packages (inherits CUDA torch)
+uv venv .venv --python /usr/local/bin/python3 --system-site-packages
+
+# Install dependencies (this pulls CPU torch from PyPI)
+uv pip install -r pyproject.toml --python .venv/bin/python
+
+# Remove CPU torch, fall back to system CUDA torch
+uv pip uninstall torch torchvision --python .venv/bin/python
+
+# Downgrade numpy (system torch needs numpy 1.x)
+uv pip install "numpy<2" --python .venv/bin/python
+```
+
+### Verify CUDA PyTorch
+
+```bash
+.venv/bin/python -c "import torch; print('CUDA:', torch.cuda.is_available())"
+# Should print: CUDA: True
+```
+
+This enables GPU acceleration for:
+- **llama.cpp inference** (GGUF models) - 35+ tok/s
+- **Transformers models** (classifiers, embeddings) - GPU accelerated
+- **Anomaly detection** (sklearn) - CPU only
+
+## Installing Built Libraries
+
+Copy the built libraries to LlamaFarm's cache:
+
+```bash
+CACHE_DIR="$HOME/.cache/llamafarm-llama/jetson"
+mkdir -p "$CACHE_DIR"
+
+cp build/src/libllama.so "$CACHE_DIR/"
+cp build/ggml/src/libggml*.so* "$CACHE_DIR/"
+
+# Point LlamaFarm to the custom build
+export LLAMAFARM_LLAMA_LIB_DIR="$CACHE_DIR"
+```
+
+## Running the Server
+
+```bash
+cd /path/to/llamafarm/runtimes/universal
+
+# Start with conservative settings for 8GB memory
+uv run python server.py \
+    --model 'unsloth/Qwen3-1.7B-GGUF:Q4_K_M' \
+    --ctx-len 2048
+```
+
+### Test the API
+
+```bash
+curl -s -X POST http://localhost:11540/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "unsloth/Qwen3-1.7B-GGUF:Q4_K_M",
+    "messages": [{"role": "user", "content": "Hello!"}],
+    "max_tokens": 100,
+    "n_ctx": 2048
+  }'
+```
+
+**Important**: Always pass `n_ctx` in requests to avoid defaulting to the model's full context (40960 for Qwen3), which causes OOM.
+
+## Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `LLAMAFARM_SYNC_INFERENCE` | Force sync (`1`) or async (`0`) inference | Auto-detect |
+| `LLAMAFARM_LLAMA_LIB_DIR` | Path to custom llama.cpp libraries | Auto |
+| `CUDA_CACHE_DISABLE` | Disable CUDA cache (reduces fragmentation) | 0 |
+
+## Memory Optimization
+
+Jetson uses unified memory shared between CPU and GPU. Optimize with:
+
+### 1. Use Quantized Models
+
+Q4_K_M provides the best balance of quality and memory:
+
+```
+Model Size (Qwen3-1.7B):
+- Q4_K_M: ~1.0 GB
+- Q8_0: ~1.8 GB
+- FP16: ~3.4 GB
+```
+
+### 2. Reduce Context Size
+
+Start with `n_ctx=2048` and increase only if needed:
+
+```
+KV Cache Memory (Qwen3-1.7B):
+- n_ctx=2048: ~224 MB
+- n_ctx=4096: ~448 MB
+- n_ctx=8192: ~896 MB
+```
+
+### 3. Enable KV Cache Quantization
+
+For even lower memory, use quantized KV cache:
+
+```python
+# In your model configuration
+cache_type_k="q4_0"  # 4-bit keys
+cache_type_v="q4_0"  # 4-bit values
+```
+
+This reduces KV cache memory by ~4x.
+
+## Troubleshooting
+
+### "double free or corruption" crash
+
+**Cause**: CUDA backend initialization from worker thread.
+
+**Solution**: LlamaFarm automatically initializes the backend from the main thread. If you see this error, ensure you're using the latest version.
+
+### Slow performance (< 25 tok/s)
+
+**Check**:
+1. Rebuild llama.cpp with `GGML_CUDA_GRAPHS=OFF`
+2. Verify all layers on GPU: look for "offloaded 29/29 layers" in logs
+3. Check `n_ctx` isn't too large (causes memory pressure)
+
+### Out of memory
+
+**Solutions**:
+1. Reduce `n_ctx` (e.g., 2048 instead of 4096)
+2. Use smaller quantization (Q4_K_M instead of Q8_0)
+3. Enable KV cache quantization
+4. Monitor with `tegrastats`
+
+### Model loads on CPU
+
+**Check**:
+1. Verify CUDA: `nvcc --version`
+2. Ensure libggml-cuda.so exists in library directory
+3. Check logs for "CUDA0" device detection
+
+## Performance Benchmarks
+
+Tested on Jetson Orin Nano 8GB with Qwen3-1.7B Q4_K_M:
+
+| Metric | Value |
+|--------|-------|
+| Tokens/second | 35-36 tok/s |
+| Time to first token | ~70-100ms |
+| Memory usage | ~2.5 GB |
+| Power consumption | ~15W |
+
+## systemd Service
+
+Create `/etc/systemd/system/llamafarm.service`:
+
+```ini
+[Unit]
+Description=LlamaFarm Universal Runtime
+After=network.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/data/llamafarm/runtimes/universal
+Environment=LLAMAFARM_LLAMA_LIB_DIR=/root/.cache/llamafarm-llama/jetson
+Environment=LLAMAFARM_SYNC_INFERENCE=1
+ExecStart=/root/.local/bin/uv run python server.py --model unsloth/Qwen3-1.7B-GGUF:Q4_K_M --ctx-len 2048
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Enable and start:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable llamafarm
+sudo systemctl start llamafarm
+```
+
+## See Also
+
+- [Deployment Overview](./index.md)
+- [Configuration Guide](../configuration/index.md)
+- [Troubleshooting](../troubleshooting/index.md)
 
 ---
 
@@ -13644,5 +15375,2633 @@ npm run build
 ## Source Code
 
 See `docs/website/mcp/` for the full implementation.
+
+---
+
+# Polars Buffer API
+
+LlamaFarm provides direct access to high-performance Polars-based data buffers for advanced streaming and feature engineering use cases.
+
+## Why Polars Matters for Anomaly Detection
+
+In streaming anomaly detection, **Feature Engineering Latency** is the biggest bottleneck—not model inference:
+
+| Operation | Typical Latency |
+|-----------|----------------|
+| Isolation Forest inference | ~1ms |
+| Rolling std of 10,000 rows (Pandas) | 10-50ms |
+| Rolling std of 10,000 rows (Polars) | \<1ms |
+
+**The Problem:** To detect if "$500" is anomalous, the model needs context—"Is $500 normal for this user?" This requires calculating rolling statistics over a history window. In Pandas, this creates a major latency bottleneck.
+
+**The Solution:** Polars is a columnar data store written in Rust with:
+
+1. **Apache Arrow Memory Format** - No copy-on-append, efficient memory allocation
+2. **SIMD Vectorization** - Calculate mean of 2,000 numbers in the same CPU cycles as 2 numbers
+3. **Parallel Execution** - Compute rolling stats for ALL columns simultaneously across CPU cores
+4. **Cold Start Handling** - `fill_null(0.0)` ensures valid feature vectors from the very first transaction
+
+## Overview
+
+Polars buffers are the "data substrate" underlying LlamaFarm's streaming anomaly detection. While most users should use the [Streaming Anomaly Detection API](./streaming-anomaly-detection.md) directly, the Polars Buffer API is available for:
+
+- **Custom feature engineering** pipelines
+- **Integration with external ML systems**
+- **Manual control** over data lifecycle
+- **Building custom streaming analytics**
+
+**Key Features:**
+- **High-performance columnar storage** using Polars DataFrames
+- **Automatic sliding window** truncation (memory never grows indefinitely)
+- **Rolling feature computation** (mean, std, min, max) with SIMD + parallel execution
+- **Lag features** for temporal patterns
+- **Sub-millisecond append performance**
+- **Cold start handling** with null filling
+
+---
+
+## How the Data Flows
+
+Understanding the internal data flow helps you optimize your pipeline:
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                           DATA FLOW VISUALIZATION                            │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                              │
+│  Step 1: INIT          →  []                                                │
+│                                                                              │
+│  Step 2: INGEST        →  {"amount": 100}                                   │
+│          (Tick 1)          ↓                                                │
+│                         [100]    ← Polars converts dict to 1-row DataFrame  │
+│                                                                              │
+│  Step 3: STACK         →  {"amount": 150}                                   │
+│          (Tick 2)          ↓                                                │
+│                         [100, 150]  ← pl.concat (Arrow memory - no copy)    │
+│                                                                              │
+│  ...                                                                         │
+│                                                                              │
+│  Step 101: TRUNCATE    →  {"amount": 200}                                   │
+│            (Tick 101)      ↓                                                │
+│                         [150, ..., 200]  ← tail(window_size) drops $100     │
+│                                                                              │
+│  Step 102: COMPUTE     →  rolling_mean = 175.0                              │
+│            (SIMD)          (Calculated instantly with vectorization)        │
+│                                                                              │
+│  Step 103: EXPORT      →  [200.0, 175.0, ...]                               │
+│            (to NumPy)      (Raw value + Context features for model)         │
+│                                                                              │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Cold Start Behavior
+
+During the first few ticks, rolling features have insufficient history:
+
+| Tick | Buffer | rolling_mean_5 | rolling_std_5 | What Happens |
+|------|--------|----------------|---------------|--------------|
+| 1 | [100] | 100.0 | **0.0** | std is null → filled with 0.0 |
+| 2 | [100, 150] | 125.0 | 35.36 | 2 values, real std |
+| 5 | [100, 150, 120, 80, 200] | 130.0 | 45.83 | Full 5-value window |
+
+The `fill_null(0.0)` ensures your model always receives valid numeric vectors, even from the very first transaction. No crashes, no NaN errors.
+
+---
+
+## When to Use Polars Buffers
+
+| Use Case | Recommended API |
+|----------|-----------------|
+| Real-time anomaly detection | [Streaming Anomaly Detection](./streaming-anomaly-detection.md) |
+| Custom feature engineering | **Polars Buffers** |
+| Feeding features to external ML | **Polars Buffers** |
+| Simple anomaly detection | [Batch Anomaly Detection](./anomaly-detection.md) |
+| Rolling statistics only | **Polars Buffers** |
+
+---
+
+## Quick Start
+
+### Create a Buffer
+
+```bash
+curl -X POST http://localhost:14345/v1/ml/polars/buffers \
+  -H "Content-Type: application/json" \
+  -d '{
+    "buffer_id": "sensor-data",
+    "window_size": 1000
+  }'
+```
+
+Response:
+```json
+{
+  "object": "buffer_created",
+  "buffer_id": "sensor-data",
+  "window_size": 1000,
+  "status": "created"
+}
+```
+
+### Append Data
+
+```bash
+# Single record
+curl -X POST http://localhost:14345/v1/ml/polars/append \
+  -H "Content-Type: application/json" \
+  -d '{
+    "buffer_id": "sensor-data",
+    "data": {"temperature": 72.5, "humidity": 45.2, "pressure": 1013.25}
+  }'
+
+# Batch append (more efficient)
+curl -X POST http://localhost:14345/v1/ml/polars/append \
+  -H "Content-Type: application/json" \
+  -d '{
+    "buffer_id": "sensor-data",
+    "data": [
+      {"temperature": 72.5, "humidity": 45.2, "pressure": 1013.25},
+      {"temperature": 73.1, "humidity": 44.8, "pressure": 1013.10},
+      {"temperature": 71.9, "humidity": 46.0, "pressure": 1013.50}
+    ]
+  }'
+```
+
+Response:
+```json
+{
+  "object": "append_result",
+  "buffer_id": "sensor-data",
+  "appended": 3,
+  "buffer_size": 3,
+  "avg_append_ms": 0.15
+}
+```
+
+### Compute Rolling Features
+
+```bash
+curl -X POST http://localhost:14345/v1/ml/polars/features \
+  -H "Content-Type: application/json" \
+  -d '{
+    "buffer_id": "sensor-data",
+    "rolling_windows": [5, 10, 20],
+    "include_rolling_stats": ["mean", "std", "min", "max"],
+    "include_lags": true,
+    "lag_periods": [1, 2, 3],
+    "tail": 5
+  }'
+```
+
+Response:
+```json
+{
+  "object": "polars_data",
+  "buffer_id": "sensor-data",
+  "rows": 5,
+  "columns": [
+    "temperature", "humidity", "pressure",
+    "temperature_rolling_mean_5", "temperature_rolling_std_5",
+    "temperature_rolling_min_5", "temperature_rolling_max_5",
+    "temperature_rolling_mean_10", "temperature_rolling_std_10",
+    "humidity_rolling_mean_5", "humidity_rolling_std_5",
+    "temperature_lag_1", "temperature_lag_2", "temperature_lag_3",
+    "humidity_lag_1", "humidity_lag_2", "humidity_lag_3"
+  ],
+  "data": [
+    {
+      "temperature": 72.5,
+      "humidity": 45.2,
+      "temperature_rolling_mean_5": 72.8,
+      "temperature_rolling_std_5": 0.45,
+      "temperature_lag_1": 73.1,
+      "temperature_lag_2": 71.9
+    }
+  ]
+}
+```
+
+---
+
+## API Reference
+
+### Create Buffer
+
+`POST /v1/ml/polars/buffers`
+
+Creates a new named buffer with automatic sliding window.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `buffer_id` | string | Yes | Unique identifier |
+| `window_size` | int | No | Max records to keep (default: 1000) |
+
+### List Buffers
+
+`GET /v1/ml/polars/buffers`
+
+Returns all active buffers with statistics.
+
+Response:
+```json
+{
+  "object": "list",
+  "data": [
+    {
+      "buffer_id": "sensor-data",
+      "size": 500,
+      "window_size": 1000,
+      "columns": ["temperature", "humidity", "pressure"],
+      "numeric_columns": ["temperature", "humidity", "pressure"],
+      "memory_bytes": 12000,
+      "append_count": 500,
+      "avg_append_ms": 0.12
+    }
+  ],
+  "total": 1
+}
+```
+
+### Get Buffer Stats
+
+`GET /v1/ml/polars/buffers/{buffer_id}`
+
+Returns detailed statistics for a specific buffer.
+
+### Delete Buffer
+
+`DELETE /v1/ml/polars/buffers/{buffer_id}`
+
+Removes buffer and frees memory.
+
+### Clear Buffer
+
+`POST /v1/ml/polars/buffers/{buffer_id}/clear`
+
+Clears data but keeps buffer structure.
+
+### Append Data
+
+`POST /v1/ml/polars/append`
+
+Appends single record or batch.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `buffer_id` | string | Yes | Target buffer |
+| `data` | dict or list | Yes | Single record or batch |
+
+### Compute Features
+
+`POST /v1/ml/polars/features`
+
+Computes rolling statistics and lag features.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `buffer_id` | string | Required | Source buffer |
+| `rolling_windows` | list[int] | [5, 10, 20] | Window sizes |
+| `include_rolling_stats` | list[str] | ["mean", "std", "min", "max"] | Stats to compute |
+| `include_lags` | bool | true | Include lag features |
+| `lag_periods` | list[int] | [1, 2, 3] | Lag periods |
+| `tail` | int | null | Return only last N rows |
+
+### Get Buffer Data
+
+`GET /v1/ml/polars/buffers/{buffer_id}/data`
+
+Returns raw buffer contents.
+
+Query parameters:
+- `tail`: Return only last N rows
+- `with_features`: Compute and include rolling features (bool)
+
+---
+
+## Rolling Features Explained
+
+### Rolling Statistics
+
+For each numeric column and window size:
+
+| Feature | Formula | Use Case |
+|---------|---------|----------|
+| `{col}_rolling_mean_{w}` | Mean of last w values | Smoothing, trend |
+| `{col}_rolling_std_{w}` | Std dev of last w values | Volatility, noise |
+| `{col}_rolling_min_{w}` | Min of last w values | Lower bound |
+| `{col}_rolling_max_{w}` | Max of last w values | Upper bound |
+
+**Example:** With `rolling_windows: [5, 10]` and column `temperature`:
+- `temperature_rolling_mean_5` - 5-point moving average
+- `temperature_rolling_mean_10` - 10-point moving average
+- `temperature_rolling_std_5` - 5-point volatility
+- `temperature_rolling_std_10` - 10-point volatility
+
+### Lag Features
+
+| Feature | Description |
+|---------|-------------|
+| `{col}_lag_1` | Previous value |
+| `{col}_lag_2` | Value 2 steps ago |
+| `{col}_lag_n` | Value n steps ago |
+
+**Use cases:**
+- Detecting sudden changes (current vs lag_1)
+- Identifying trends (compare lag_1, lag_2, lag_3)
+- Cyclic patterns (compare to periodic lags)
+
+---
+
+## Performance Characteristics
+
+### Append Performance
+
+| Operation | Typical Latency |
+|-----------|-----------------|
+| Single append | 0.1-0.3 ms |
+| Batch append (100 records) | 0.5-1.0 ms |
+| Batch append (1000 records) | 2-5 ms |
+
+### Memory Usage
+
+Approximate memory per 1000 records:
+- 5 columns: ~40 KB
+- 10 columns: ~80 KB
+- 20 columns: ~160 KB
+
+Plus overhead for rolling features during computation.
+
+### Window Truncation
+
+The buffer automatically truncates to `window_size`:
+- Oldest records are dropped first
+- No manual cleanup needed
+- Bounded memory usage
+
+---
+
+## Python Example: Custom Feature Pipeline
+
+```python
+
+class CustomFeaturePipeline:
+    """Build custom features from streaming data."""
+
+    def __init__(self, buffer_id: str = "custom-features"):
+        self.buffer_id = buffer_id
+        self.base_url = "http://localhost:14345/v1/ml/polars"
+        self.client = httpx.AsyncClient()
+
+    async def initialize(self, window_size: int = 500):
+        """Create the buffer."""
+        await self.client.post(f"{self.base_url}/buffers", json={
+            "buffer_id": self.buffer_id,
+            "window_size": window_size
+        })
+
+    async def add_data(self, data: dict | list):
+        """Append data to buffer."""
+        return await self.client.post(f"{self.base_url}/append", json={
+            "buffer_id": self.buffer_id,
+            "data": data
+        })
+
+    async def get_features(self, windows: list[int] = None) -> dict:
+        """Get latest features."""
+        resp = await self.client.post(f"{self.base_url}/features", json={
+            "buffer_id": self.buffer_id,
+            "rolling_windows": windows or [5, 10, 20],
+            "include_lags": True,
+            "lag_periods": [1, 2, 5],
+            "tail": 1  # Just the latest row
+        })
+        result = resp.json()
+        return result["data"][0] if result["rows"] > 0 else None
+
+    async def get_raw_data(self, tail: int = 10) -> list:
+        """Get recent raw data."""
+        resp = await self.client.get(
+            f"{self.base_url}/buffers/{self.buffer_id}/data",
+            params={"tail": tail}
+        )
+        return resp.json()["data"]
+
+    async def cleanup(self):
+        """Delete buffer."""
+        await self.client.delete(f"{self.base_url}/buffers/{self.buffer_id}")
+        await self.client.aclose()
+
+async def main():
+    pipeline = CustomFeaturePipeline()
+    await pipeline.initialize(window_size=1000)
+
+    try:
+        # Simulate streaming data
+        import random
+        for i in range(100):
+            data = {
+                "sensor_id": "temp-001",
+                "value": 72 + random.gauss(0, 2),
+                "timestamp": i
+            }
+            await pipeline.add_data(data)
+
+            if i >= 20:  # Need enough data for features
+                features = await pipeline.get_features()
+                if features:
+                    # Use features for your ML model
+                    print(f"Sample {i}: rolling_mean_5={features.get('value_rolling_mean_5', 'N/A'):.2f}")
+
+            await asyncio.sleep(0.1)
+
+    finally:
+        await pipeline.cleanup()
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+---
+
+## Integration Patterns
+
+### Pattern 1: Polars + External ML
+
+Use Polars for feature engineering, feed to your own model:
+
+```python
+# 1. Collect data in Polars buffer
+await append_to_buffer(raw_data)
+
+# 2. Get engineered features
+features = await get_features(rolling_windows=[5, 10, 30])
+
+# 3. Feed to your scikit-learn/XGBoost/etc model
+prediction = your_model.predict([list(features.values())])
+```
+
+### Pattern 2: Polars + Streaming Anomaly
+
+Combine custom features with LlamaFarm anomaly detection:
+
+```python
+# 1. Build custom features
+features = await polars_get_features(buffer_id="custom")
+
+# 2. Stream to anomaly detector
+result = await anomaly_stream(
+    model="my-detector",
+    data=features,
+    backend="ecod"
+)
+```
+
+### Pattern 3: Multiple Feature Sets
+
+Use multiple buffers for different purposes:
+
+```python
+# Fast-moving features (short windows)
+await append(buffer_id="fast-features", data=raw)
+fast = await get_features("fast-features", rolling_windows=[3, 5, 10])
+
+# Slow-moving features (long windows)
+await append(buffer_id="slow-features", data=raw)
+slow = await get_features("slow-features", rolling_windows=[50, 100, 200])
+
+# Combine for multi-scale analysis
+combined = {**fast, **slow}
+```
+
+---
+
+## Best Practices
+
+### Buffer Sizing
+
+| Data Rate | Recommended window_size |
+|-----------|------------------------|
+| 1 sample/sec | 3600 (1 hour) |
+| 10 samples/sec | 6000 (10 min) |
+| 100 samples/sec | 10000 (100 sec) |
+| 1000 samples/sec | 10000-50000 |
+
+### Rolling Window Selection
+
+- **Short windows (3-10)**: Detect sudden changes, noise
+- **Medium windows (20-50)**: Trend detection
+- **Long windows (100+)**: Baseline comparison
+
+### Memory Management
+
+1. Set appropriate `window_size`
+2. Delete unused buffers
+3. Use `clear` instead of delete/recreate
+4. Monitor with `GET /v1/ml/polars/buffers`
+
+---
+
+## Next Steps
+
+- [Streaming Anomaly Detection](./streaming-anomaly-detection.md) - High-level streaming API
+- [Anomaly Detection Guide](./anomaly-detection.md) - Batch detection
+- [Use Cases: Financial Fraud Detection](../use-cases/financial-fraud-detection.md) - Complete example
+
+---
+
+# Streaming Anomaly Detection
+
+For real-time data streams, LlamaFarm provides a streaming anomaly detection API that handles the complexities of online learning: cold start, automatic retraining, sliding windows, and seamless model updates.
+
+## Overview
+
+The streaming API is designed for scenarios where:
+- Data arrives continuously (sensors, logs, metrics)
+- You need immediate anomaly scores
+- The underlying data distribution may drift over time
+- You can't wait to collect a large batch before training.
+
+**Key Features:**
+- **Cold Start Handling**: Collects initial samples before first training
+- **Tick-Tock Retraining**: Seamlessly swaps models during retrain
+- **Sliding Window**: Maintains recent history, discards old data
+- **Automatic Feature Engineering**: Optional Polars-based rolling features
+- **12 PyOD Backends**: Choose the right algorithm for your data
+
+## Quick Start
+
+```bash
+# Send streaming data point
+curl -X POST http://localhost:14345/v1/ml/anomaly/stream \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "sensor-stream",
+    "data": {"temperature": 72.5, "humidity": 45.2, "pressure": 1013.25},
+    "backend": "ecod",
+    "min_samples": 50,
+    "retrain_interval": 100,
+    "window_size": 1000,
+    "threshold": 0.5
+  }'
+```
+
+**During cold start (collecting samples):**
+```json
+{
+  "object": "streaming_result",
+  "model": "sensor-stream",
+  "status": "collecting",
+  "results": [
+    {"index": 0, "score": null, "is_anomaly": null, "samples_until_ready": 49}
+  ],
+  "model_version": 0,
+  "samples_collected": 1,
+  "samples_until_ready": 49
+}
+```
+
+**After model is trained:**
+```json
+{
+  "object": "streaming_result",
+  "model": "sensor-stream",
+  "status": "ready",
+  "results": [
+    {"index": 0, "score": 0.32, "is_anomaly": false, "raw_score": 0.28, "samples_until_ready": 0}
+  ],
+  "model_version": 1,
+  "samples_collected": 150,
+  "samples_until_ready": 0
+}
+```
+
+---
+
+## How Streaming Works
+
+### The Tick-Tock Pattern
+
+LlamaFarm uses a tick-tock pattern for seamless model updates:
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  Time ──────────────────────────────────────────────────>│
+│                                                          │
+│  Model A: [ACTIVE]────────────────[ACTIVE]──────────    │
+│                    \                     \               │
+│  Model B:          [TRAINING]──[ACTIVE]   [TRAINING]──  │
+│                                                          │
+│  Data:    ●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●    │
+│           ↑                    ↑                         │
+│           Retrain triggered    Retrain triggered         │
+└──────────────────────────────────────────────────────────┘
+```
+
+1. **Active Model**: Scores incoming data immediately
+2. **Background Training**: New model trains on updated window
+3. **Atomic Swap**: Once trained, new model becomes active
+4. **Zero Downtime**: Scoring continues throughout
+
+### Lifecycle States
+
+| Status | Description | Scoring |
+|--------|-------------|---------|
+| `collecting` | Cold start - gathering initial samples | Returns `null` scores |
+| `ready` | Model trained and scoring | Returns anomaly scores |
+| `retraining` | Background retrain in progress | Returns scores (using current model) |
+
+---
+
+## Parameters
+
+### Request Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `model` | string | "default-stream" | Unique identifier for this detector |
+| `data` | dict or list | **required** | Single data point or batch of points |
+| `backend` | string | "ecod" | PyOD algorithm (see Backend Selection) |
+| `min_samples` | int | 50 | Samples needed before first training |
+| `retrain_interval` | int | 100 | Retrain after this many new samples |
+| `window_size` | int | 1000 | Sliding window size (keeps most recent N) |
+| `threshold` | float | 0.5 | Anomaly score threshold (0-1) |
+| `contamination` | float | 0.1 | Expected proportion of anomalies (0-0.5) |
+
+### Rolling Feature Parameters (Polars-Powered)
+
+Enable automatic feature engineering using high-performance Polars:
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `rolling_windows` | list[int] | null | Window sizes, e.g., [5, 10, 20] |
+| `include_lags` | bool | false | Include lag features |
+| `lag_periods` | list[int] | null | Lag periods, e.g., [1, 2, 3] |
+
+When `rolling_windows` is provided, the detector computes:
+- `{col}_rolling_mean_{window}` - Rolling mean
+- `{col}_rolling_std_{window}` - Rolling standard deviation
+- `{col}_rolling_min_{window}` - Rolling minimum
+- `{col}_rolling_max_{window}` - Rolling maximum
+- `{col}_lag_{period}` - Lagged values (if `include_lags=true`)
+
+**Why Rolling Features Matter:**
+
+A raw value like `$500` is meaningless without context. The model needs to know: "Is $500 normal for this user?" Rolling features provide this context automatically.
+
+**Polars Performance Advantage:**
+
+| Feature Engineering | Pandas | Polars |
+|--------------------|--------|--------|
+| Rolling std (10K rows) | 10-50ms | \<1ms |
+| Multi-column parallel | Sequential | Parallel (all CPU cores) |
+| Memory on append | Copy each time | Arrow (no-copy) |
+
+**Cold Start Handling:**
+
+During the first few samples, rolling statistics have insufficient history. Polars automatically fills null values with `0.0`, ensuring your model always receives valid numeric vectors—no crashes from NaN values.
+
+**Example with Rolling Features:**
+
+```bash
+curl -X POST http://localhost:14345/v1/ml/anomaly/stream \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "fraud-detector",
+    "data": {"amount": 500, "merchant_category": 5},
+    "backend": "ecod",
+    "min_samples": 50,
+    "window_size": 1000,
+    "rolling_windows": [5, 10, 20],
+    "include_lags": true,
+    "lag_periods": [1, 2, 5],
+    "schema": {"amount": "numeric", "merchant_category": "numeric"}
+  }'
+```
+
+This transforms each transaction from 2 features to **26 features**:
+- 2 original: `amount`, `merchant_category`
+- 24 rolling: 4 stats × 3 windows × 2 columns
+- Plus lag features if enabled
+
+See [Polars Buffer API](./polars-buffers.md) for detailed information about the underlying Polars mechanics.
+
+---
+
+## Backend Selection
+
+Choose the right algorithm for your use case:
+
+### Recommended for Streaming
+
+| Backend | Speed | Why Use It |
+|---------|-------|------------|
+| `ecod` | ⚡⚡⚡ | **Recommended default** - Fast, parameter-free, handles drift |
+| `hbos` | ⚡⚡⚡⚡ | Fastest algorithm, great for high-throughput |
+| `loda` | ⚡⚡⚡ | Designed for streaming, lightweight |
+| `copod` | ⚡⚡⚡ | Parameter-free, interpretable |
+
+### When to Use Other Backends
+
+| Backend | Use Case |
+|---------|----------|
+| `isolation_forest` | General purpose, reliable baseline |
+| `knn` | When local density matters |
+| `cblof` | Data has natural clusters |
+| `suod` | Maximum robustness (ensemble of multiple algorithms) |
+| `autoencoder` | Complex non-linear patterns (slower) |
+
+### All 12 Backends
+
+```bash
+# Get full backend information
+curl http://localhost:14345/v1/ml/anomaly/backends
+```
+
+| Backend | Category | Speed | Memory | Best For |
+|---------|----------|-------|--------|----------|
+| `isolation_forest` | Legacy | Fast | Low | General purpose |
+| `one_class_svm` | Legacy | Slow | Medium | Tight boundaries |
+| `local_outlier_factor` | Legacy | Medium | Medium | Density anomalies |
+| `autoencoder` | Deep Learning | Slow | High | Complex patterns |
+| `ecod` | Fast | Very Fast | Low | Streaming (recommended) |
+| `hbos` | Fast | Very Fast | Low | High throughput |
+| `copod` | Fast | Very Fast | Low | Interpretability |
+| `knn` | Distance | Medium | Medium | Density-based |
+| `mcd` | Distance | Medium | Medium | Gaussian data |
+| `cblof` | Clustering | Medium | Medium | Clustered data |
+| `suod` | Ensemble | Medium | Medium | Maximum robustness |
+| `loda` | Streaming | Fast | Low | Online scenarios |
+
+---
+
+## Managing Streaming Detectors
+
+### List All Active Detectors
+
+```bash
+curl http://localhost:14345/v1/ml/anomaly/stream/detectors
+```
+
+Response:
+```json
+{
+  "object": "list",
+  "data": [
+    {
+      "model_id": "sensor-stream",
+      "backend": "ecod",
+      "status": "ready",
+      "model_version": 3,
+      "samples_collected": 450,
+      "total_processed": 450,
+      "samples_since_retrain": 50,
+      "is_ready": true
+    }
+  ],
+  "total": 1
+}
+```
+
+### Get Specific Detector Stats
+
+```bash
+curl http://localhost:14345/v1/ml/anomaly/stream/sensor-stream
+```
+
+### Reset Detector
+
+Clear all data and restart cold start:
+
+```bash
+curl -X POST http://localhost:14345/v1/ml/anomaly/stream/sensor-stream/reset
+```
+
+### Delete Detector
+
+Remove detector and free memory:
+
+```bash
+curl -X DELETE http://localhost:14345/v1/ml/anomaly/stream/sensor-stream
+```
+
+---
+
+## Batch Processing
+
+Send multiple data points in one request:
+
+```bash
+curl -X POST http://localhost:14345/v1/ml/anomaly/stream \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "sensor-stream",
+    "data": [
+      {"temperature": 72.5, "humidity": 45.2},
+      {"temperature": 73.1, "humidity": 44.8},
+      {"temperature": 71.9, "humidity": 46.0},
+      {"temperature": 150.0, "humidity": 10.0}
+    ],
+    "backend": "ecod"
+  }'
+```
+
+Response includes results for each point:
+```json
+{
+  "object": "streaming_result",
+  "model": "sensor-stream",
+  "status": "ready",
+  "results": [
+    {"index": 0, "score": 0.28, "is_anomaly": false, "raw_score": 0.22},
+    {"index": 1, "score": 0.31, "is_anomaly": false, "raw_score": 0.25},
+    {"index": 2, "score": 0.26, "is_anomaly": false, "raw_score": 0.21},
+    {"index": 3, "score": 0.89, "is_anomaly": true, "raw_score": 0.85}
+  ],
+  "model_version": 2,
+  "threshold": 0.5
+}
+```
+
+---
+
+## With Rolling Features
+
+Enable automatic feature engineering for time-series patterns:
+
+```bash
+curl -X POST http://localhost:14345/v1/ml/anomaly/stream \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "enhanced-sensor",
+    "data": {"temperature": 72.5, "humidity": 45.2},
+    "backend": "ecod",
+    "rolling_windows": [5, 10, 20],
+    "include_lags": true,
+    "lag_periods": [1, 2, 3],
+    "min_samples": 30
+  }'
+```
+
+This automatically computes and includes:
+- `temperature_rolling_mean_5`, `temperature_rolling_mean_10`, `temperature_rolling_mean_20`
+- `temperature_rolling_std_5`, `temperature_rolling_std_10`, `temperature_rolling_std_20`
+- `temperature_lag_1`, `temperature_lag_2`, `temperature_lag_3`
+- Same for humidity
+
+The detector learns patterns like "temperature suddenly diverging from recent mean" or "humidity spiking compared to 5 minutes ago".
+
+---
+
+## Python Client Example
+
+```python
+
+async def stream_sensor_data():
+    """Simulate streaming sensor data with occasional anomalies."""
+    async with httpx.AsyncClient() as client:
+        base_url = "http://localhost:14345/v1/ml/anomaly/stream"
+
+        for i in range(200):
+            # Normal data
+            temp = 72 + random.gauss(0, 2)
+            humidity = 45 + random.gauss(0, 3)
+
+            # Inject anomaly every 50 samples
+            if i > 0 and i % 50 == 0:
+                temp = 150  # Anomalous spike
+                print(f"Injecting anomaly at sample {i}")
+
+            response = await client.post(base_url, json={
+                "model": "python-sensor",
+                "data": {"temperature": temp, "humidity": humidity},
+                "backend": "ecod",
+                "min_samples": 30,
+                "retrain_interval": 50,
+                "threshold": 0.5
+            })
+
+            result = response.json()
+
+            if result["status"] == "ready":
+                for r in result["results"]:
+                    if r["is_anomaly"]:
+                        print(f"⚠️  ANOMALY at sample {i}: score={r['score']:.3f}")
+            else:
+                print(f"Collecting... {result['samples_until_ready']} samples until ready")
+
+            await asyncio.sleep(0.1)  # 10 samples/second
+
+if __name__ == "__main__":
+    asyncio.run(stream_sensor_data())
+```
+
+---
+
+## Integration with Polars Buffers
+
+For advanced use cases, you can use Polars buffers directly alongside streaming detection:
+
+```python
+
+async def advanced_streaming():
+    async with httpx.AsyncClient() as client:
+        base_url = "http://localhost:14345/v1/ml"
+
+        # Create a Polars buffer for custom feature engineering
+        await client.post(f"{base_url}/polars/buffers", json={
+            "buffer_id": "custom-features",
+            "window_size": 500
+        })
+
+        for data_point in data_stream:
+            # Append to Polars buffer
+            await client.post(f"{base_url}/polars/append", json={
+                "buffer_id": "custom-features",
+                "data": data_point
+            })
+
+            # Get custom features
+            features_resp = await client.post(f"{base_url}/polars/features", json={
+                "buffer_id": "custom-features",
+                "rolling_windows": [5, 10],
+                "include_lags": True,
+                "tail": 1  # Just the latest row
+            })
+
+            if features_resp.json()["rows"] > 0:
+                enhanced_data = features_resp.json()["data"][0]
+
+                # Stream to anomaly detector with enhanced features
+                await client.post(f"{base_url}/anomaly/stream", json={
+                    "model": "custom-enhanced",
+                    "data": enhanced_data,
+                    "backend": "ecod"
+                })
+```
+
+See [Polars Buffer API](./polars-buffers.md) for more details on direct buffer access.
+
+---
+
+## Best Practices
+
+### Choosing Parameters
+
+1. **min_samples**: Set high enough for meaningful training
+   - Simple univariate: 30-50
+   - Multivariate (5-10 features): 100-200
+   - Complex patterns: 500+
+
+2. **retrain_interval**: Balance freshness vs. stability
+   - Fast-changing data: 50-100
+   - Stable distributions: 500-1000
+   - Very stable: 5000+
+
+3. **window_size**: Balance memory vs. history
+   - Typical: 1000-10000
+   - Memory constrained: 500
+   - Long patterns: 50000+
+
+4. **threshold**: Start with 0.5 and adjust
+   - More sensitive: 0.3-0.4
+   - Fewer false positives: 0.6-0.7
+
+### Performance Tips
+
+1. **Use batch requests** when possible (fewer HTTP calls)
+2. **Choose fast backends** (ecod, hbos) for high-throughput
+3. **Limit rolling windows** to what you need
+4. **Set appropriate window_size** to bound memory
+
+### Handling Concept Drift
+
+The sliding window and periodic retraining naturally handle drift:
+- Old data falls out of the window
+- New data influences the model
+- Retraining incorporates new patterns
+
+For sudden distribution shifts:
+```bash
+# Reset and restart cold start
+curl -X POST http://localhost:14345/v1/ml/anomaly/stream/my-detector/reset
+```
+
+---
+
+## Next Steps
+
+- [Polars Buffer API](./polars-buffers.md) - Direct access to data buffers
+- [Anomaly Detection Guide](./anomaly-detection.md) - Batch anomaly detection
+- [Use Cases: IoT Sensor Monitoring](../use-cases/iot-sensor-monitoring.md) - Complete example
+
+---
+
+# Financial Fraud Detection
+
+This use case demonstrates how to build a real-time fraud detection system for financial transactions using LlamaFarm's anomaly detection APIs.
+
+## Scenario
+
+You're building a fraud detection system for a payment processor that handles:
+- Thousands of transactions per second
+- Multiple data types (amounts, locations, device fingerprints)
+- Evolving fraud patterns
+- Real-time alerting requirements
+
+## Architecture
+
+```
+┌──────────────┐    ┌─────────────┐    ┌──────────────┐
+│ Transaction  │───▶│  LlamaFarm  │───▶│   Fraud      │
+│   Stream     │    │  Streaming  │    │   Review     │
+└──────────────┘    │  + Batch    │    │   Queue      │
+                    └─────────────┘    └──────────────┘
+                          │
+                    ┌─────┴─────┐
+                    │  Trained  │
+                    │  Models   │
+                    │  (daily)  │
+                    └───────────┘
+```
+
+## Backend Selection for Fraud Detection
+
+| Backend | Use Case | Strengths |
+|---------|----------|-----------|
+| `isolation_forest` | **Primary choice** - complex transaction patterns | Handles high-dimensional data, robust |
+| `suod` | Maximum accuracy (ensemble) | Combines multiple algorithms |
+| `autoencoder` | Deep pattern learning | Best for complex non-linear fraud patterns |
+| `ecod` | Real-time streaming | Fastest, good for pre-screening |
+
+**For this use case, we'll use a hybrid approach:**
+1. **Streaming with `ecod`** for real-time pre-screening
+2. **Batch with `isolation_forest`** for daily model training
+3. **`suod` ensemble** for high-risk transaction review
+
+## Step 1: Feature Engineering with Polars
+
+Fraud detection requires rich features. Use Polars buffers for per-user behavioral features:
+
+```python
+
+LLAMAFARM_URL = "http://localhost:14345/v1/ml"
+
+async def setup_user_buffer(user_id: str):
+    """Create a per-user behavior buffer."""
+    async with httpx.AsyncClient() as client:
+        await client.post(f"{LLAMAFARM_URL}/polars/buffers", json={
+            "buffer_id": f"user-{user_id}",
+            "window_size": 1000  # Keep last 1000 transactions
+        })
+
+async def add_transaction_features(user_id: str, transaction: dict):
+    """Add transaction and compute behavioral features."""
+    async with httpx.AsyncClient() as client:
+        # Append transaction
+        await client.post(f"{LLAMAFARM_URL}/polars/append", json={
+            "buffer_id": f"user-{user_id}",
+            "data": transaction
+        })
+
+        # Get behavioral features
+        response = await client.post(f"{LLAMAFARM_URL}/polars/features", json={
+            "buffer_id": f"user-{user_id}",
+            "rolling_windows": [5, 10, 50],  # Last 5, 10, 50 transactions
+            "include_rolling_stats": ["mean", "std", "min", "max"],
+            "include_lags": True,
+            "lag_periods": [1, 5, 10],
+            "tail": 1  # Just the latest with features
+        })
+
+        if response.json()["rows"] > 0:
+            return response.json()["data"][0]
+        return transaction  # Not enough history yet
+```
+
+## Step 2: Real-Time Streaming Detection
+
+For immediate fraud screening:
+
+```python
+async def screen_transaction(enhanced_transaction: dict):
+    """Fast pre-screening with streaming detector."""
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{LLAMAFARM_URL}/anomaly/stream",
+            json={
+                "model": "fraud-realtime",
+                "data": enhanced_transaction,
+                "backend": "ecod",  # Fast pre-screening
+                "min_samples": 100,
+                "retrain_interval": 1000,
+                "window_size": 10000,
+                "threshold": 0.4,  # Lower threshold = catch more
+                "contamination": 0.01  # Expect 1% fraud
+            }
+        )
+        result = response.json()
+
+        if result["status"] != "collecting":
+            for r in result["results"]:
+                if r["is_anomaly"]:
+                    return {
+                        "action": "review",
+                        "score": r["score"],
+                        "reason": "realtime_anomaly"
+                    }
+            # Use last result's score if available
+            if result["results"]:
+                return {"action": "approve", "score": result["results"][-1].get("score", 0)}
+
+        return {"action": "approve", "score": 0}
+```
+
+## Step 3: Batch Model Training (Daily)
+
+Train more accurate models on historical data:
+
+```python
+async def train_daily_model(training_data: list[dict]):
+    """Train daily fraud detection model on historical data."""
+    async with httpx.AsyncClient() as client:
+        # Define schema for mixed data types
+        schema = {
+            "amount": "numeric",
+            "amount_rolling_mean_10": "numeric",
+            "amount_rolling_std_10": "numeric",
+            "merchant_id": "hash",      # High cardinality
+            "device_type": "label",     # Low cardinality
+            "country": "label",
+            "hour_of_day": "numeric",
+            "is_weekend": "binary",
+            "days_since_last_tx": "numeric"
+        }
+
+        # Train with isolation_forest for complex patterns
+        response = await client.post(
+            f"{LLAMAFARM_URL}/anomaly/fit",
+            json={
+                "model": "fraud-daily",
+                "backend": "isolation_forest",
+                "data": training_data,
+                "schema": schema,
+                "contamination": 0.01,  # 1% expected fraud rate
+                "normalization": "standardization",
+                "overwrite": False  # Version models
+            }
+        )
+
+        result = response.json()
+        print(f"Trained model: {result['model']}")
+        print(f"Samples: {result['samples_fitted']}")
+
+        # Save for production use
+        await client.post(f"{LLAMAFARM_URL}/anomaly/save", json={
+            "model": result['model'],
+            "backend": "isolation_forest"
+        })
+
+        return result['model']
+```
+
+## Step 4: Ensemble Scoring for High-Risk
+
+For transactions flagged by real-time screening:
+
+```python
+async def deep_fraud_analysis(transaction: dict) -> dict:
+    """Run transaction through ensemble model for high accuracy."""
+    async with httpx.AsyncClient() as client:
+        # Score with ensemble backend
+        response = await client.post(
+            f"{LLAMAFARM_URL}/anomaly/score",
+            json={
+                "model": "fraud-ensemble",
+                "backend": "suod",  # Ensemble of multiple algorithms
+                "data": [transaction],
+                "normalization": "standardization"
+            }
+        )
+        result = response.json()
+
+        if result["data"]:
+            score = result["data"][0]
+            return {
+                "is_fraud": score["is_anomaly"],
+                "confidence": score["score"],
+                "raw_score": score["raw_score"],
+                "recommendation": (
+                    "block" if score["score"] > 0.8 else
+                    "review" if score["score"] > 0.5 else
+                    "approve"
+                )
+            }
+
+        return {"is_fraud": False, "confidence": 0}
+```
+
+## Complete Pipeline
+
+```python
+async def process_transaction(transaction: dict):
+    """Complete fraud detection pipeline."""
+
+    user_id = transaction["user_id"]
+
+    # 1. Add to user's behavior buffer
+    enhanced = await add_transaction_features(user_id, {
+        "amount": transaction["amount"],
+        "merchant_id": transaction["merchant_id"],
+        "device_type": transaction["device_type"],
+        "country": transaction["country"],
+        "timestamp": transaction["timestamp"]
+    })
+
+    # 2. Real-time screening (sub-10ms)
+    screening = await screen_transaction(enhanced)
+
+    if screening["action"] == "approve":
+        return {"decision": "approve", "latency_ms": 10}
+
+    # 3. Deep analysis for flagged transactions
+    deep = await deep_fraud_analysis(enhanced)
+
+    if deep["recommendation"] == "block":
+        return {
+            "decision": "block",
+            "reason": "high_fraud_confidence",
+            "score": deep["confidence"]
+        }
+
+    return {
+        "decision": "review",
+        "reason": "flagged_for_review",
+        "score": deep["confidence"]
+    }
+```
+
+## Feature Engineering Patterns
+
+### Velocity Features
+
+Detect rapid transaction sequences:
+
+```python
+# With Polars rolling features
+{
+    "rolling_windows": [3, 5, 10],  # Last 3, 5, 10 transactions
+    "include_rolling_stats": ["mean", "std", "max"],
+}
+
+# Produces:
+# - amount_rolling_mean_3 (avg of last 3)
+# - amount_rolling_std_5 (volatility of last 5)
+# - amount_rolling_max_10 (max in last 10)
+```
+
+### Time-Based Features
+
+Detect unusual timing:
+
+```python
+def extract_time_features(timestamp):
+    """Extract time-based features."""
+    dt = datetime.fromisoformat(timestamp)
+    return {
+        "hour_of_day": dt.hour,
+        "day_of_week": dt.weekday(),
+        "is_weekend": 1 if dt.weekday() >= 5 else 0,
+        "is_night": 1 if dt.hour < 6 or dt.hour > 22 else 0
+    }
+```
+
+### Geographic Features
+
+Detect impossible travel:
+
+```python
+def geographic_features(current_country, last_country, minutes_between):
+    """Detect geographic impossibilities."""
+    return {
+        "country_changed": 1 if current_country != last_country else 0,
+        "minutes_since_last": minutes_between,
+        # If country changed in < 120 minutes, suspicious
+        "impossible_travel": 1 if (
+            current_country != last_country and
+            minutes_between < 120
+        ) else 0
+    }
+```
+
+## Schema Design
+
+```python
+# Complete fraud detection schema
+FRAUD_SCHEMA = {
+    # Transaction attributes
+    "amount": "numeric",
+    "merchant_id": "hash",         # Millions of merchants
+    "merchant_category": "label",  # ~50 categories
+    "device_type": "label",        # mobile, desktop, tablet
+    "device_fingerprint": "hash",  # High cardinality
+
+    # Geographic
+    "country": "label",
+    "city": "hash",
+    "ip_prefix": "hash",
+
+    # Time
+    "hour_of_day": "numeric",
+    "is_weekend": "binary",
+    "is_night": "binary",
+
+    # Velocity (from Polars)
+    "amount_rolling_mean_5": "numeric",
+    "amount_rolling_std_5": "numeric",
+    "amount_rolling_max_10": "numeric",
+    "tx_count_rolling_mean_5": "numeric",
+
+    # Lags
+    "amount_lag_1": "numeric",
+    "minutes_since_last": "numeric",
+
+    # Derived
+    "amount_vs_avg": "numeric",  # Current / user's average
+    "impossible_travel": "binary"
+}
+```
+
+## Performance Optimization
+
+### Batch Processing
+
+For bulk scoring (end-of-day review):
+
+```python
+async def batch_score(transactions: list[dict]):
+    """Score many transactions at once."""
+    async with httpx.AsyncClient(timeout=60.0) as client:
+        response = await client.post(
+            f"{LLAMAFARM_URL}/anomaly/score",
+            json={
+                "model": "fraud-daily-latest",
+                "backend": "isolation_forest",
+                "data": transactions,
+                "normalization": "standardization"
+            }
+        )
+        return response.json()["data"]
+
+# Score 10,000 transactions at once
+results = await batch_score(pending_transactions)
+```
+
+### Caching User Buffers
+
+```python
+# Instead of creating buffer on every transaction
+# Pre-create buffers for active users
+
+async def warmup_user_buffers(active_user_ids: list[str]):
+    """Pre-create buffers for expected active users."""
+    async with httpx.AsyncClient() as client:
+        for user_id in active_user_ids:
+            await client.post(f"{LLAMAFARM_URL}/polars/buffers", json={
+                "buffer_id": f"user-{user_id}",
+                "window_size": 500
+            })
+```
+
+## Monitoring and Tuning
+
+### Track Model Performance
+
+```python
+async def log_decision(transaction_id: str, decision: dict, actual_fraud: bool = None):
+    """Log decisions for model tuning."""
+    log = {
+        "transaction_id": transaction_id,
+        "decision": decision["decision"],
+        "score": decision.get("score"),
+        "timestamp": datetime.now().isoformat()
+    }
+
+    if actual_fraud is not None:
+        # After manual review or chargeback
+        log["actual_fraud"] = actual_fraud
+        log["correct"] = (
+            (decision["decision"] == "block" and actual_fraud) or
+            (decision["decision"] == "approve" and not actual_fraud)
+        )
+
+    # Store for analysis
+    await store_decision_log(log)
+```
+
+### Tune Thresholds
+
+```python
+# Based on your business requirements:
+
+# High security (catch more fraud, more false positives)
+threshold = 0.3
+contamination = 0.02
+
+# Balanced
+threshold = 0.5
+contamination = 0.01
+
+# Customer-friendly (fewer false positives, might miss some fraud)
+threshold = 0.7
+contamination = 0.005
+```
+
+## Complete Example
+
+```python
+#!/usr/bin/env python3
+"""Complete fraud detection example."""
+
+from datetime import datetime, timedelta
+
+LLAMAFARM_URL = "http://localhost:14345/v1/ml"
+
+async def simulate_transaction() -> dict:
+    """Generate realistic transaction data."""
+    # Normal transaction
+    tx = {
+        "amount": random.lognormvariate(3, 1),  # Log-normal amounts
+        "merchant_category": random.choice([
+            "grocery", "gas", "restaurant", "retail", "online"
+        ]),
+        "device_type": random.choice(["mobile", "desktop", "tablet"]),
+        "hour": datetime.now().hour,
+        "is_weekend": 1 if datetime.now().weekday() >= 5 else 0
+    }
+
+    # Occasionally simulate fraud patterns
+    if random.random() < 0.02:  # 2% fraud rate
+        tx["amount"] = random.uniform(1000, 5000)  # Unusually large
+        tx["merchant_category"] = "electronics"  # High-risk category
+        tx["_is_fraud"] = True
+    else:
+        tx["_is_fraud"] = False
+
+    return tx
+
+async def main():
+    """Run fraud detection demo."""
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        print("💳 Starting Fraud Detection Demo")
+        print("-" * 50)
+
+        tx_count = 0
+        flagged_count = 0
+        fraud_count = 0
+
+        while tx_count < 200:
+            tx = await simulate_transaction()
+            is_actual_fraud = tx.pop("_is_fraud")
+
+            # Stream to detector
+            response = await client.post(
+                f"{LLAMAFARM_URL}/anomaly/stream",
+                json={
+                    "model": "fraud-demo",
+                    "data": tx,
+                    "backend": "ecod",
+                    "min_samples": 50,
+                    "retrain_interval": 100,
+                    "window_size": 500,
+                    "threshold": 0.5,
+                    "contamination": 0.02
+                }
+            )
+            result = response.json()
+            tx_count += 1
+
+            if is_actual_fraud:
+                fraud_count += 1
+
+            if result["status"] == "collecting":
+                if tx_count % 10 == 0:
+                    print(f"⏳ Collecting: {result['samples_until_ready']} to go")
+            else:
+                for r in result["results"]:
+                    if r["is_anomaly"]:
+                        flagged_count += 1
+                        status = "✅ TRUE POSITIVE" if is_actual_fraud else "⚠️  FALSE POSITIVE"
+                        print(f"🚨 Flagged tx #{tx_count}: ${tx['amount']:.2f} "
+                              f"@ {tx['merchant_category']} | score={r['score']:.3f} | {status}")
+                    elif is_actual_fraud:
+                        print(f"❌ MISSED FRAUD: ${tx['amount']:.2f} @ {tx['merchant_category']}")
+
+            await asyncio.sleep(0.05)  # 20 TPS
+
+        print("-" * 50)
+        print(f"Summary: {tx_count} transactions, "
+              f"{fraud_count} actual fraud, "
+              f"{flagged_count} flagged")
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+## Next Steps
+
+- [Streaming Anomaly Detection](../models/streaming-anomaly-detection.md) - API reference
+- [Polars Buffer API](../models/polars-buffers.md) - Feature engineering
+- [IoT Sensor Monitoring](./iot-sensor-monitoring.md) - Another use case
+
+---
+
+# IoT Sensor Monitoring
+
+This use case demonstrates how to build a production-ready IoT sensor monitoring system using LlamaFarm's streaming anomaly detection and Polars buffer APIs.
+
+## Scenario
+
+You're monitoring a fleet of industrial sensors (temperature, humidity, pressure) that produce data every second. You need to:
+
+1. Detect equipment malfunctions in real-time
+2. Handle concept drift as seasons change
+3. Alert operators to anomalies within seconds
+4. Run on edge devices with limited resources
+
+## Architecture
+
+```
+┌─────────────┐    ┌─────────────┐    ┌─────────────┐
+│  Sensors    │───▶│  LlamaFarm  │───▶│   Alerts    │
+│ (1000/sec)  │    │  Streaming  │    │  Dashboard  │
+└─────────────┘    └─────────────┘    └─────────────┘
+                          │
+                   ┌──────┴──────┐
+                   │  Polars     │
+                   │  Buffer     │
+                   │  (rolling)  │
+                   └─────────────┘
+```
+
+## Why These Components?
+
+| Component | Why |
+|-----------|-----|
+| **Streaming API** | Handles cold start, auto-retraining, sliding window |
+| **ECOD Backend** | Fast (5000+ samples/sec), parameter-free, handles drift |
+| **Polars Buffers** | Sub-millisecond append, efficient rolling features |
+| **Rolling Features** | Detect gradual trends and sudden spikes |
+
+## Backend Selection Guide
+
+For IoT sensor monitoring:
+
+| Backend | When to Use | Speed | Accuracy |
+|---------|-------------|-------|----------|
+| `ecod` | **Default choice** - works great for most sensors | ⚡⚡⚡⚡ | ⭐⭐⭐⭐ |
+| `hbos` | Ultra-high throughput (>10k samples/sec) | ⚡⚡⚡⚡⚡ | ⭐⭐⭐ |
+| `isolation_forest` | Complex multi-sensor correlations | ⚡⚡⚡ | ⭐⭐⭐⭐ |
+| `loda` | Memory-constrained edge devices | ⚡⚡⚡⚡ | ⭐⭐⭐ |
+
+**For this use case, we'll use `ecod`** because:
+- Parameter-free (no tuning needed)
+- Fast enough for 1000 samples/second
+- Handles seasonal drift naturally
+
+## Step 1: Configure the Detector
+
+```python
+# sensor_monitor.py
+
+from datetime import datetime
+
+# Configuration
+LLAMAFARM_URL = "http://localhost:14345/v1/ml"
+MODEL_ID = "factory-sensors"
+BACKEND = "ecod"
+
+# Streaming parameters tuned for IoT
+DETECTOR_CONFIG = {
+    "model": MODEL_ID,
+    "backend": BACKEND,
+    "min_samples": 100,        # Enough for initial pattern learning
+    "retrain_interval": 500,   # Retrain every 500 samples (~8 minutes)
+    "window_size": 3600,       # Keep 1 hour of history
+    "threshold": 0.5,          # Balanced sensitivity
+    "contamination": 0.05,     # Expect ~5% anomalies
+    # Enable rolling features for trend detection
+    "rolling_windows": [10, 60, 300],  # 10s, 1min, 5min windows
+    "include_lags": True,
+    "lag_periods": [1, 5, 10]  # Compare to recent values
+}
+```
+
+## Step 2: Create the Streaming Loop
+
+```python
+async def stream_sensor_data():
+    """Main streaming loop for sensor monitoring."""
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        sample_count = 0
+        anomaly_count = 0
+
+        while True:
+            # Simulate sensor reading
+            sensor_data = read_sensors()
+
+            # Send to streaming detector
+            response = await client.post(
+                f"{LLAMAFARM_URL}/anomaly/stream",
+                json={**DETECTOR_CONFIG, "data": sensor_data}
+            )
+            result = response.json()
+
+            sample_count += 1
+
+            # Check status
+            if result["status"] == "collecting":
+                print(f"Cold start: {result['samples_until_ready']} samples until ready")
+            else:
+                # Process results
+                for r in result["results"]:
+                    if r["is_anomaly"]:
+                        anomaly_count += 1
+                        await send_alert(sensor_data, r["score"])
+
+            # Log progress every 100 samples
+            if sample_count % 100 == 0:
+                print(f"Processed: {sample_count}, Anomalies: {anomaly_count}, "
+                      f"Model version: {result['model_version']}")
+
+            await asyncio.sleep(1)  # 1 sample per second
+
+def read_sensors() -> dict:
+    """Simulate sensor readings (replace with real sensor code)."""
+    # Normal operating ranges
+    temp = 72 + random.gauss(0, 2)      # 72°F ± 2
+    humidity = 45 + random.gauss(0, 3)  # 45% ± 3
+    pressure = 1013 + random.gauss(0, 5)  # 1013 hPa ± 5
+
+    # Simulate occasional real anomalies
+    if random.random() < 0.02:  # 2% chance
+        temp = random.choice([50, 95])  # Equipment malfunction
+
+    return {
+        "temperature": round(temp, 2),
+        "humidity": round(humidity, 2),
+        "pressure": round(pressure, 2),
+        "timestamp": datetime.now().isoformat()
+    }
+
+async def send_alert(data: dict, score: float):
+    """Send alert to monitoring system."""
+    print(f"🚨 ANOMALY DETECTED! Score: {score:.3f}")
+    print(f"   Data: temp={data['temperature']}, humidity={data['humidity']}")
+    # In production: send to PagerDuty, Slack, email, etc.
+```
+
+## Step 3: Understanding the Rolling Features
+
+When `rolling_windows` is enabled, the detector automatically computes:
+
+| Feature | Window | What It Detects |
+|---------|--------|-----------------|
+| `temperature_rolling_mean_10` | 10 samples | Short-term average |
+| `temperature_rolling_std_10` | 10 samples | Short-term volatility |
+| `temperature_rolling_mean_60` | 60 samples | 1-minute trend |
+| `temperature_rolling_mean_300` | 5 minutes | Longer baseline |
+| `temperature_lag_1` | Previous | Sudden jumps |
+| `temperature_lag_10` | 10 ago | Compare to recent |
+
+**Why this matters:**
+- A sensor reading of 80°F might be normal if it's been trending up
+- The same 80°F is anomalous if it jumped from 72°F suddenly
+- Rolling features capture this context automatically
+
+## Step 4: Handling Concept Drift
+
+Sensors naturally drift with:
+- Seasonal temperature changes
+- Equipment aging
+- Calibration shifts
+
+The streaming API handles this automatically:
+
+```python
+# The sliding window naturally adapts
+window_size = 3600  # Keep 1 hour
+
+# Periodic retraining incorporates new patterns
+retrain_interval = 500  # Every ~8 minutes
+
+# Result: the model continuously adapts to gradual changes
+# while still detecting sudden anomalies
+```
+
+**For sudden operational changes** (e.g., switching to night shift):
+
+```python
+# Reset the detector to restart learning
+await client.post(f"{LLAMAFARM_URL}/anomaly/stream/{MODEL_ID}/reset")
+print("Detector reset - starting fresh learning phase")
+```
+
+## Step 5: Monitoring Detector Health
+
+```python
+async def monitor_detector_health():
+    """Periodically check detector status."""
+    async with httpx.AsyncClient() as client:
+        while True:
+            response = await client.get(
+                f"{LLAMAFARM_URL}/anomaly/stream/{MODEL_ID}"
+            )
+            stats = response.json()
+
+            print(f"""
+            Detector Health:
+            - Status: {stats['status']}
+            - Model Version: {stats['model_version']}
+            - Samples Collected: {stats['samples_collected']}
+            - Total Processed: {stats['total_processed']}
+            - Samples Since Retrain: {stats['samples_since_retrain']}
+            - Is Ready: {stats['is_ready']}
+            """)
+
+            await asyncio.sleep(60)  # Check every minute
+```
+
+## Step 6: Using Polars Buffers for Custom Analysis
+
+For advanced analysis beyond anomaly detection:
+
+```python
+async def analyze_with_polars(sensor_data: dict):
+    """Use Polars buffers for custom feature engineering.
+
+    Args:
+        sensor_data: Sensor reading dict with values like temperature, humidity, etc.
+    """
+    async with httpx.AsyncClient() as client:
+        # Create dedicated analysis buffer
+        await client.post(f"{LLAMAFARM_URL}/polars/buffers", json={
+            "buffer_id": "sensor-analysis",
+            "window_size": 3600  # 1 hour
+        })
+
+        # In your streaming loop, also append to analysis buffer
+        await client.post(f"{LLAMAFARM_URL}/polars/append", json={
+            "buffer_id": "sensor-analysis",
+            "data": sensor_data
+        })
+
+        # Get custom features for dashboard/reporting
+        features = await client.post(f"{LLAMAFARM_URL}/polars/features", json={
+            "buffer_id": "sensor-analysis",
+            "rolling_windows": [60, 300, 900],  # 1min, 5min, 15min
+            "include_rolling_stats": ["mean", "std", "min", "max"],
+            "include_lags": True,
+            "tail": 100  # Last 100 readings with features
+        })
+
+        return features.json()["data"]
+```
+
+## Complete Example
+
+```python
+#!/usr/bin/env python3
+"""Complete IoT sensor monitoring example."""
+
+from datetime import datetime
+
+LLAMAFARM_URL = "http://localhost:14345/v1/ml"
+MODEL_ID = "factory-sensors"
+
+async def main():
+    """Run the sensor monitoring system."""
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        print("🏭 Starting IoT Sensor Monitor")
+        print(f"   Model: {MODEL_ID}")
+        print(f"   Backend: ecod")
+        print("-" * 50)
+
+        sample_count = 0
+        anomaly_count = 0
+
+        while True:
+            # Generate sensor reading
+            temp = 72 + random.gauss(0, 2)
+            humidity = 45 + random.gauss(0, 3)
+            pressure = 1013 + random.gauss(0, 5)
+
+            # Inject anomaly every ~50 samples
+            if sample_count > 100 and random.random() < 0.02:
+                temp = random.choice([50, 95])
+                print(f"💉 Injecting anomaly: temp={temp}")
+
+            sensor_data = {
+                "temperature": round(temp, 2),
+                "humidity": round(humidity, 2),
+                "pressure": round(pressure, 2)
+            }
+
+            # Stream to detector
+            response = await client.post(
+                f"{LLAMAFARM_URL}/anomaly/stream",
+                json={
+                    "model": MODEL_ID,
+                    "data": sensor_data,
+                    "backend": "ecod",
+                    "min_samples": 50,
+                    "retrain_interval": 100,
+                    "window_size": 1000,
+                    "threshold": 0.5,
+                    "rolling_windows": [5, 10, 20],
+                    "include_lags": True
+                }
+            )
+            result = response.json()
+            sample_count += 1
+
+            # Handle response
+            if result["status"] == "collecting":
+                if sample_count % 10 == 0:
+                    print(f"⏳ Collecting... {result['samples_until_ready']} until ready")
+            else:
+                for r in result["results"]:
+                    if r["is_anomaly"]:
+                        anomaly_count += 1
+                        print(f"🚨 ANOMALY #{anomaly_count}: score={r['score']:.3f}, "
+                              f"data={sensor_data}")
+
+                if sample_count % 50 == 0:
+                    print(f"✅ Sample {sample_count}: "
+                          f"anomalies={anomaly_count}, "
+                          f"version={result['model_version']}")
+
+            await asyncio.sleep(0.1)  # 10 samples/second for demo
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+## Performance Considerations
+
+### Edge Device Optimization
+
+For resource-constrained edge devices:
+
+```python
+# Use lighter backend
+"backend": "loda",  # Lower memory than ecod
+
+# Smaller windows
+"window_size": 500,  # 8 minutes instead of 1 hour
+"min_samples": 30,   # Faster cold start
+
+# Disable rolling features to save memory
+# (let the backend handle pattern detection)
+"rolling_windows": None,
+"include_lags": False
+```
+
+### High-Throughput Optimization
+
+For >1000 samples/second:
+
+```python
+# Batch multiple readings
+batch = [read_sensors() for _ in range(100)]
+await client.post(url, json={**config, "data": batch})
+
+# Use fastest backend
+"backend": "hbos",  # Histogram-based, extremely fast
+
+# Increase retrain interval
+"retrain_interval": 5000,  # Retrain less frequently
+```
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| Too many false positives | Increase `threshold` (0.6-0.7) or `contamination` (0.1-0.2) |
+| Missing real anomalies | Decrease `threshold` (0.3-0.4) |
+| Slow cold start | Decrease `min_samples` (30-50) |
+| Memory growing | Decrease `window_size` |
+| Model not adapting | Decrease `retrain_interval` |
+
+## Next Steps
+
+- [Streaming Anomaly Detection](../models/streaming-anomaly-detection.md) - API reference
+- [Polars Buffer API](../models/polars-buffers.md) - Custom feature engineering
+- [Financial Fraud Detection](./financial-fraud-detection.md) - Another use case
+
+---
+
+# Detection, Classification & Embeddings
+
+Single-frame inference endpoints for object detection, image classification, segmentation, and CLIP embeddings. All endpoints are available through the LlamaFarm server (port 14345).
+
+## Object Detection
+
+Detect objects in images using YOLO models.
+
+**Endpoint:** `POST /v1/vision/detect`
+
+```bash
+curl -X POST http://localhost:14345/v1/vision/detect \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "yolov8n",
+    "images": ["data:image/png;base64,..."],
+    "confidence_threshold": 0.5,
+    "classes": ["person", "car"]
+  }'
+```
+
+**Parameters:**
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `model` | string | Yes | - | YOLO model ID (e.g., `yolov8n`, `yolov8m`, `yolov8x`) |
+| `images` | list[string] | Yes | - | Base64-encoded images |
+| `confidence_threshold` | float | No | `0.5` | Minimum detection confidence |
+| `classes` | list[string] | No | all | Filter to specific class names |
+
+**Response:**
+
+```json
+{
+  "detections": [
+    {
+      "class_name": "person",
+      "confidence": 0.92,
+      "bbox": [120.5, 80.3, 340.2, 410.7]
+    }
+  ],
+  "model": "yolov8n",
+  "inference_time_ms": 12.4
+}
+```
+
+### Supported Models
+
+Any YOLO-compatible model works. Common choices:
+
+| Model | Size | Speed | Accuracy | Use Case |
+|-------|------|-------|----------|----------|
+| `yolov8n` | 6 MB | ~5ms | Good | Real-time, edge devices |
+| `yolov8s` | 22 MB | ~10ms | Better | Balanced |
+| `yolov8m` | 50 MB | ~25ms | High | General purpose |
+| `yolov8l` | 83 MB | ~50ms | Higher | When accuracy matters |
+| `yolov8x` | 131 MB | ~80ms | Highest | Audit, validation |
+
+## Image Classification
+
+Zero-shot image classification using CLIP models. Classify images into arbitrary categories without training.
+
+**Endpoint:** `POST /v1/vision/classify`
+
+```bash
+curl -X POST http://localhost:14345/v1/vision/classify \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "openai/clip-vit-base-patch32",
+    "images": ["data:image/png;base64,..."],
+    "labels": ["cat", "dog", "bird", "fish"]
+  }'
+```
+
+**Parameters:**
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `model` | string | Yes | - | CLIP model ID from HuggingFace |
+| `images` | list[string] | Yes | - | Base64-encoded images |
+| `labels` | list[string] | Yes | - | Candidate class labels |
+
+## Segmentation
+
+Instance and semantic segmentation to get pixel-level object boundaries.
+
+**Endpoint:** `POST /v1/vision/segment`
+
+```bash
+curl -X POST http://localhost:14345/v1/vision/segment \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "yolov8n-seg",
+    "images": ["data:image/png;base64,..."],
+    "confidence_threshold": 0.5
+  }'
+```
+
+Segmentation masks are returned as polygon coordinates or run-length encoded (RLE) format. In the streaming pipeline, segmentation masks automatically attach to detections when `enrich_on_escalation` is enabled.
+
+## CLIP Embeddings
+
+Generate embeddings for images and/or text using CLIP models. Useful for multimodal RAG, image search, and similarity matching.
+
+**Endpoint:** `POST /v1/vision/embed`
+
+```bash
+# Embed images
+curl -X POST http://localhost:14345/v1/vision/embed \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "openai/clip-vit-base-patch32",
+    "images": ["data:image/png;base64,..."]
+  }'
+
+# Embed text
+curl -X POST http://localhost:14345/v1/vision/embed \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "openai/clip-vit-base-patch32",
+    "texts": ["a photo of a cat", "a painting of a dog"]
+  }'
+```
+
+Image and text embeddings live in the same vector space, so you can search images by text description and vice versa.
+
+## Model Management
+
+List, load, save, and delete vision models.
+
+```bash
+# List available models
+curl http://localhost:14345/v1/vision/models
+
+# Save a model to disk
+curl -X POST http://localhost:14345/v1/vision/models/save \
+  -H "Content-Type: application/json" \
+  -d '{"model": "yolov8n", "task": "detection", "name": "my-detector"}'
+
+# Load a saved model
+curl -X POST http://localhost:14345/v1/vision/models/load \
+  -H "Content-Type: application/json" \
+  -d '{"task": "detection", "name": "my-detector"}'
+
+# Delete a saved model
+curl -X DELETE http://localhost:14345/v1/vision/models/detection/my-detector
+```
+
+---
+
+# Federation & Distribution
+
+Federation connects multiple LlamaFarm instances so they can share model inference, distribute trained models, and route vision work to the best available GPU.
+
+## Concepts
+
+**Peers** -- Other LlamaFarm instances that can run vision models. On standalone, you configure peers manually. On mesh (Atmosphere), peers are discovered automatically.
+
+**Remote Model Proxy** -- A `DetectionModel` that calls `/v1/vision/federation/escalate` on a remote LlamaFarm instance. The cascade chain doesn't know or care whether a model is local or remote.
+
+**Model Packages** -- Portable `.tar.gz` bundles containing model weights, metadata, class maps, and validation metrics. Used to distribute trained models across nodes.
+
+## Peer Management
+
+```bash
+# List federation peers
+curl http://localhost:14345/v1/vision/federation/peers
+
+# Register a peer
+curl -X POST http://localhost:14345/v1/vision/federation/peers \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "gpu-server",
+    "url": "http://192.168.1.100:14345",
+    "models": ["yolov8x"],
+    "gpu_vram_gb": 24,
+    "priority": 0,
+    "timeout": 30.0
+  }'
+
+# Remove a peer
+curl -X DELETE http://localhost:14345/v1/vision/federation/peers/gpu-server
+
+# Check federation health
+curl http://localhost:14345/v1/vision/federation/status
+```
+
+## Inbound Escalation
+
+When another LlamaFarm instance is uncertain about a detection, it sends the full escalation envelope to this endpoint. The local node runs its model and returns its opinion.
+
+**Endpoint:** `POST /v1/vision/federation/escalate`
+
+```bash
+curl -X POST http://localhost:14345/v1/vision/federation/escalate \
+  -H "Content-Type: application/json" \
+  -d '{
+    "image": "<base64-encoded>",
+    "model": "yolov8x",
+    "confidence_threshold": 0.5,
+    "opinions": [
+      {
+        "model_id": "yolov8n",
+        "node_id": "edge-device-1",
+        "class_name": "bird",
+        "confidence": 0.45
+      }
+    ]
+  }'
+```
+
+**Response:**
+
+```json
+{
+  "model": "yolov8x",
+  "detections": [
+    {
+      "class_name": "eagle",
+      "confidence": 0.91,
+      "bbox": [100, 50, 300, 250]
+    }
+  ],
+  "inference_time_ms": 82.3,
+  "node_id": "gpu-server"
+}
+```
+
+## Using Remote Models in the Cascade
+
+Add remote models to a streaming session's cascade chain by prefixing with `remote:`:
+
+```bash
+curl -X POST http://localhost:14345/v1/vision/stream/start \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "yolov8n",
+    "cascade": {
+      "enabled": true,
+      "cascade_chain": [
+        "yolov8n",
+        "remote:gpu-server/yolov8x"
+      ],
+      "confidence_threshold": 0.7
+    }
+  }'
+```
+
+The `RemoteModelProxy` implements the same `DetectionModel` interface as local models. The cascade loop calls `.detect()` on each -- it doesn't distinguish local from remote.
+
+## Model Packages
+
+Package trained models for distribution to other nodes.
+
+### List Packages
+
+```bash
+curl http://localhost:14345/v1/vision/federation/packages
+```
+
+### Create a Package
+
+```bash
+curl -X POST http://localhost:14345/v1/vision/federation/packages \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model_id": "bird-detector-v3",
+    "model_path": "/path/to/best.pt",
+    "description": "Fine-tuned bird detector"
+  }'
+```
+
+### Import a Package
+
+```bash
+curl -X POST http://localhost:14345/v1/vision/federation/packages/import \
+  -H "Content-Type: application/json" \
+  -d '{
+    "source": "/path/to/bird-detector-v3.tar.gz"
+  }'
+```
+
+### Package Format
+
+Packages are `.tar.gz` archives containing:
+
+```
+package.tar.gz
+├── model.pt                  # Model weights
+├── metadata.json             # Model ID, version, base model, class names, etc.
+├── class_map.json            # {class_name: index} mapping
+└── validation_metrics.json   # Accuracy, mAP, per-class metrics
+```
+
+Packages are created automatically when the validation gate promotes a new model. On mesh deployments, packages are announced via Atmosphere gossip so peers can pull updated models.
+
+---
+
+# Vision Pipeline
+
+LlamaFarm includes a complete vision pipeline for object detection, image classification, segmentation, CLIP embeddings, and OCR. The pipeline supports real-time streaming with an automatic learning loop that improves models over time with minimal human intervention.
+
+## Capabilities
+
+| Capability | Endpoint | Description |
+|-----------|----------|-------------|
+| [Object Detection](./detection) | `POST /v1/vision/detect` | Detect objects with YOLO models |
+| [Image Classification](./detection#image-classification) | `POST /v1/vision/classify` | Classify images with CLIP zero-shot |
+| [Segmentation](./detection#segmentation) | `POST /v1/vision/segment` | Instance/semantic segmentation |
+| [CLIP Embeddings](./detection#clip-embeddings) | `POST /v1/vision/embed` | Image and text embeddings for multimodal RAG |
+| [OCR](../models/specialized-ml#ocr-text-extraction) | `POST /v1/vision/ocr` | Extract text from images and PDFs |
+| [Streaming](./streaming) | `POST /v1/vision/stream/*` | Real-time frame processing with cascade |
+| [Training](./training) | `POST /v1/vision/train` | Fine-tune detection models |
+| [Federation](./federation) | `/v1/vision/federation/*` | Multi-node model distribution |
+
+## Architecture Overview
+
+The vision system is organized into layers:
+
+```
+                        ┌─────────────────────────┐
+                        │   Vision API Endpoints   │
+                        │  detect / classify / ocr │
+                        └────────────┬────────────┘
+                                     │
+                        ┌────────────▼────────────┐
+                        │   Streaming Pipeline     │
+                        │  cascade chain + enrich  │
+                        └────────────┬────────────┘
+                                     │
+              ┌──────────────────────┼──────────────────────┐
+              │                      │                      │
+    ┌─────────▼─────────┐ ┌─────────▼─────────┐ ┌─────────▼─────────┐
+    │   Local Models     │ │   Remote Models    │ │   Review Queue     │
+    │  YOLO / CLIP / SAM │ │  RemoteModelProxy  │ │  Human feedback    │
+    └─────────┬─────────┘ └─────────┬─────────┘ └─────────┬─────────┘
+              │                      │                      │
+              └──────────────────────┼──────────────────────┘
+                                     │
+                        ┌────────────▼────────────┐
+                        │    Replay Buffer         │
+                        │  SQLite-backed samples   │
+                        └────────────┬────────────┘
+                                     │
+              ┌──────────────────────┼──────────────────────┐
+              │                      │                      │
+    ┌─────────▼─────────┐ ┌─────────▼─────────┐ ┌─────────▼─────────┐
+    │   Auto Trainer     │ │   Audit Pipeline   │ │  Validation Gate   │
+    │  periodic retrain  │ │  model-checks-model│ │  blue/green swap   │
+    └───────────────────┘ └───────────────────┘ └───────────────────┘
+```
+
+## Deployment Modes
+
+The vision pipeline works identically in two deployment modes:
+
+**Standalone (laptop/desktop):** All models run locally. The cascade chain tries progressively larger models (e.g., yolov8n -> yolov8m -> yolov8x). Training happens on your GPU/CPU.
+
+**Mesh/Edge (Atmosphere):** A tiny model runs on the edge device. Uncertain detections escalate to GPU peers discovered via mesh service discovery. The `RemoteModelProxy` wraps remote LlamaFarm instances with the same `DetectionModel` interface -- the cascade loop doesn't know or care whether a model is local or remote.
+
+## The Learning Loop
+
+The system is designed to be 99% automatic. The only human task is occasionally reviewing uncertain detections in the review queue.
+
+1. **Detect** -- Fast model runs on every frame
+2. **Escalate** -- Uncertain detections cascade to bigger models with full context (bounding boxes, segmentation masks, prior opinions)
+3. **Feedback** -- Resolved detections automatically become training samples in the replay buffer
+4. **Train** -- Auto-trainer fires when the replay buffer hits a threshold (default: 50 samples)
+5. **Validate** -- Candidate model must beat current model on a held-out validation set
+6. **Promote** -- Blue/green swap with automatic rollback if needed
+7. **Audit** -- A bigger model periodically spot-checks the fast model's predictions, catching systematic errors
+
+## Quick Start
+
+```bash
+# Start the Universal Runtime
+nx start universal-runtime
+
+# Detect objects in an image
+curl -X POST http://localhost:14345/v1/vision/detect \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "yolov8n",
+    "images": ["data:image/png;base64,..."],
+    "confidence_threshold": 0.5
+  }'
+
+# Start a streaming session with cascade
+curl -X POST http://localhost:14345/v1/vision/stream/start \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "yolov8n",
+    "cascade": {
+      "enabled": true,
+      "cascade_chain": ["yolov8n", "yolov8m"],
+      "confidence_threshold": 0.7
+    }
+  }'
+```
+
+## Next Steps
+
+- [Detection, Classification & Embeddings](./detection) -- Single-frame inference endpoints
+- [Streaming & Cascade](./streaming) -- Real-time processing with automatic learning
+- [Training & Validation](./training) -- Auto-training, validation gate, model management
+- [Federation & Distribution](./federation) -- Multi-node deployment and model packaging
+
+---
+
+# Streaming & Cascade
+
+The streaming pipeline processes video frames in real-time with an automatic multi-hop cascade. When a model is uncertain, the detection escalates to bigger models with full context -- bounding boxes, segmentation masks, and every prior model's opinion.
+
+## Streaming Sessions
+
+### Start a Session
+
+**Endpoint:** `POST /v1/vision/stream/start`
+
+```bash
+curl -X POST http://localhost:14345/v1/vision/stream/start \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "yolov8n",
+    "cascade": {
+      "enabled": true,
+      "cascade_chain": ["yolov8n", "yolov8m"],
+      "confidence_threshold": 0.7,
+      "enrich_on_escalation": true,
+      "segmentation_model_id": "yolov8n-seg",
+      "classification_model_id": "openai/clip-vit-base-patch32"
+    }
+  }'
+```
+
+**Cascade Configuration:**
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `false` | Enable multi-hop cascade |
+| `cascade_chain` | list[string] | `[]` | Ordered list of model IDs to try |
+| `confidence_threshold` | float | `0.7` | Minimum confidence to accept a detection |
+| `enrich_on_escalation` | bool | `true` | Attach segmentation masks and CLIP labels before escalating |
+| `segmentation_model_id` | string | `null` | Model for bbox segmentation enrichment |
+| `classification_model_id` | string | `null` | CLIP model for classification enrichment |
+
+### Process Frames
+
+**Endpoint:** `POST /v1/vision/stream/frame`
+
+```bash
+curl -X POST http://localhost:14345/v1/vision/stream/frame \
+  -H "Content-Type: application/json" \
+  -d '{
+    "session_id": "abc123",
+    "image": "data:image/png;base64,..."
+  }'
+```
+
+**Response:**
+
+```json
+{
+  "detections": [
+    {
+      "class_name": "bird",
+      "confidence": 0.85,
+      "bbox": [100, 50, 300, 250],
+      "model": "yolov8m"
+    }
+  ],
+  "hop_count": 2,
+  "cascade_resolved_by": "yolov8m",
+  "inference_time_ms": 45.2
+}
+```
+
+### Stop a Session
+
+**Endpoint:** `POST /v1/vision/stream/stop`
+
+```bash
+curl -X POST http://localhost:14345/v1/vision/stream/stop \
+  -H "Content-Type: application/json" \
+  -d '{"session_id": "abc123"}'
+```
+
+### List Sessions and Stats
+
+```bash
+# List active sessions
+curl http://localhost:14345/v1/vision/stream/sessions
+
+# Get session statistics
+curl http://localhost:14345/v1/vision/stream/sessions/abc123/stats
+```
+
+## How the Cascade Works
+
+When a detection's confidence falls below the threshold, the pipeline escalates through the cascade chain:
+
+```
+Frame arrives
+  │
+  ├── Hop 0: yolov8n (fast, ~5ms)
+  │   confidence >= 0.7 → DONE (return result)
+  │   confidence < 0.7  → enrich bbox with seg + CLIP → Hop 1
+  │
+  ├── Hop 1: yolov8m (medium, ~25ms)
+  │   confidence >= 0.7 → DONE + auto-feedback to replay buffer
+  │   confidence < 0.7  → Hop 2
+  │
+  ├── Hop 2: yolov8x or remote model (~80ms+)
+  │   confidence >= 0.5 → DONE + feedback to hop 0 AND hop 1
+  │   confidence < 0.5  → REVIEW QUEUE (needs human eyes)
+  │
+  └── Max 3 hops (circuit breaker)
+```
+
+At each hop, the pipeline builds a `ModelOpinion` recording what that model saw. All opinions flow forward so the next model has full context.
+
+### Cross-Modal Enrichment
+
+When `enrich_on_escalation` is enabled, before escalating to the next model the pipeline:
+
+1. Crops the bounding box region from the full image
+2. Runs segmentation to get a pixel-level mask of the object
+3. Runs CLIP classification to get candidate class labels
+4. Packages everything into the escalation so the next model gets precise visual context
+
+### Escalation Envelope
+
+The data structure flowing through the cascade:
+
+```
+EscalationEnvelope
+├── image_bytes          # Original full frame
+├── image_hash           # For dedup
+├── source_id            # Camera/source identifier
+├── opinions[]           # What each model predicted
+│   ├── model_id         # "yolov8n" or "remote:gpu-server/yolov8x"
+│   ├── node_id          # "local" or Atmosphere node ID
+│   ├── class_name       # What it thinks this is
+│   ├── confidence       # How sure it is
+│   ├── bbox             # Bounding box coordinates
+│   └── mask_polygon     # Segmentation mask (if available)
+├── detections[]         # Bounding boxes with crops and masks
+├── hops                 # How many models have seen this
+└── max_hops             # Circuit breaker (default: 3)
+```
+
+## Corrections and Replay Buffer
+
+Submit human corrections for detections and inspect the replay buffer.
+
+```bash
+# Submit a correction
+curl -X POST http://localhost:14345/v1/vision/corrections \
+  -H "Content-Type: application/json" \
+  -d '{
+    "image_id": "img_abc123",
+    "correct_class": "eagle",
+    "bbox": [100, 50, 300, 250]
+  }'
+
+# Check replay buffer status
+curl http://localhost:14345/v1/vision/replay-buffer
+
+# Clear replay buffer
+curl -X POST http://localhost:14345/v1/vision/replay-buffer/clear
+```
+
+The replay buffer stores training samples with priority weighting:
+
+| Source | Priority | Description |
+|--------|----------|-------------|
+| Human correction | 2.0 | Manual review queue feedback |
+| Audit disagreement | 2.0 | Bigger model disagrees with small model |
+| Cascade resolved (hop 2+) | 1.8 | Multiple models needed to resolve |
+| Escalation resolved (hop 1) | 1.5 | Single escalation resolved it |
+| Low confidence | ~0.4 | Detection below threshold |
+
+Samples persist to SQLite so they survive restarts. When the buffer hits the training threshold (default: 50 samples), the auto-trainer fires automatically.
+
+---
+
+# Training & Validation
+
+The vision pipeline includes automatic model retraining with a validation gate that prevents regressions. Models must prove they're better before going live.
+
+## Auto-Training
+
+When the replay buffer accumulates enough training samples (default: 50), the auto-trainer fires automatically. No manual intervention needed.
+
+### How It Works
+
+1. **Collect** -- Cascade resolutions, human corrections, and audit disagreements fill the replay buffer
+2. **Dataset** -- Auto-trainer builds a YOLO-format dataset with proper class maps and 80/20 train/val split
+3. **Train** -- Fine-tunes a candidate model for a few epochs with EWC (Elastic Weight Consolidation) to prevent catastrophic forgetting
+4. **Validate** -- Candidate runs against a held-out validation set of human-verified and audit-verified images
+5. **Promote or Reject** -- If the candidate beats the current model, blue/green swap. Otherwise, reject and keep current.
+
+### Check Auto-Train Status
+
+```bash
+curl http://localhost:14345/v1/vision/auto-train/status
+```
+
+### Trigger Training Manually
+
+```bash
+curl -X POST http://localhost:14345/v1/vision/auto-train/trigger
+```
+
+## Training API
+
+For manual training control:
+
+```bash
+# Start a training job
+curl -X POST http://localhost:14345/v1/vision/train \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "yolov8n",
+    "dataset_path": "/path/to/dataset",
+    "epochs": 10,
+    "batch_size": 16
+  }'
+
+# Check training status
+curl http://localhost:14345/v1/vision/train/job_abc123
+
+# List all training jobs
+curl http://localhost:14345/v1/vision/train
+
+# Cancel a training job
+curl -X DELETE http://localhost:14345/v1/vision/train/job_abc123
+```
+
+## Validation Gate
+
+The validation gate is the safety net between training and deployment. A candidate model must demonstrate improvement on known-good images before it replaces the current model.
+
+### Validation Set Sources
+
+The gate automatically builds a validation set from two sources:
+
+- **Human-verified images** -- Images where a human confirmed the correct label via the review queue (highest trust)
+- **Audit-verified images** -- Images where the audit pipeline's larger model agreed with the primary model's prediction
+
+### Blue/Green Promotion
+
+When validation passes:
+
+1. The current model is backed up as `{model_id}_v{N}.pt`
+2. The candidate is installed as the new current model
+3. A few live frames run through both models as a final check
+4. The old model stays available for rollback
+
+### Rollback
+
+If a promoted model misbehaves, the system can roll back to the previous version:
+
+- Automatic rollback if live-frame validation fails during promotion
+- Manual rollback via the model management API
+
+## Audit Pipeline
+
+A bigger model periodically reviews what the fast model has been classifying with high confidence. This catches systematic errors the cascade missed.
+
+### How It Works
+
+1. Sample N recent high-confidence predictions (the ones that were NOT escalated)
+2. Re-run through a larger model (local or remote via `RemoteModelProxy`)
+3. Compare results:
+   - **Agreement** -- Mark as verified (becomes validation data)
+   - **Disagreement** -- Add to replay buffer as training sample (priority 2.0)
+
+The audit model can be any model -- a larger local YOLO model, or a `RemoteModelProxy` pointing at a GPU server. The pipeline doesn't distinguish between local and remote.
+
+## Dataset Format
+
+The auto-trainer produces YOLO-format datasets:
+
+```
+dataset/
+├── data.yaml          # Class names, paths
+├── class_map.json     # {class_name: index}
+├── train/
+│   ├── images/        # Training images
+│   └── labels/        # YOLO-format .txt labels
+└── val/
+    ├── images/        # Validation images (20%)
+    └── labels/        # YOLO-format .txt labels
+```
+
+Each label file contains one line per detection:
+
+```
+# class_index center_x center_y width height (all normalized 0-1)
+0 0.45 0.52 0.30 0.60
+1 0.72 0.31 0.15 0.25
+```
 
 ---

--- a/docs/website/yarn.lock
+++ b/docs/website/yarn.lock
@@ -122,7 +122,7 @@
     "@algolia/requester-fetch" "5.43.0"
     "@algolia/requester-node-http" "5.43.0"
 
-"@algolia/client-search@5.43.0":
+"@algolia/client-search@>= 4.9.1 < 6", "@algolia/client-search@5.43.0":
   version "5.43.0"
   resolved "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.43.0.tgz"
   integrity sha512-wKy6x6fKcnB1CsfeNNdGp4dzLzz04k8II3JLt6Sp81F8s57Ks3/K9qsysmL9SJa8P486s719bBttVLE8JJYurQ==
@@ -210,7 +210,7 @@
   resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.0.tgz"
   integrity sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==
 
-"@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.21.3", "@babel/core@^7.23.9", "@babel/core@^7.25.9":
+"@babel/core@^7.0.0", "@babel/core@^7.0.0 || ^8.0.0-0", "@babel/core@^7.0.0-0", "@babel/core@^7.0.0-0 || ^8.0.0-0 <8.0.0", "@babel/core@^7.11.6", "@babel/core@^7.12.0", "@babel/core@^7.12.3", "@babel/core@^7.13.0", "@babel/core@^7.21.3", "@babel/core@^7.23.9", "@babel/core@^7.25.9", "@babel/core@^7.4.0 || ^8.0.0-0 <8.0.0", "@babel/core@^7.8.0":
   version "7.28.0"
   resolved "https://registry.npmjs.org/@babel/core/-/core-7.28.0.tgz"
   integrity sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==
@@ -1766,7 +1766,7 @@
     utility-types "^3.10.0"
     webpack "^5.88.1"
 
-"@docusaurus/plugin-content-docs@3.9.2":
+"@docusaurus/plugin-content-docs@*", "@docusaurus/plugin-content-docs@3.9.2":
   version "3.9.2"
   resolved "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.9.2.tgz"
   integrity sha512-C5wZsGuKTY8jEYsqdxhhFOe1ZDjH0uIYJ9T/jebHwkyxqnr4wW0jTkB72OMqNjsoQRcb0JN3PcSeTwFlVgzCZg==
@@ -2406,7 +2406,7 @@
     "@nodelib/fs.stat" "2.0.5"
     run-parallel "^1.1.9"
 
-"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
+"@nodelib/fs.stat@^2.0.2", "@nodelib/fs.stat@2.0.5":
   version "2.0.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz"
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
@@ -2577,7 +2577,7 @@
     "@svgr/babel-plugin-transform-react-native-svg" "8.1.0"
     "@svgr/babel-plugin-transform-svg-component" "8.0.0"
 
-"@svgr/core@8.1.0":
+"@svgr/core@*", "@svgr/core@8.1.0":
   version "8.1.0"
   resolved "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz"
   integrity sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==
@@ -2754,7 +2754,7 @@
     "@types/range-parser" "*"
     "@types/send" "*"
 
-"@types/express@*", "@types/express@^4.17.21":
+"@types/express@*", "@types/express@^4.17.13", "@types/express@^4.17.21":
   version "4.17.25"
   resolved "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz"
   integrity sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==
@@ -2916,7 +2916,7 @@
     "@types/history" "^4.7.11"
     "@types/react" "*"
 
-"@types/react@*":
+"@types/react@*", "@types/react@>= 16.8.0 < 20.0.0", "@types/react@>=16":
   version "19.1.9"
   resolved "https://registry.npmjs.org/@types/react/-/react-19.1.9.tgz"
   integrity sha512-WmdoynAX8Stew/36uTSVMcLJJ1KRh6L3IZRx1PZ7qJtBqT3dYTgyDTx8H1qoRghErydW7xw9mSJ3wS//tCRpFA==
@@ -3017,7 +3017,7 @@
   resolved "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.0.3.tgz"
   integrity sha512-yNEQvPcVrK9sIe637+I0jD6leluPxzwJKx/Haw6F4H77CdDsszUn5V3o96LPziXkSNE2B83+Z3mjqGKBK/R6Gg==
 
-"@webassemblyjs/ast@1.14.1", "@webassemblyjs/ast@^1.14.1":
+"@webassemblyjs/ast@^1.14.1", "@webassemblyjs/ast@1.14.1":
   version "1.14.1"
   resolved "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz"
   integrity sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==
@@ -3118,7 +3118,7 @@
     "@webassemblyjs/wasm-gen" "1.14.1"
     "@webassemblyjs/wasm-parser" "1.14.1"
 
-"@webassemblyjs/wasm-parser@1.14.1", "@webassemblyjs/wasm-parser@^1.14.1":
+"@webassemblyjs/wasm-parser@^1.14.1", "@webassemblyjs/wasm-parser@1.14.1":
   version "1.14.1"
   resolved "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz"
   integrity sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==
@@ -3173,7 +3173,7 @@ acorn-walk@^8.0.0:
   dependencies:
     acorn "^8.11.0"
 
-acorn@^8.0.0, acorn@^8.0.4, acorn@^8.11.0, acorn@^8.14.0, acorn@^8.15.0:
+"acorn@^6.0.0 || ^7.0.0 || ^8.0.0", acorn@^8.0.0, acorn@^8.0.4, acorn@^8.11.0, acorn@^8.14.0, acorn@^8.15.0:
   version "8.15.0"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz"
   integrity sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==
@@ -3196,7 +3196,7 @@ aggregate-error@^3.0.0:
     clean-stack "^2.0.0"
     indent-string "^4.0.0"
 
-ai@5.0.93, ai@^5.0.30:
+ai@^5.0.30, ai@5.0.93:
   version "5.0.93"
   resolved "https://registry.npmjs.org/ai/-/ai-5.0.93.tgz"
   integrity sha512-9eGcu+1PJgPg4pRNV4L7tLjRR3wdJC9CXQoNMvtqvYNOLZHFCzjHtVIOr2SIkoJJeu2+sOy3hyiSuTmy2MA40g==
@@ -3225,7 +3225,7 @@ ajv-keywords@^5.1.0:
   dependencies:
     fast-deep-equal "^3.1.3"
 
-ajv@^6.12.5:
+ajv@^6.12.5, ajv@^6.9.1:
   version "6.12.6"
   resolved "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -3235,7 +3235,7 @@ ajv@^6.12.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.0.0, ajv@^8.9.0:
+ajv@^8.0.0, ajv@^8.8.2, ajv@^8.9.0:
   version "8.17.1"
   resolved "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz"
   integrity sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==
@@ -3252,7 +3252,7 @@ algoliasearch-helper@^3.26.0:
   dependencies:
     "@algolia/events" "^4.0.1"
 
-algoliasearch@^5.28.0, algoliasearch@^5.37.0:
+algoliasearch@^5.28.0, algoliasearch@^5.37.0, "algoliasearch@>= 3.1 < 6", "algoliasearch@>= 4.9.1 < 6":
   version "5.43.0"
   resolved "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.43.0.tgz"
   integrity sha512-hbkK41JsuGYhk+atBDxlcKxskjDCh3OOEDpdKZPtw+3zucBqhlojRG5e5KtCmByGyYvwZswVeaSWglgLn2fibg==
@@ -3494,7 +3494,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-bare-events@^2.5.4, bare-events@^2.7.0:
+bare-events@*, bare-events@^2.5.4, bare-events@^2.7.0:
   version "2.8.2"
   resolved "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz"
   integrity sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==
@@ -3630,7 +3630,7 @@ braces@^3.0.3, braces@~3.0.2:
   dependencies:
     fill-range "^7.1.1"
 
-browserslist@^4.0.0, browserslist@^4.23.0, browserslist@^4.24.0, browserslist@^4.24.4, browserslist@^4.25.0, browserslist@^4.25.1:
+browserslist@^4.0.0, browserslist@^4.23.0, browserslist@^4.24.0, browserslist@^4.24.4, browserslist@^4.25.0, browserslist@^4.25.1, "browserslist@>= 4.21.0":
   version "4.25.1"
   resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.25.1.tgz"
   integrity sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==
@@ -4351,19 +4351,19 @@ debounce@^1.2.1:
   resolved "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz"
   integrity sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==
 
+debug@^4.0.0, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.4, debug@^4.4.1, debug@^4.4.3, debug@4:
+  version "4.4.3"
+  resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+  dependencies:
+    ms "^2.1.3"
+
 debug@2.6.9:
   version "2.6.9"
   resolved "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
   dependencies:
     ms "2.0.0"
-
-debug@4, debug@^4.0.0, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.4, debug@^4.4.1, debug@^4.4.3:
-  version "4.4.3"
-  resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz"
-  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
-  dependencies:
-    ms "^2.1.3"
 
 decode-named-character-reference@^1.0.0:
   version "1.2.0"
@@ -4449,15 +4449,15 @@ degenerator@^5.0.0:
     escodegen "^2.1.0"
     esprima "^4.0.1"
 
-depd@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz"
-  integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
-
 depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz"
   integrity sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==
+
+depd@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz"
+  integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
 dequal@^2.0.0, dequal@^2.0.3:
   version "2.0.3"
@@ -4494,7 +4494,7 @@ devlop@^1.0.0, devlop@^1.1.0:
   dependencies:
     dequal "^2.0.0"
 
-devtools-protocol@0.0.1521046:
+devtools-protocol@*, devtools-protocol@0.0.1521046:
   version "0.0.1521046"
   resolved "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1521046.tgz"
   integrity sha512-vhE6eymDQSKWUXwwA37NtTTVEzjtGVfDr3pRbsWEQ5onH/Snp2c+2xZHWJJawG/0hCCJLRGt4xVtEVUVILol4w==
@@ -4930,7 +4930,7 @@ eventsource-parser@^3.0.6:
   resolved "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz"
   integrity sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==
 
-execa@5.1.1, execa@^5.0.0:
+execa@^5.0.0, execa@5.1.1:
   version "5.1.1"
   resolved "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz"
   integrity sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==
@@ -5101,7 +5101,7 @@ figures@^3.2.0:
   dependencies:
     escape-string-regexp "^1.0.5"
 
-file-loader@^6.2.0:
+file-loader@*, file-loader@^6.2.0:
   version "6.2.0"
   resolved "https://registry.npmjs.org/file-loader/-/file-loader-6.2.0.tgz"
   integrity sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==
@@ -5370,15 +5370,15 @@ got@^12.1.0:
     p-cancelable "^3.0.0"
     responselike "^3.0.0"
 
-graceful-fs@4.2.10:
-  version "4.2.10"
-  resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz"
-  integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
-
 graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.11, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
   version "4.2.11"
   resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
+
+graceful-fs@4.2.10:
+  version "4.2.10"
+  resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz"
+  integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
 gray-matter@^4.0.3:
   version "4.0.3"
@@ -5661,6 +5661,16 @@ http-deceiver@^1.2.7:
   resolved "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz"
   integrity sha512-LmpOGxTfbpgtGVxJrj5k7asXHCgNZp5nLfp+hWc8QQRqtb7fUy6kRY3BO1h9ddF6yIPYUARgxGOwB42DnxIaNw==
 
+http-errors@~1.6.2:
+  version "1.6.3"
+  resolved "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz"
+  integrity sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==
+  dependencies:
+    depd "~1.1.2"
+    inherits "2.0.3"
+    setprototypeof "1.1.0"
+    statuses ">= 1.4.0 < 2"
+
 http-errors@2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz"
@@ -5671,16 +5681,6 @@ http-errors@2.0.0:
     setprototypeof "1.2.0"
     statuses "2.0.1"
     toidentifier "1.0.1"
-
-http-errors@~1.6.2:
-  version "1.6.3"
-  resolved "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz"
-  integrity sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==
-  dependencies:
-    depd "~1.1.2"
-    inherits "2.0.3"
-    setprototypeof "1.1.0"
-    statuses ">= 1.4.0 < 2"
 
 http-parser-js@>=0.5.1:
   version "0.5.10"
@@ -5807,7 +5807,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.3:
+inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.3, inherits@2, inherits@2.0.4:
   version "2.0.4"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -5817,15 +5817,20 @@ inherits@2.0.3:
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
   integrity sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==
 
+ini@^1.3.4:
+  version "1.3.8"
+  resolved "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz"
+  integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
+
+ini@~1.3.0:
+  version "1.3.8"
+  resolved "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz"
+  integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
+
 ini@2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz"
   integrity sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==
-
-ini@^1.3.4, ini@~1.3.0:
-  version "1.3.8"
-  resolved "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz"
-  integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
 inline-style-parser@0.2.4:
   version "0.2.4"
@@ -5844,15 +5849,15 @@ ip-address@^10.0.1:
   resolved "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz"
   integrity sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==
 
-ipaddr.js@1.9.1:
-  version "1.9.1"
-  resolved "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz"
-  integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
-
 ipaddr.js@^2.1.0:
   version "2.2.0"
   resolved "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.2.0.tgz"
   integrity sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==
+
+ipaddr.js@1.9.1:
+  version "1.9.1"
+  resolved "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz"
+  integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
 
 is-alphabetical@^2.0.0:
   version "2.0.1"
@@ -6036,15 +6041,15 @@ is-yarn-global@^0.4.0:
   resolved "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.4.1.tgz"
   integrity sha512-/kppl+R+LO5VmhYSEWARUFjodS25D68gvj8W7z0I7OWhUla5xWu8KL6CtB2V0R6yqhnRgbcaREMr4EEM6htLPQ==
 
-isarray@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-  integrity sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==
-
 isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
   integrity sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==
+
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+  integrity sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -6313,7 +6318,7 @@ jest-resolve-dependencies@^29.7.0:
     jest-regex-util "^29.6.3"
     jest-snapshot "^29.7.0"
 
-jest-resolve@^29.7.0:
+jest-resolve@*, jest-resolve@^29.7.0:
   version "29.7.0"
   resolved "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz"
   integrity sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==
@@ -7422,12 +7427,12 @@ micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.5, micromatch@^4.0.8:
     braces "^3.0.3"
     picomatch "^2.3.1"
 
-mime-db@1.52.0:
-  version "1.52.0"
-  resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz"
-  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+mime-db@^1.54.0:
+  version "1.54.0"
+  resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz"
+  integrity sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==
 
-"mime-db@>= 1.43.0 < 2", mime-db@^1.54.0:
+"mime-db@>= 1.43.0 < 2":
   version "1.54.0"
   resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz"
   integrity sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==
@@ -7437,14 +7442,12 @@ mime-db@~1.33.0:
   resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz"
   integrity sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==
 
-mime-types@2.1.18, mime-types@~2.1.17:
-  version "2.1.18"
-  resolved "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz"
-  integrity sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==
-  dependencies:
-    mime-db "~1.33.0"
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@^2.1.27, mime-types@~2.1.24, mime-types@~2.1.34:
+mime-types@^2.1.27:
   version "2.1.35"
   resolved "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -7457,6 +7460,27 @@ mime-types@^3.0.1:
   integrity sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==
   dependencies:
     mime-db "^1.54.0"
+
+mime-types@~2.1.17, mime-types@2.1.18:
+  version "2.1.18"
+  resolved "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz"
+  integrity sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==
+  dependencies:
+    mime-db "~1.33.0"
+
+mime-types@~2.1.24:
+  version "2.1.35"
+  resolved "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
+
+mime-types@~2.1.34:
+  version "2.1.35"
+  resolved "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
 
 mime@1.6.0:
   version "1.6.0"
@@ -7491,7 +7515,7 @@ minimalistic-assert@^1.0.0:
   resolved "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz"
   integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
 
-minimatch@3.1.2, minimatch@^3.0.4, minimatch@^3.1.1:
+minimatch@^3.0.4, minimatch@^3.1.1, minimatch@3.1.2:
   version "3.1.2"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
@@ -7513,15 +7537,15 @@ mrmime@^2.0.0:
   resolved "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz"
   integrity sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==
 
+ms@^2.1.3, ms@2.1.3:
+  version "2.1.3"
+  resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
+  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
   integrity sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==
-
-ms@2.1.3, ms@^2.1.3:
-  version "2.1.3"
-  resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
-  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
 multicast-dns@^7.2.5:
   version "7.2.5"
@@ -7541,15 +7565,15 @@ natural-compare@^1.4.0:
   resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-negotiator@0.6.3:
-  version "0.6.3"
-  resolved "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz"
-  integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
-
 negotiator@~0.6.4:
   version "0.6.4"
   resolved "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz"
   integrity sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==
+
+negotiator@0.6.3:
+  version "0.6.3"
+  resolved "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz"
+  integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
 
 neo-async@^2.6.2:
   version "2.6.2"
@@ -7675,7 +7699,7 @@ obuf@^1.0.0, obuf@^1.1.2:
   resolved "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz"
   integrity sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==
 
-on-finished@2.4.1, on-finished@^2.4.1:
+on-finished@^2.4.1, on-finished@2.4.1:
   version "2.4.1"
   resolved "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz"
   integrity sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==
@@ -7939,6 +7963,13 @@ path-parse@^1.0.7:
   resolved "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
+path-to-regexp@^1.7.0:
+  version "1.9.0"
+  resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz"
+  integrity sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==
+  dependencies:
+    isarray "0.0.1"
+
 path-to-regexp@0.1.12:
   version "0.1.12"
   resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz"
@@ -7948,13 +7979,6 @@ path-to-regexp@3.3.0:
   version "3.3.0"
   resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.3.0.tgz"
   integrity sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==
-
-path-to-regexp@^1.7.0:
-  version "1.9.0"
-  resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz"
-  integrity sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==
-  dependencies:
-    isarray "0.0.1"
 
 path-type@^4.0.0:
   version "4.0.0"
@@ -8543,7 +8567,7 @@ postcss-zindex@^6.0.2:
   resolved "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-6.0.2.tgz"
   integrity sha512-5BxW9l1evPB/4ZIc+2GobEBoKC+h8gPGCMi+jxsYvd2x0mjq7wazk6DrP71pStqxE9Foxh5TVnonbWpFZzXaYg==
 
-postcss@^8.4.21, postcss@^8.4.24, postcss@^8.4.33, postcss@^8.5.4:
+"postcss@^7.0.0 || ^8.0.1", postcss@^8, postcss@^8.0.3, postcss@^8.0.9, postcss@^8.1.0, postcss@^8.2.2, postcss@^8.4, postcss@^8.4.21, postcss@^8.4.23, postcss@^8.4.24, postcss@^8.4.31, postcss@^8.4.33, postcss@^8.4.6, postcss@^8.5.4:
   version "8.5.6"
   resolved "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz"
   integrity sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==
@@ -8730,15 +8754,20 @@ randombytes@^2.1.0:
   dependencies:
     safe-buffer "^5.1.0"
 
+range-parser@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz"
+  integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
+
+range-parser@~1.2.1:
+  version "1.2.1"
+  resolved "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz"
+  integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
+
 range-parser@1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz"
   integrity sha512-kA5WQoNVo4t9lNx2kQNFCxKeBl5IbbSNBl1M/tLkw9WCn+hxNBAW5Qh8gdhs63CJnhjJ2zQWFoqPJP2sK1AV5A==
-
-range-parser@^1.2.1, range-parser@~1.2.1:
-  version "1.2.1"
-  resolved "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz"
-  integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
 
 raw-body@2.5.2:
   version "2.5.2"
@@ -8760,7 +8789,7 @@ rc@1.2.8:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-dom@^19.0.0:
+react-dom@*, "react-dom@^16.6.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom@^18.0.0 || ^19.0.0", react-dom@^19.0.0, "react-dom@>= 16.8.0 < 20.0.0":
   version "19.1.1"
   resolved "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz"
   integrity sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==
@@ -8783,7 +8812,17 @@ react-fast-compare@^3.2.0:
     react-fast-compare "^3.2.0"
     shallowequal "^1.1.0"
 
-react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0:
+react-is@^16.13.1:
+  version "16.13.1"
+  resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-is@^16.6.0:
+  version "16.13.1"
+  resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -8805,7 +8844,7 @@ react-loadable-ssr-addon-v5-slorber@^1.0.1:
   dependencies:
     "@babel/runtime" "^7.10.3"
 
-"react-loadable@npm:@docusaurus/react-loadable@6.0.0":
+react-loadable@*, "react-loadable@npm:@docusaurus/react-loadable@6.0.0":
   version "6.0.0"
   resolved "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-6.0.0.tgz"
   integrity sha512-YMMxTUQV/QFSnbgrP3tjDzLHRg7vsbMn8e9HAa8o/1iXoiomo48b7sk/kkmWEuWNDPJVlKSJRB6Y2fHqdJk+SQ==
@@ -8832,7 +8871,7 @@ react-router-dom@^5.3.4:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
-react-router@5.3.4, react-router@^5.3.4:
+react-router@^5.3.4, react-router@>=5, react-router@5.3.4:
   version "5.3.4"
   resolved "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz"
   integrity sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==
@@ -8847,7 +8886,7 @@ react-router@5.3.4, react-router@^5.3.4:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
-react@^19.0.0:
+react@*, "react@^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^16.6.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^18 || ^19 || ^19.0.0-rc", "react@^18.0.0 || ^19.0.0", react@^19.0.0, react@^19.1.1, "react@>= 16.8.0 < 20.0.0", react@>=15, react@>=16, react@>=16.0.0:
   version "19.1.1"
   resolved "https://registry.npmjs.org/react/-/react-19.1.1.tgz"
   integrity sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==
@@ -9191,12 +9230,17 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-safe-buffer@5.2.1, safe-buffer@>=5.1.0, safe-buffer@^5.1.0:
+safe-buffer@^5.1.0, safe-buffer@>=5.1.0, safe-buffer@5.2.1:
   version "5.2.1"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
-safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@~5.1.0:
+  version "5.1.2"
+  resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz"
+  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+
+safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
@@ -9240,6 +9284,11 @@ schema-utils@^4.0.0, schema-utils@^4.0.1, schema-utils@^4.2.0, schema-utils@^4.3
     ajv-formats "^2.1.1"
     ajv-keywords "^5.1.0"
 
+"search-insights@>= 1 < 3":
+  version "2.17.3"
+  resolved "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz"
+  integrity sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==
+
 section-matter@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz"
@@ -9268,7 +9317,12 @@ semver-diff@^4.0.0:
   dependencies:
     semver "^7.3.5"
 
-semver@^6.3.0, semver@^6.3.1:
+semver@^6.3.0:
+  version "6.3.1"
+  resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
+  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
+
+semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
@@ -9526,14 +9580,6 @@ source-map-js@^1.0.1, source-map-js@^1.2.1:
   resolved "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
 
-source-map-support@0.5.13:
-  version "0.5.13"
-  resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz"
-  integrity sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==
-  dependencies:
-    buffer-from "^1.0.0"
-    source-map "^0.6.0"
-
 source-map-support@~0.5.20:
   version "0.5.21"
   resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz"
@@ -9542,7 +9588,20 @@ source-map-support@~0.5.20:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
-source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
+source-map-support@0.5.13:
+  version "0.5.13"
+  resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz"
+  integrity sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
+source-map@^0.6.0:
+  version "0.6.1"
+  resolved "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+source-map@^0.6.1:
   version "0.6.1"
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
@@ -9551,6 +9610,16 @@ source-map@^0.7.0:
   version "0.7.6"
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz"
   integrity sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==
+
+source-map@~0.6.0:
+  version "0.6.1"
+  resolved "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+source-map@~0.6.1:
+  version "0.6.1"
+  resolved "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
 space-separated-tokens@^2.0.0:
   version "2.0.2"
@@ -9597,15 +9666,15 @@ stack-utils@^2.0.3:
   dependencies:
     escape-string-regexp "^2.0.0"
 
-statuses@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz"
-  integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
-
 "statuses@>= 1.4.0 < 2":
   version "1.5.0"
   resolved "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz"
   integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
+
+statuses@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz"
+  integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
 
 std-env@^3.7.0:
   version "3.9.0"
@@ -9621,6 +9690,13 @@ streamx@^2.15.0, streamx@^2.21.0:
     fast-fifo "^1.3.2"
     text-decoder "^1.1.0"
 
+string_decoder@^1.1.1, string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz"
+  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
+  dependencies:
+    safe-buffer "~5.1.0"
+
 string-length@^4.0.1:
   version "4.0.2"
   resolved "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz"
@@ -9629,7 +9705,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+string-width@^4.1.0, string-width@^4.2.0:
+  version "4.2.3"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -9646,13 +9731,6 @@ string-width@^5.0.1, string-width@^5.1.2:
     eastasianwidth "^0.2.0"
     emoji-regex "^9.2.2"
     strip-ansi "^7.0.1"
-
-string_decoder@^1.1.1, string_decoder@~1.1.1:
-  version "1.1.1"
-  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz"
-  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
-  dependencies:
-    safe-buffer "~5.1.0"
 
 stringify-entities@^4.0.0:
   version "4.0.4"
@@ -9911,7 +9989,7 @@ trough@^2.0.0:
   resolved "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz"
   integrity sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==
 
-tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.6.0:
+tslib@^2, tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.6.0, tslib@2:
   version "2.8.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
@@ -9956,7 +10034,7 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@~5.6.2:
+typescript@>=4.9.5, typescript@~5.6.2:
   version "5.6.3"
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz"
   integrity sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==
@@ -10064,7 +10142,7 @@ universalify@^2.0.0:
   resolved "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz"
   integrity sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==
 
-unpipe@1.0.0, unpipe@~1.0.0:
+unpipe@~1.0.0, unpipe@1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
   integrity sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==
@@ -10310,7 +10388,7 @@ webpack-sources@^3.3.3:
   resolved "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.3.tgz"
   integrity sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==
 
-webpack@^5.88.1, webpack@^5.95.0:
+"webpack@^4.0.0 || ^5.0.0", webpack@^5.0.0, webpack@^5.1.0, webpack@^5.20.0, webpack@^5.88.1, webpack@^5.95.0, "webpack@>=4.41.1 || 5.x", webpack@>=5, "webpack@3 || 4 || 5":
   version "5.101.0"
   resolved "https://registry.npmjs.org/webpack/-/webpack-5.101.0.tgz"
   integrity sha512-B4t+nJqytPeuZlHuIKTbalhljIFXeNRqrUGAQgTGlfOl2lXXKXw+yZu6bicycP+PUlM44CxBjCFD6aciKFT3LQ==
@@ -10355,7 +10433,7 @@ webpackbar@^6.0.1:
     std-env "^3.7.0"
     wrap-ansi "^7.0.0"
 
-websocket-driver@>=0.5.1, websocket-driver@^0.7.4:
+websocket-driver@^0.7.4, websocket-driver@>=0.5.1:
   version "0.7.4"
   resolved "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz"
   integrity sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==
@@ -10517,7 +10595,7 @@ zod@^3.24.1:
   resolved "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz"
   integrity sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==
 
-zod@^4.1.8:
+"zod@^3.25.76 || ^4.1.8", zod@^4.1.8:
   version "4.1.12"
   resolved "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz"
   integrity sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==

--- a/examples/test_vision_real.py
+++ b/examples/test_vision_real.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python3
+"""
+Test Vision APIs with Real Images
+
+Usage:
+    # Test detection on a single image
+    python test_vision_real.py detect path/to/image.jpg
+    
+    # Test classification
+    python test_vision_real.py classify path/to/image.jpg "cat,dog,bird,car,person"
+    
+    # Test OCR
+    python test_vision_real.py ocr path/to/document.png
+    
+    # Test streaming cascade (interactive)
+    python test_vision_real.py stream
+    
+    # Test with a URL
+    python test_vision_real.py detect https://example.com/image.jpg
+"""
+
+import argparse
+import base64
+import json
+import sys
+from pathlib import Path
+from urllib.request import urlopen, Request
+
+import requests
+
+BASE_URL = "http://localhost:14345"
+RUNTIME_URL = "http://localhost:11540"
+
+
+def image_to_base64(image_path: str) -> str:
+    """Convert image file or URL to base64 data URI."""
+    if image_path.startswith("http://") or image_path.startswith("https://"):
+        # Download from URL with User-Agent
+        print(f"📥 Downloading from {image_path}...")
+        req = Request(image_path, headers={"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)"})
+        response = urlopen(req)
+        image_bytes = response.read()
+        content_type = response.headers.get("Content-Type", "image/jpeg")
+    else:
+        # Read from file
+        path = Path(image_path)
+        if not path.exists():
+            raise FileNotFoundError(f"Image not found: {image_path}")
+        
+        image_bytes = path.read_bytes()
+        
+        # Detect content type from extension
+        ext = path.suffix.lower()
+        content_types = {
+            ".jpg": "image/jpeg",
+            ".jpeg": "image/jpeg",
+            ".png": "image/png",
+            ".gif": "image/gif",
+            ".webp": "image/webp",
+        }
+        content_type = content_types.get(ext, "image/jpeg")
+    
+    b64 = base64.b64encode(image_bytes).decode()
+    return f"data:{content_type};base64,{b64}"
+
+
+def test_detection(image_path: str, model: str = "yolov8n", confidence: float = 0.5):
+    """Test object detection on an image."""
+    print(f"\n🎯 Testing Detection")
+    print(f"   Image: {image_path}")
+    print(f"   Model: {model}")
+    print(f"   Confidence threshold: {confidence}")
+    print("-" * 50)
+    
+    image_b64 = image_to_base64(image_path)
+    
+    # Use multipart form
+    response = requests.post(
+        f"{BASE_URL}/v1/vision/detect",
+        data={
+            "image": image_b64,
+            "model": model,
+            "confidence_threshold": confidence,
+        },
+    )
+    
+    if response.status_code != 200:
+        print(f"❌ Error: {response.status_code}")
+        print(response.text)
+        return
+    
+    result = response.json()
+    
+    print(f"\n✅ Detection complete ({result.get('inference_time_ms', 0):.1f}ms)")
+    print(f"   Model: {result.get('model', 'unknown')}")
+    
+    detections = result.get("detections", [])
+    if not detections:
+        print("\n   No objects detected")
+    else:
+        print(f"\n   Found {len(detections)} object(s):")
+        for i, det in enumerate(detections, 1):
+            box = det.get("box", {})
+            print(f"   {i}. {det['class_name']:15s} {det['confidence']*100:5.1f}%  "
+                  f"[{box.get('x1',0):.0f},{box.get('y1',0):.0f} → {box.get('x2',0):.0f},{box.get('y2',0):.0f}]")
+
+
+def test_classification(image_path: str, classes: str, model: str = "clip-vit-base"):
+    """Test zero-shot image classification."""
+    print(f"\n🏷️  Testing Classification")
+    print(f"   Image: {image_path}")
+    print(f"   Classes: {classes}")
+    print(f"   Model: {model}")
+    print("-" * 50)
+    
+    image_b64 = image_to_base64(image_path)
+    
+    response = requests.post(
+        f"{BASE_URL}/v1/vision/classify",
+        data={
+            "image": image_b64,
+            "model": model,
+            "classes": classes,
+            "top_k": 5,
+        },
+    )
+    
+    if response.status_code != 200:
+        print(f"❌ Error: {response.status_code}")
+        print(response.text)
+        return
+    
+    result = response.json()
+    
+    print(f"\n✅ Classification complete ({result.get('inference_time_ms', 0):.1f}ms)")
+    print(f"   Top prediction: {result.get('class_name')} ({result.get('confidence', 0)*100:.1f}%)")
+    
+    all_scores = result.get("all_scores", {})
+    if all_scores:
+        print("\n   All scores:")
+        for cls, score in sorted(all_scores.items(), key=lambda x: -x[1]):
+            bar = "█" * int(score * 30)
+            print(f"   {cls:15s} {score*100:5.1f}% {bar}")
+
+
+def test_ocr(image_path: str, model: str = "surya"):
+    """Test OCR text extraction."""
+    print(f"\n📄 Testing OCR")
+    print(f"   Image: {image_path}")
+    print(f"   Model: {model}")
+    print("-" * 50)
+    
+    image_b64 = image_to_base64(image_path)
+    
+    response = requests.post(
+        f"{BASE_URL}/v1/vision/ocr",
+        data={
+            "images": json.dumps([image_b64]),
+            "model": model,
+            "languages": "en",
+        },
+    )
+    
+    if response.status_code != 200:
+        print(f"❌ Error: {response.status_code}")
+        print(response.text)
+        return
+    
+    result = response.json()
+    
+    print(f"\n✅ OCR complete")
+    print(f"   Model: {result.get('model', 'unknown')}")
+    
+    for item in result.get("data", []):
+        print(f"\n   Page {item.get('index', 0)} (confidence: {item.get('confidence', 0)*100:.1f}%):")
+        print("   " + "-" * 40)
+        text = item.get("text", "")
+        # Indent text
+        for line in text.split("\n")[:20]:  # First 20 lines
+            print(f"   {line}")
+        if text.count("\n") > 20:
+            print(f"   ... ({text.count(chr(10)) - 20} more lines)")
+
+
+def test_streaming(primary_model: str = "yolov8n", secondary_model: str = "yolov8m"):
+    """Interactive streaming cascade test."""
+    print(f"\n🎬 Streaming Cascade Test")
+    print(f"   Primary model: {primary_model}")
+    print(f"   Secondary model: {secondary_model}")
+    print("-" * 50)
+    
+    # Start session
+    response = requests.post(
+        f"{RUNTIME_URL}/v1/vision/stream/start",
+        json={
+            "model": primary_model,
+            "config": {
+                "confidence_threshold": 0.7,
+                "escalation_threshold": 0.5,
+                "cooldown_seconds": 1.0,
+                "cascade": {
+                    "secondary_model_id": secondary_model,
+                    "feedback_to_primary": True,
+                    "save_uncertain_images": True,
+                },
+            },
+        },
+    )
+    
+    if response.status_code != 200:
+        print(f"❌ Failed to start session: {response.status_code}")
+        print(response.text)
+        return
+    
+    session = response.json()
+    session_id = session["session_id"]
+    print(f"\n✅ Session started: {session_id}")
+    
+    print("\n📸 Enter image paths to process (or 'quit' to stop):")
+    print("   Tip: You can also paste URLs")
+    
+    try:
+        while True:
+            image_path = input("\n> ").strip()
+            
+            if image_path.lower() in ("quit", "exit", "q"):
+                break
+            
+            if not image_path:
+                continue
+            
+            try:
+                image_b64 = image_to_base64(image_path)
+            except Exception as e:
+                print(f"❌ Error loading image: {e}")
+                continue
+            
+            # Process frame
+            response = requests.post(
+                f"{RUNTIME_URL}/v1/vision/stream/frame",
+                json={
+                    "session_id": session_id,
+                    "image": image_b64,
+                },
+            )
+            
+            if response.status_code != 200:
+                print(f"❌ Error: {response.status_code}")
+                continue
+            
+            result = response.json()
+            
+            status_emoji = {
+                "ok": "⚪",
+                "action": "🟢",
+                "review": "🟡",
+            }.get(result["status"], "❓")
+            
+            print(f"\n{status_emoji} Status: {result['status'].upper()}")
+            
+            if result.get("escalated_to"):
+                print(f"   ⬆️  Escalated to: {result['escalated_to']}")
+            
+            if result.get("added_to_replay"):
+                print(f"   📚 Added to replay buffer!")
+            
+            if result.get("detections"):
+                print(f"   Detections:")
+                for det in result["detections"]:
+                    print(f"      • {det['class_name']}: {det['confidence']*100:.1f}%")
+            
+            if result.get("image_id"):
+                print(f"   📋 Queued for review: {result['image_id']}")
+    
+    except KeyboardInterrupt:
+        print("\n\n⏹️  Interrupted")
+    
+    # Stop session
+    response = requests.post(
+        f"{RUNTIME_URL}/v1/vision/stream/stop",
+        json={"session_id": session_id},
+    )
+    
+    if response.status_code == 200:
+        stats = response.json()
+        print(f"\n📊 Session Statistics:")
+        print(f"   Frames processed: {stats.get('frames_processed', 0)}")
+        print(f"   Actions triggered: {stats.get('actions_triggered', 0)}")
+        print(f"   Duration: {stats.get('duration_seconds', 0):.1f}s")
+    
+    # Get replay buffer stats
+    response = requests.get(f"{RUNTIME_URL}/v1/vision/replay-buffer")
+    if response.status_code == 200:
+        buffer = response.json()
+        print(f"\n📚 Replay Buffer:")
+        print(f"   Size: {buffer['stats']['size']}")
+        print(f"   Training eligible: {buffer['training_eligible']}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Test Vision APIs with real images")
+    subparsers = parser.add_subparsers(dest="command", help="Command to run")
+    
+    # Detection
+    detect_parser = subparsers.add_parser("detect", help="Test object detection")
+    detect_parser.add_argument("image", help="Image path or URL")
+    detect_parser.add_argument("--model", default="yolov8n", help="Model to use")
+    detect_parser.add_argument("--confidence", type=float, default=0.5, help="Confidence threshold")
+    
+    # Classification
+    classify_parser = subparsers.add_parser("classify", help="Test image classification")
+    classify_parser.add_argument("image", help="Image path or URL")
+    classify_parser.add_argument("classes", help="Comma-separated class names")
+    classify_parser.add_argument("--model", default="clip-vit-base", help="Model to use")
+    
+    # OCR
+    ocr_parser = subparsers.add_parser("ocr", help="Test OCR text extraction")
+    ocr_parser.add_argument("image", help="Image path or URL")
+    ocr_parser.add_argument("--model", default="surya", help="OCR backend")
+    
+    # Streaming
+    stream_parser = subparsers.add_parser("stream", help="Interactive streaming cascade test")
+    stream_parser.add_argument("--primary", default="yolov8n", help="Primary model")
+    stream_parser.add_argument("--secondary", default="yolov8m", help="Secondary model")
+    
+    args = parser.parse_args()
+    
+    if args.command == "detect":
+        test_detection(args.image, args.model, args.confidence)
+    elif args.command == "classify":
+        test_classification(args.image, args.classes, args.model)
+    elif args.command == "ocr":
+        test_ocr(args.image, args.model)
+    elif args.command == "stream":
+        test_streaming(args.primary, args.secondary)
+    else:
+        parser.print_help()
+        print("\n" + "=" * 50)
+        print("Quick Examples:")
+        print("=" * 50)
+        print("""
+# Detection (finds objects)
+python test_vision_real.py detect ~/Desktop/photo.jpg
+python test_vision_real.py detect https://upload.wikimedia.org/wikipedia/commons/thumb/4/4d/Cat_November_2010-1a.jpg/1200px-Cat_November_2010-1a.jpg
+
+# Classification (what is this?)
+python test_vision_real.py classify ~/Desktop/photo.jpg "cat,dog,bird,person,car"
+
+# OCR (extract text)
+python test_vision_real.py ocr ~/Desktop/document.png
+
+# Streaming cascade (interactive)
+python test_vision_real.py stream
+""")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/vision/01_detect_and_classify.py
+++ b/examples/vision/01_detect_and_classify.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""
+Step 1: Detection, Classification, and Segmentation
+
+Demonstrates the core vision endpoints:
+- Object detection with bounding boxes
+- Image classification with CLIP embeddings
+- Segmentation masks
+- OCR text extraction
+
+Prerequisites:
+    - Universal Runtime running: nx start universal-runtime
+
+Run:
+    cd runtimes/universal
+    uv run python ../../examples/vision/01_detect_and_classify.py
+"""
+
+import asyncio
+import base64
+import json
+import os
+from io import BytesIO
+from pathlib import Path
+
+import httpx
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+def get_runtime_url():
+    """Get Universal Runtime URL from environment or default."""
+    if url := os.environ.get("RUNTIME_URL"):
+        return url.rstrip("/")
+    env_file = Path(__file__).parent / ".env"
+    if env_file.exists():
+        with open(env_file) as f:
+            for line in f:
+                line = line.strip()
+                if line.startswith("RUNTIME_URL="):
+                    return line.split("=", 1)[1].strip().strip('"\'').rstrip("/")
+    return "http://localhost:14345"
+
+
+RUNTIME_URL = get_runtime_url()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def generate_test_image(width: int = 640, height: int = 480) -> bytes:
+    """Generate a simple test image (gradient with shapes)."""
+    try:
+        from PIL import Image, ImageDraw, ImageFont
+    except ImportError:
+        print("Pillow not installed -- generating a minimal JPEG header")
+        # Minimal valid JPEG
+        return b"\xff\xd8\xff\xe0" + b"\x00" * 100 + b"\xff\xd9"
+
+    img = Image.new("RGB", (width, height), (135, 206, 235))  # Sky blue
+    draw = ImageDraw.Draw(img)
+
+    # Ground
+    draw.rectangle([(0, height // 2), (width, height)], fill=(34, 139, 34))
+
+    # "Person" - rectangle + circle
+    px, py = width // 4, height // 3
+    draw.ellipse([(px - 15, py - 40), (px + 15, py)], fill=(255, 220, 185))
+    draw.rectangle([(px - 20, py), (px + 20, py + 60)], fill=(0, 0, 200))
+    draw.rectangle([(px - 5, py + 60), (px + 5, py + 90)], fill=(0, 0, 180))
+
+    # "Car" - rectangles
+    cx, cy = 3 * width // 4, height // 2 + 20
+    draw.rectangle([(cx - 50, cy - 20), (cx + 50, cy + 20)], fill=(200, 0, 0))
+    draw.rectangle([(cx - 35, cy - 40), (cx + 35, cy - 20)], fill=(180, 0, 0))
+    draw.ellipse([(cx - 40, cy + 10), (cx - 20, cy + 30)], fill=(30, 30, 30))
+    draw.ellipse([(cx + 20, cy + 10), (cx + 40, cy + 30)], fill=(30, 30, 30))
+
+    # Text label (for OCR)
+    try:
+        draw.text((10, 10), "LLAMAFARM VISION TEST", fill=(255, 255, 255))
+    except Exception:
+        pass
+
+    buf = BytesIO()
+    img.save(buf, format="JPEG", quality=85)
+    return buf.getvalue()
+
+
+def b64(image_bytes: bytes) -> str:
+    return base64.b64encode(image_bytes).decode()
+
+
+def print_header(title: str):
+    print()
+    print("=" * 60)
+    print(f"  {title}")
+    print("=" * 60)
+    print()
+
+
+def print_detections(detections: list[dict]):
+    if not detections:
+        print("  (no detections)")
+        return
+    for det in detections:
+        box = det.get("box") or det
+        conf = det.get("confidence", 0)
+        cls = det.get("class_name", det.get("class", "?"))
+        coords = ""
+        if "x1" in box:
+            coords = f"  [{box['x1']:.0f},{box['y1']:.0f} -> {box['x2']:.0f},{box['y2']:.0f}]"
+        print(f"  {cls:12s}  conf={conf:.3f}{coords}")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+async def main():
+    print_header("LlamaFarm Vision - Detection & Classification Demo")
+
+    image_bytes = generate_test_image()
+    image_b64 = b64(image_bytes)
+    print(f"Generated test image: {len(image_bytes):,} bytes ({len(image_b64):,} base64 chars)")
+
+    async with httpx.AsyncClient(base_url=RUNTIME_URL, timeout=60.0) as client:
+
+        # ------------------------------------------------------------------
+        # 1. Health check
+        # ------------------------------------------------------------------
+        print("\n--- Health Check ---")
+        try:
+            resp = await client.get("/health")
+            health = resp.json()
+            print(f"  Status: {health.get('status', 'unknown')}")
+        except Exception as e:
+            print(f"  Cannot reach runtime at {RUNTIME_URL}: {e}")
+            print("  Start the runtime: nx start universal-runtime")
+            return
+
+        # ------------------------------------------------------------------
+        # 2. Object Detection
+        # ------------------------------------------------------------------
+        print_header("1. Object Detection")
+        print("POST /v1/vision/detect")
+        print()
+
+        resp = await client.post("/v1/vision/detect", json={
+            "image": image_b64,
+            "model": "yolov8n",
+            "confidence_threshold": 0.25,
+        })
+
+        if resp.status_code == 200:
+            data = resp.json()
+            detections = data.get("detections", data.get("boxes", []))
+            print(f"  Model: {data.get('model', 'yolov8n')}")
+            print(f"  Inference: {data.get('inference_time_ms', 0):.1f}ms")
+            print(f"  Detections: {len(detections)}")
+            print_detections(detections)
+        else:
+            print(f"  Response {resp.status_code}: {resp.text[:200]}")
+
+        # ------------------------------------------------------------------
+        # 3. Classification
+        # ------------------------------------------------------------------
+        print_header("2. Image Classification")
+        print("POST /v1/vision/classify")
+        print()
+
+        resp = await client.post("/v1/vision/classify", json={
+            "image": image_b64,
+            "labels": ["outdoor scene", "indoor", "vehicle", "person", "animal"],
+        })
+
+        if resp.status_code == 200:
+            data = resp.json()
+            print("  Classification results:")
+            for item in sorted(
+                data.get("scores", data.get("results", [])),
+                key=lambda x: x.get("score", x.get("confidence", 0)),
+                reverse=True,
+            ):
+                label = item.get("label", item.get("class", "?"))
+                score = item.get("score", item.get("confidence", 0))
+                bar = "#" * int(score * 30)
+                print(f"    {label:20s} {score:.3f} {bar}")
+        else:
+            print(f"  Response {resp.status_code}: {resp.text[:200]}")
+
+        # ------------------------------------------------------------------
+        # 4. Segmentation
+        # ------------------------------------------------------------------
+        print_header("3. Segmentation")
+        print("POST /v1/vision/segment")
+        print()
+
+        resp = await client.post("/v1/vision/segment", json={
+            "image": image_b64,
+            "model": "yolov8n-seg",
+            "confidence_threshold": 0.25,
+        })
+
+        if resp.status_code == 200:
+            data = resp.json()
+            segments = data.get("segments", data.get("detections", []))
+            print(f"  Segments found: {len(segments)}")
+            for seg in segments[:5]:
+                cls = seg.get("class_name", "?")
+                conf = seg.get("confidence", 0)
+                has_mask = bool(seg.get("mask") or seg.get("mask_polygon"))
+                print(f"    {cls:12s} conf={conf:.3f}  mask={'yes' if has_mask else 'no'}")
+        else:
+            print(f"  Response {resp.status_code}: {resp.text[:200]}")
+
+        # ------------------------------------------------------------------
+        # 5. OCR
+        # ------------------------------------------------------------------
+        print_header("4. OCR (Text Extraction)")
+        print("POST /v1/vision/ocr")
+        print()
+
+        resp = await client.post("/v1/vision/ocr", json={
+            "image": image_b64,
+        })
+
+        if resp.status_code == 200:
+            data = resp.json()
+            text = data.get("text", "")
+            print(f"  Extracted text: \"{text[:100]}\"")
+            blocks = data.get("blocks", [])
+            if blocks:
+                print(f"  Text blocks: {len(blocks)}")
+        else:
+            print(f"  Response {resp.status_code}: {resp.text[:200]}")
+
+    # Done
+    print_header("Done!")
+    print("All core vision endpoints demonstrated.")
+    print("Run 02_streaming_cascade.py next for the streaming pipeline.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/vision/02_streaming_cascade.py
+++ b/examples/vision/02_streaming_cascade.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""
+Step 2: Streaming Sessions with Cascade Pipeline
+
+Demonstrates the real-time vision pipeline:
+- Start a streaming session with cascade chain
+- Process frames with automatic escalation
+- Review the replay buffer
+- Submit human corrections
+- Check auto-training status
+
+Prerequisites:
+    - Universal Runtime running: nx start universal-runtime
+    - Run 01_detect_and_classify.py first (to warm up models)
+
+Run:
+    cd runtimes/universal
+    uv run python ../../examples/vision/02_streaming_cascade.py
+"""
+
+import asyncio
+import base64
+import os
+import time
+from io import BytesIO
+from pathlib import Path
+
+import httpx
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+def get_runtime_url():
+    if url := os.environ.get("RUNTIME_URL"):
+        return url.rstrip("/")
+    env_file = Path(__file__).parent / ".env"
+    if env_file.exists():
+        with open(env_file) as f:
+            for line in f:
+                line = line.strip()
+                if line.startswith("RUNTIME_URL="):
+                    return line.split("=", 1)[1].strip().strip('"\'').rstrip("/")
+    return "http://localhost:14345"
+
+
+RUNTIME_URL = get_runtime_url()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def generate_frame(index: int, width: int = 320, height: int = 240) -> bytes:
+    """Generate a unique test frame."""
+    try:
+        from PIL import Image, ImageDraw
+    except ImportError:
+        return b"\xff\xd8\xff\xe0" + bytes([index % 256]) * 50 + b"\xff\xd9"
+
+    img = Image.new("RGB", (width, height), (
+        100 + (index * 7) % 100,
+        150 + (index * 13) % 80,
+        200 - (index * 3) % 100,
+    ))
+    draw = ImageDraw.Draw(img)
+
+    # Moving object
+    x = 20 + (index * 30) % (width - 80)
+    y = 40 + (index * 15) % (height - 80)
+    draw.rectangle([(x, y), (x + 60, y + 60)], fill=(255, 0, 0))
+    draw.ellipse([(x + 10, y - 20), (x + 50, y)], fill=(255, 220, 185))
+
+    buf = BytesIO()
+    img.save(buf, format="JPEG", quality=70)
+    return buf.getvalue()
+
+
+def b64(data: bytes) -> str:
+    return base64.b64encode(data).decode()
+
+
+def print_header(title: str):
+    print()
+    print("=" * 60)
+    print(f"  {title}")
+    print("=" * 60)
+    print()
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+async def main():
+    print_header("LlamaFarm Vision - Streaming Cascade Demo")
+
+    async with httpx.AsyncClient(base_url=RUNTIME_URL, timeout=60.0) as client:
+
+        # Health check
+        try:
+            resp = await client.get("/health")
+            resp.raise_for_status()
+        except Exception as e:
+            print(f"Cannot reach runtime at {RUNTIME_URL}: {e}")
+            print("Start the runtime: nx start universal-runtime")
+            return
+
+        # ------------------------------------------------------------------
+        # 1. Start streaming session with cascade
+        # ------------------------------------------------------------------
+        print_header("1. Start Streaming Session")
+        print("POST /v1/vision/stream/start")
+        print()
+
+        start_resp = await client.post("/v1/vision/stream/start", json={
+            "model": "yolov8n",
+            "source_id": "demo-camera-1",
+            "cascade": {
+                "enabled": True,
+                "cascade_chain": ["yolov8n", "yolov8m"],
+                "confidence_threshold": 0.7,
+                "enrich_on_escalation": True,
+            },
+        })
+
+        if start_resp.status_code != 200:
+            print(f"  Failed to start session: {start_resp.text[:200]}")
+            return
+
+        session = start_resp.json()
+        session_id = session.get("session_id", "unknown")
+        print(f"  Session ID: {session_id}")
+        print(f"  Model: {session.get('model', 'yolov8n')}")
+        print(f"  Cascade: {session.get('cascade', {})}")
+
+        # ------------------------------------------------------------------
+        # 2. Process frames
+        # ------------------------------------------------------------------
+        print_header("2. Process Frames (10 frames)")
+        print("POST /v1/vision/stream/frame")
+        print()
+
+        results = {"action": 0, "ok": 0, "review": 0, "escalated": 0}
+        total_time = 0
+
+        for i in range(10):
+            frame = generate_frame(i)
+            t0 = time.perf_counter()
+
+            resp = await client.post("/v1/vision/stream/frame", json={
+                "session_id": session_id,
+                "image": b64(frame),
+            })
+
+            elapsed = (time.perf_counter() - t0) * 1000
+            total_time += elapsed
+
+            if resp.status_code == 200:
+                data = resp.json()
+                status = data.get("status", "ok")
+                conf = data.get("confidence", 0)
+                results[status] = results.get(status, 0) + 1
+
+                icon = {"action": "!!", "review": "??", "escalated": "^^"}.get(status, "  ")
+                print(f"  Frame {i:2d}: [{icon}] {status:10s} conf={conf:.3f}  {elapsed:.0f}ms")
+            else:
+                print(f"  Frame {i:2d}: ERROR {resp.status_code}")
+
+        avg = total_time / 10
+        print()
+        print(f"  Average frame time: {avg:.1f}ms")
+        print(f"  Results: {results}")
+
+        # ------------------------------------------------------------------
+        # 3. Check session stats
+        # ------------------------------------------------------------------
+        print_header("3. Session Statistics")
+        print(f"GET /v1/vision/stream/sessions/{session_id}/stats")
+        print()
+
+        resp = await client.get(f"/v1/vision/stream/sessions/{session_id}/stats")
+        if resp.status_code == 200:
+            stats = resp.json()
+            for k, v in stats.items():
+                if not k.startswith("_"):
+                    print(f"  {k}: {v}")
+        else:
+            print(f"  {resp.status_code}: {resp.text[:200]}")
+
+        # ------------------------------------------------------------------
+        # 4. Check replay buffer
+        # ------------------------------------------------------------------
+        print_header("4. Replay Buffer Status")
+        print("GET /v1/vision/replay-buffer")
+        print()
+
+        resp = await client.get("/v1/vision/replay-buffer")
+        if resp.status_code == 200:
+            buf = resp.json()
+            print(f"  Size: {buf.get('size', 0)}")
+            print(f"  By source: {buf.get('by_source', {})}")
+            print(f"  Avg priority: {buf.get('avg_priority', 0):.2f}")
+        else:
+            print(f"  {resp.status_code}: {resp.text[:200]}")
+
+        # ------------------------------------------------------------------
+        # 5. Submit a correction
+        # ------------------------------------------------------------------
+        print_header("5. Submit Human Correction")
+        print("POST /v1/vision/corrections")
+        print()
+
+        resp = await client.post("/v1/vision/corrections", json={
+            "image_id": "demo_correction_001",
+            "corrected_class": "truck",
+            "box": [100.0, 150.0, 300.0, 350.0],
+        })
+        if resp.status_code == 200:
+            print(f"  Correction submitted: {resp.json()}")
+        else:
+            print(f"  {resp.status_code}: {resp.text[:200]}")
+
+        # ------------------------------------------------------------------
+        # 6. List active sessions
+        # ------------------------------------------------------------------
+        print_header("6. Active Sessions")
+        print("GET /v1/vision/stream/sessions")
+        print()
+
+        resp = await client.get("/v1/vision/stream/sessions")
+        if resp.status_code == 200:
+            sessions = resp.json()
+            if isinstance(sessions, list):
+                print(f"  Active sessions: {len(sessions)}")
+                for s in sessions:
+                    print(f"    - {s.get('session_id', '?')} ({s.get('model', '?')})")
+            else:
+                print(f"  {sessions}")
+        else:
+            print(f"  {resp.status_code}: {resp.text[:200]}")
+
+        # ------------------------------------------------------------------
+        # 7. Stop session
+        # ------------------------------------------------------------------
+        print_header("7. Stop Session")
+        print("POST /v1/vision/stream/stop")
+        print()
+
+        resp = await client.post("/v1/vision/stream/stop", json={
+            "session_id": session_id,
+        })
+        if resp.status_code == 200:
+            final = resp.json()
+            print(f"  Session stopped. Final stats:")
+            for k, v in final.items():
+                if not k.startswith("_"):
+                    print(f"    {k}: {v}")
+        else:
+            print(f"  {resp.status_code}: {resp.text[:200]}")
+
+        # ------------------------------------------------------------------
+        # 8. Auto-training status
+        # ------------------------------------------------------------------
+        print_header("8. Auto-Training Status")
+        print("GET /v1/vision/auto-train/status")
+        print()
+
+        resp = await client.get("/v1/vision/auto-train/status")
+        if resp.status_code == 200:
+            status = resp.json()
+            for k, v in status.items():
+                print(f"  {k}: {v}")
+        else:
+            print(f"  {resp.status_code}: {resp.text[:200]}")
+
+    print_header("Done!")
+    print("Streaming cascade demo complete.")
+    print("Run 03_federation_and_models.py for federation and model management.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/vision/03_federation_and_models.py
+++ b/examples/vision/03_federation_and_models.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""
+Step 3: Federation, Model Management, and Training
+
+Demonstrates the distributed learning pipeline:
+- Model management (list, save, load)
+- Federation peer management
+- Training jobs
+- Model packaging for distribution
+- Review queue
+
+Prerequisites:
+    - Universal Runtime running: nx start universal-runtime
+
+Run:
+    cd runtimes/universal
+    uv run python ../../examples/vision/03_federation_and_models.py
+"""
+
+import asyncio
+import os
+from pathlib import Path
+
+import httpx
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+def get_runtime_url():
+    if url := os.environ.get("RUNTIME_URL"):
+        return url.rstrip("/")
+    env_file = Path(__file__).parent / ".env"
+    if env_file.exists():
+        with open(env_file) as f:
+            for line in f:
+                line = line.strip()
+                if line.startswith("RUNTIME_URL="):
+                    return line.split("=", 1)[1].strip().strip('"\'').rstrip("/")
+    return "http://localhost:14345"
+
+
+RUNTIME_URL = get_runtime_url()
+
+
+def print_header(title: str):
+    print()
+    print("=" * 60)
+    print(f"  {title}")
+    print("=" * 60)
+    print()
+
+
+def print_json(data, indent: int = 4):
+    """Pretty-print JSON-like data."""
+    if isinstance(data, dict):
+        for k, v in data.items():
+            if isinstance(v, (dict, list)):
+                print(f"{'':>{indent}}{k}:")
+                print_json(v, indent + 4)
+            else:
+                print(f"{'':>{indent}}{k}: {v}")
+    elif isinstance(data, list):
+        if not data:
+            print(f"{'':>{indent}}(empty)")
+        for item in data[:10]:
+            if isinstance(item, dict):
+                summary = ", ".join(f"{k}={v}" for k, v in list(item.items())[:4])
+                print(f"{'':>{indent}}- {summary}")
+            else:
+                print(f"{'':>{indent}}- {item}")
+        if len(data) > 10:
+            print(f"{'':>{indent}}... and {len(data) - 10} more")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+async def main():
+    print_header("LlamaFarm Vision - Federation & Model Management Demo")
+
+    async with httpx.AsyncClient(base_url=RUNTIME_URL, timeout=60.0) as client:
+
+        # Health check
+        try:
+            resp = await client.get("/health")
+            resp.raise_for_status()
+        except Exception as e:
+            print(f"Cannot reach runtime at {RUNTIME_URL}: {e}")
+            print("Start the runtime: nx start universal-runtime")
+            return
+
+        # ------------------------------------------------------------------
+        # 1. List vision models
+        # ------------------------------------------------------------------
+        print_header("1. Available Vision Models")
+        print("GET /v1/vision/models")
+        print()
+
+        resp = await client.get("/v1/vision/models")
+        if resp.status_code == 200:
+            models = resp.json()
+            if isinstance(models, list):
+                print(f"  Found {len(models)} models:")
+                for m in models:
+                    name = m.get("name", m.get("model_id", "?"))
+                    task = m.get("task", "?")
+                    print(f"    - {name} ({task})")
+            elif isinstance(models, dict):
+                print_json(models)
+        else:
+            print(f"  {resp.status_code}: {resp.text[:200]}")
+
+        # ------------------------------------------------------------------
+        # 2. Save current model
+        # ------------------------------------------------------------------
+        print_header("2. Save Model")
+        print("POST /v1/vision/models/save")
+        print()
+
+        resp = await client.post("/v1/vision/models/save", json={
+            "model": "yolov8n",
+            "task": "detection",
+            "name": "demo-checkpoint-v1",
+        })
+        if resp.status_code == 200:
+            result = resp.json()
+            print("  Model saved:")
+            print_json(result)
+        else:
+            print(f"  {resp.status_code}: {resp.text[:200]}")
+
+        # ------------------------------------------------------------------
+        # 3. Load a saved model
+        # ------------------------------------------------------------------
+        print_header("3. Load Saved Model")
+        print("POST /v1/vision/models/load")
+        print()
+
+        resp = await client.post("/v1/vision/models/load", json={
+            "task": "detection",
+            "name": "demo-checkpoint-v1",
+        })
+        if resp.status_code == 200:
+            result = resp.json()
+            print("  Model loaded:")
+            print_json(result)
+        else:
+            print(f"  {resp.status_code}: {resp.text[:200]}")
+
+        # ------------------------------------------------------------------
+        # 4. Training jobs
+        # ------------------------------------------------------------------
+        print_header("4. Training Pipeline")
+
+        # List existing jobs
+        print("GET /v1/vision/train")
+        print()
+
+        resp = await client.get("/v1/vision/train")
+        if resp.status_code == 200:
+            jobs = resp.json()
+            if isinstance(jobs, list):
+                print(f"  Training jobs: {len(jobs)}")
+                for job in jobs:
+                    print(f"    - {job.get('job_id', '?')}: {job.get('status', '?')}")
+            else:
+                print_json(jobs)
+        else:
+            print(f"  {resp.status_code}: {resp.text[:200]}")
+
+        # Auto-training status
+        print()
+        print("GET /v1/vision/auto-train/status")
+        print()
+
+        resp = await client.get("/v1/vision/auto-train/status")
+        if resp.status_code == 200:
+            print("  Auto-train status:")
+            print_json(resp.json())
+        else:
+            print(f"  {resp.status_code}: {resp.text[:200]}")
+
+        # ------------------------------------------------------------------
+        # 5. Federation
+        # ------------------------------------------------------------------
+        print_header("5. Federation Peers")
+
+        # List peers
+        print("GET /v1/vision/federation/peers")
+        print()
+
+        resp = await client.get("/v1/vision/federation/peers")
+        if resp.status_code == 200:
+            peers = resp.json()
+            if isinstance(peers, list):
+                print(f"  Peers: {len(peers)}")
+                for p in peers:
+                    print(f"    - {p.get('name', '?')} @ {p.get('url', '?')}")
+            else:
+                print_json(peers)
+        else:
+            print(f"  {resp.status_code}: {resp.text[:200]}")
+
+        # Register a demo peer
+        print()
+        print("POST /v1/vision/federation/peers")
+        print()
+
+        resp = await client.post("/v1/vision/federation/peers", json={
+            "name": "demo-gpu-server",
+            "url": "http://192.168.1.100:14345",
+            "models": ["yolov8x", "yolov8l"],
+            "gpu_vram_gb": 24.0,
+            "priority": 1,
+            "timeout": 30.0,
+        })
+        if resp.status_code == 200:
+            print("  Peer registered:")
+            print_json(resp.json())
+        else:
+            print(f"  {resp.status_code}: {resp.text[:200]}")
+
+        # Federation status
+        print()
+        print("GET /v1/vision/federation/status")
+        print()
+
+        resp = await client.get("/v1/vision/federation/status")
+        if resp.status_code == 200:
+            print("  Federation status:")
+            print_json(resp.json())
+        else:
+            print(f"  {resp.status_code}: {resp.text[:200]}")
+
+        # ------------------------------------------------------------------
+        # 6. Model Packages
+        # ------------------------------------------------------------------
+        print_header("6. Model Packages")
+
+        # List packages
+        print("GET /v1/vision/federation/packages")
+        print()
+
+        resp = await client.get("/v1/vision/federation/packages")
+        if resp.status_code == 200:
+            packages = resp.json()
+            if isinstance(packages, list):
+                print(f"  Packages: {len(packages)}")
+                for pkg in packages:
+                    print(f"    - {pkg.get('model_id', '?')} v{pkg.get('version', '?')}")
+            else:
+                print_json(packages)
+        else:
+            print(f"  {resp.status_code}: {resp.text[:200]}")
+
+        # Create a package
+        print()
+        print("POST /v1/vision/federation/packages")
+        print()
+
+        resp = await client.post("/v1/vision/federation/packages", json={
+            "model_id": "yolov8n",
+            "description": "Demo detection model package",
+        })
+        if resp.status_code == 200:
+            print("  Package created:")
+            print_json(resp.json())
+        else:
+            print(f"  {resp.status_code}: {resp.text[:200]}")
+
+        # ------------------------------------------------------------------
+        # 7. Cleanup demo peer
+        # ------------------------------------------------------------------
+        print_header("7. Cleanup")
+        print("DELETE /v1/vision/federation/peers/demo-gpu-server")
+        print()
+
+        resp = await client.delete("/v1/vision/federation/peers/demo-gpu-server")
+        if resp.status_code == 200:
+            print("  Demo peer removed")
+        else:
+            print(f"  {resp.status_code}: {resp.text[:200]}")
+
+        # Delete demo model checkpoint
+        print()
+        print("DELETE /v1/vision/models/detection/demo-checkpoint-v1")
+        print()
+
+        resp = await client.delete("/v1/vision/models/detection/demo-checkpoint-v1")
+        if resp.status_code == 200:
+            print("  Demo checkpoint removed")
+        else:
+            print(f"  {resp.status_code}: {resp.text[:200]}")
+
+    print_header("Demo Complete!")
+    print("The vision pipeline is ready for production use.")
+    print()
+    print("What was demonstrated:")
+    print("  - Object detection, classification, segmentation, OCR")
+    print("  - Streaming sessions with cascade escalation")
+    print("  - Replay buffer for automatic learning")
+    print("  - Human corrections feeding the training loop")
+    print("  - Model save/load/versioning")
+    print("  - Federation peer management")
+    print("  - Model packaging for distribution")
+    print()
+    print("Configure defaults in llamafarm.yaml under the 'vision' key.")
+    print("See docs/website/docs/vision/ for full documentation.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/vision/run_full_demo.sh
+++ b/examples/vision/run_full_demo.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+# Full Vision Pipeline Demo
+# Runs all demo scripts in sequence with server management
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Configuration
+RUNTIME_PORT="${RUNTIME_PORT:-14345}"
+
+# Load from .env if exists
+if [ -f "$SCRIPT_DIR/.env" ]; then
+    export $(grep -v '^#' "$SCRIPT_DIR/.env" | xargs)
+fi
+
+export RUNTIME_URL="${RUNTIME_URL:-http://localhost:$RUNTIME_PORT}"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+print_header() {
+    echo ""
+    echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${BLUE}  $1${NC}"
+    echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo ""
+}
+
+print_step() {
+    echo -e "${GREEN}▶ $1${NC}"
+}
+
+print_warning() {
+    echo -e "${YELLOW}⚠ $1${NC}"
+}
+
+print_error() {
+    echo -e "${RED}✗ $1${NC}"
+}
+
+cleanup() {
+    print_header "Cleanup"
+    print_step "Stopping servers..."
+    lsof -ti:$RUNTIME_PORT 2>/dev/null | xargs kill -9 2>/dev/null || true
+    pkill -9 -f "nx start universal-runtime" 2>/dev/null || true
+    print_step "Servers stopped"
+}
+
+wait_for_server() {
+    local url=$1
+    local name=$2
+    local max_attempts=30
+    local attempt=0
+
+    print_step "Waiting for $name to be ready..."
+
+    while [ $attempt -lt $max_attempts ]; do
+        if curl -s "$url" > /dev/null 2>&1; then
+            echo -e "${GREEN}✓ $name is ready${NC}"
+            return 0
+        fi
+        attempt=$((attempt + 1))
+        sleep 1
+    done
+
+    print_error "$name failed to start after ${max_attempts}s"
+    return 1
+}
+
+# Main
+print_header "LlamaFarm Vision Pipeline - Full Demo"
+
+echo "This demo will:"
+echo "  1. Start the Universal Runtime"
+echo "  2. Run detection, classification, segmentation, and OCR"
+echo "  3. Start a streaming session with cascade"
+echo "  4. Demonstrate federation and model management"
+echo ""
+
+trap cleanup EXIT
+
+# Step 0: Stop existing
+print_header "Step 0: Stop Existing Servers"
+cleanup
+sleep 2
+
+# Step 1: Start runtime
+print_header "Step 1: Start Universal Runtime"
+
+cd "$REPO_ROOT"
+print_step "Starting Universal Runtime..."
+nx start universal-runtime > /tmp/universal-runtime.log 2>&1 &
+
+wait_for_server "http://localhost:$RUNTIME_PORT/health" "Universal Runtime"
+
+# Step 2: Detection & Classification
+print_header "Step 2: Detection, Classification, Segmentation, OCR"
+cd "$REPO_ROOT/runtimes/universal" && uv run python "$SCRIPT_DIR/01_detect_and_classify.py"
+cd "$SCRIPT_DIR"
+echo ""
+
+# Step 3: Streaming Cascade
+print_header "Step 3: Streaming Cascade Pipeline"
+cd "$REPO_ROOT/runtimes/universal" && uv run python "$SCRIPT_DIR/02_streaming_cascade.py"
+cd "$SCRIPT_DIR"
+echo ""
+
+# Step 4: Federation & Models
+print_header "Step 4: Federation & Model Management"
+cd "$REPO_ROOT/runtimes/universal" && uv run python "$SCRIPT_DIR/03_federation_and_models.py"
+cd "$SCRIPT_DIR"
+echo ""
+
+# Summary
+print_header "Demo Complete!"
+
+echo -e "${GREEN}All vision demo scripts ran successfully!${NC}"
+echo ""
+echo "What was demonstrated:"
+echo "  ✓ Object detection with YOLOv8"
+echo "  ✓ Zero-shot classification with CLIP"
+echo "  ✓ Instance segmentation"
+echo "  ✓ OCR text extraction"
+echo "  ✓ Streaming sessions with cascade escalation"
+echo "  ✓ Replay buffer for automatic learning"
+echo "  ✓ Human corrections and review queue"
+echo "  ✓ Model save/load/versioning"
+echo "  ✓ Federation peer management"
+echo "  ✓ Model packaging and distribution"
+echo ""
+echo "Server logs: /tmp/universal-runtime.log"
+echo ""
+echo "To run individual scripts:"
+echo "  cd runtimes/universal"
+echo "  uv run python ../../examples/vision/01_detect_and_classify.py"
+echo "  uv run python ../../examples/vision/02_streaming_cascade.py"
+echo "  uv run python ../../examples/vision/03_federation_and_models.py"
+echo ""

--- a/examples/vision_cascade_demo.py
+++ b/examples/vision_cascade_demo.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""
+Vision Cascade + Auto-Learning Demo
+
+Demonstrates the complete automated learning pipeline:
+1. Primary model (yolov8n) processes images
+2. Uncertain detections escalate to secondary model (yolov8m)
+3. Secondary model successes feed back to replay buffer
+4. Failed detections go to review queue
+5. Corrections trigger automatic retraining
+
+Run with:
+    cd runtimes/universal && uv run python ../../examples/vision_cascade_demo.py
+"""
+
+import asyncio
+import base64
+import logging
+import sys
+from pathlib import Path
+
+# Add parent paths for imports
+sys.path.insert(0, str(Path(__file__).parent.parent / "runtimes" / "universal"))
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
+logger = logging.getLogger("demo")
+
+
+async def main():
+    """Run the cascade demo."""
+    
+    print("\n" + "=" * 60)
+    print("  Vision Cascade + Auto-Learning Demo")
+    print("=" * 60 + "\n")
+    
+    # Import components
+    from models.streaming_vision import (
+        StreamingVisionDetector,
+        StreamingConfig,
+        CascadeConfig,
+    )
+    from vision_training.replay_buffer import ReplayBuffer
+    from storage.image_store import ImageStore
+    from vision_training.auto_trainer import AutoTrainer, AutoTrainConfig
+    
+    # Initialize components
+    print("📦 Initializing components...")
+    
+    replay_buffer = ReplayBuffer(max_size=100)
+    image_store = ImageStore()
+    
+    # Mock model loader for demo
+    async def mock_model_loader(model_id: str):
+        """Mock model loader that returns a fake detector."""
+        class MockModel:
+            def __init__(self, model_id: str):
+                self.model_id = model_id
+                # Secondary model is "better" - higher confidence
+                self.confidence_boost = 0.2 if "m" in model_id or "l" in model_id else 0.0
+            
+            async def detect(self, image, confidence_threshold=0.5):
+                """Mock detection based on image content."""
+                from models.vision_base import DetectionResult, DetectionBox
+                import hashlib
+                
+                # Use hash of image to generate consistent "detections"
+                img_hash = int(hashlib.md5(image).hexdigest()[:8], 16)
+                
+                # Generate 0-3 detections based on hash
+                num_detections = img_hash % 4
+                
+                boxes = []
+                for i in range(num_detections):
+                    # Generate confidence based on hash and model
+                    base_conf = 0.3 + (((img_hash >> (i * 4)) % 10) / 10) * 0.5
+                    conf = min(1.0, base_conf + self.confidence_boost)
+                    
+                    if conf >= confidence_threshold:
+                        boxes.append(DetectionBox(
+                            x1=0.1 + i * 0.2,
+                            y1=0.1 + i * 0.1,
+                            x2=0.3 + i * 0.2,
+                            y2=0.4 + i * 0.1,
+                            class_name=["person", "car", "dog", "cat"][i % 4],
+                            class_id=i % 4,
+                            confidence=conf,
+                        ))
+                
+                return DetectionResult(
+                    confidence=max(b.confidence for b in boxes) if boxes else 0.0,
+                    inference_time_ms=10.0,
+                    model_name=self.model_id,
+                    boxes=boxes,
+                )
+        
+        print(f"  ✓ Loaded model: {model_id}")
+        return MockModel(model_id)
+    
+    # Initialize detector with cascade
+    detector = StreamingVisionDetector(
+        model_loader=mock_model_loader,
+        replay_buffer=replay_buffer,
+        image_store=image_store,
+    )
+    
+    # Track when training would be triggered
+    training_triggered = False
+    
+    async def on_training_trigger(buffer_size: int):
+        nonlocal training_triggered
+        if buffer_size >= 5:  # Low threshold for demo
+            training_triggered = True
+            print(f"\n🚀 TRAINING TRIGGERED! Buffer size: {buffer_size}")
+    
+    detector.set_training_trigger(on_training_trigger)
+    
+    print("  ✓ Streaming detector initialized")
+    print("  ✓ Replay buffer ready (max size: 100)")
+    print("  ✓ Image store ready")
+    
+    # Start session with cascade
+    print("\n📹 Starting streaming session with cascade...")
+    
+    config = StreamingConfig(
+        confidence_threshold=0.7,
+        escalation_threshold=0.5,
+        action_classes=["person", "car"],
+        cooldown_seconds=0.1,  # Short for demo
+        cascade=CascadeConfig(
+            secondary_model_id="yolov8m",
+            feedback_to_primary=True,
+            save_uncertain_images=True,
+        ),
+    )
+    
+    session = await detector.start_session(
+        model_id="yolov8n",
+        config=config,
+    )
+    
+    print(f"  ✓ Session started: {session.session_id}")
+    print(f"  ✓ Primary model: yolov8n")
+    print(f"  ✓ Secondary model: yolov8m")
+    print(f"  ✓ Confidence threshold: {config.confidence_threshold}")
+    print(f"  ✓ Escalation threshold: {config.escalation_threshold}")
+    
+    # Process some mock frames
+    print("\n🎬 Processing frames...")
+    print("-" * 60)
+    
+    results_summary = {
+        "ok": 0,
+        "action": 0,
+        "review": 0,
+        "escalated": 0,
+        "added_to_replay": 0,
+    }
+    
+    for i in range(20):
+        # Generate a "frame" (just random bytes for demo)
+        frame = f"frame_{i}_content_{i * 137}".encode() * 100
+        
+        result = await detector.process_frame(
+            session_id=session.session_id,
+            image=frame,
+        )
+        
+        results_summary[result.status] += 1
+        if result.added_to_replay:
+            results_summary["added_to_replay"] += 1
+        
+        # Print interesting results
+        if result.status != "ok":
+            emoji = {
+                "action": "🎯",
+                "review": "🔍",
+                "escalated": "⬆️",
+            }.get(result.status, "❓")
+            
+            escalation_info = f" (escalated to {result.escalated_to})" if result.escalated_to else ""
+            replay_info = " [LEARNED]" if result.added_to_replay else ""
+            
+            print(f"  Frame {i:2d}: {emoji} {result.status.upper():8s} conf={result.confidence:.2f}{escalation_info}{replay_info}")
+    
+    # Print summary
+    print("-" * 60)
+    print("\n📊 Session Summary:")
+    print(f"  • Total frames: 20")
+    print(f"  • Actions triggered: {results_summary['action']}")
+    print(f"  • Sent to review: {results_summary['review']}")
+    print(f"  • Added to replay buffer: {results_summary['added_to_replay']}")
+    
+    # Check replay buffer
+    buffer_stats = replay_buffer.get_stats()
+    print(f"\n📚 Replay Buffer:")
+    print(f"  • Size: {buffer_stats['size']}")
+    print(f"  • By source: {buffer_stats['by_source']}")
+    print(f"  • Avg priority: {buffer_stats['avg_priority']:.2f}")
+    
+    # Stop session
+    stats = await detector.stop_session(session.session_id)
+    
+    print(f"\n📈 Session Statistics:")
+    print(f"  • Frames processed: {stats['frames_processed']}")
+    print(f"  • Actions triggered: {stats['actions_triggered']}")
+    print(f"  • Escalations: {stats['escalations_to_secondary']}")
+    print(f"  • Secondary successes: {stats['secondary_successes']}")
+    print(f"  • Secondary success rate: {stats['secondary_success_rate']:.1%}")
+    print(f"  • Review queue: {stats['review_queue_count']}")
+    
+    # Simulate corrections
+    print("\n✏️  Simulating human corrections...")
+    
+    for i in range(3):
+        await detector.submit_correction(
+            session_id="manual",
+            image_id=f"correction_{i}",
+            corrected_class="truck",
+            original_confidence=0.4,
+        )
+    
+    buffer_stats = replay_buffer.get_stats()
+    print(f"  • Added 3 corrections")
+    print(f"  • Buffer size now: {buffer_stats['size']}")
+    print(f"  • By source: {buffer_stats['by_source']}")
+    
+    # Training trigger check
+    if training_triggered:
+        print("\n✅ Auto-training would have been triggered!")
+    else:
+        print("\n⏳ Auto-training threshold not yet reached")
+    
+    # Demo complete
+    print("\n" + "=" * 60)
+    print("  Demo Complete! 🎉")
+    print("=" * 60)
+    print("""
+Key takeaways:
+1. Primary model handles most detections quickly
+2. Uncertain detections automatically escalate to secondary model
+3. Successful secondary results feed back for training
+4. Human corrections also feed the replay buffer
+5. Training triggers automatically when buffer fills
+
+The cascade pattern gives you:
+• Fast inference (80% handled by small model)
+• High accuracy (20% verified by large model)
+• Continuous improvement (auto-learning from both)
+""")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary

- Adds Docusaurus documentation pages for vision pipeline (detection, streaming, training, federation)
- Adds standalone demo scripts for each vision capability
- Adds step-by-step tutorial examples
- Updates API reference, sidebars, and llms-full.txt

**Depends on:** #754 (core vision pipeline)

## Files

| Category | Files |
|----------|-------|
| Docusaurus pages | `docs/website/docs/vision/*.md` |
| Architecture doc | `docs/VISION.md` |
| Demo scripts | `demos/vision/demo_*.py` |
| Tutorial examples | `examples/vision/01-03_*.py` |
| Updated references | `sidebars.ts`, `api/index.md`, `llms-full.txt` |

## Test plan

- [ ] `npx docusaurus build` succeeds
- [ ] All relative links resolve correctly
- [ ] Demo scripts have correct endpoint URLs
- [ ] Examples run against a local runtime

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily adds documentation and standalone demo scripts with minimal impact on runtime code; main risk is doc/API endpoint mismatches and the Node version bump affecting local docs builds.
> 
> **Overview**
> Adds a new set of runnable `demos/vision` scripts covering detection, CLIP classification, embeddings/similarity, streaming sessions, training workflow, and an end-to-end “full pipeline” example, plus a `demos/vision/README.md` with setup/run instructions.
> 
> Introduces comprehensive Vision documentation (`docs/VISION.md` and new Docusaurus pages under `docs/website/docs/vision/*`) and wires it into the docs site by expanding the API reference with Vision endpoints and adding a new “Vision Pipeline” section to `sidebars.ts`. Also bumps the docs website’s Node engine requirement to `>=20` in `package-lock.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03edeb2b0440f1b42b7f5a6dbc15db5ef430e99d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->