### PR TITLE
fix(server): API system prompts override config system prompts

### DIFF
--- a/server/agents/base/agent.py
+++ b/server/agents/base/agent.py
@@ -56,12 +56,13 @@ class LFAgent:
         tools: list[ToolDefinition] | None = None,
         extra_body: dict | None = None,
     ) -> LFChatCompletion:
-        self._request_system_prompt = None
-        if messages:
+        if messages is not None:
+            self._request_system_prompt = None
             for message in messages:
                 if message.get("role") == "system":
-                    self._request_system_prompt = str(
-                        message.get("content", "")
+                    content = message.get("content")
+                    self._request_system_prompt = (
+                        content if isinstance(content, str) else ""
                     )
                 else:
                     self.history.add_message(message)
@@ -82,12 +83,13 @@ class LFAgent:
         tools: list[ToolDefinition] | None = None,
         extra_body: dict | None = None,
     ) -> AsyncGenerator[LFChatCompletionChunk]:
-        self._request_system_prompt = None
-        if messages:
+        if messages is not None:
+            self._request_system_prompt = None
             for message in messages:
                 if message.get("role") == "system":
-                    self._request_system_prompt = str(
-                        message.get("content", "")
+                    content = message.get("content")
+                    self._request_system_prompt = (
+                        content if isinstance(content, str) else ""
                     )
                 else:
                     self.history.add_message(message)

--- a/server/tests/test_llamagent_framework.py
+++ b/server/tests/test_llamagent_framework.py
@@ -718,6 +718,46 @@ class TestSystemPromptOverride:
             for m in msgs
         )
 
+    @pytest.mark.asyncio
+    async def test_override_persists_across_tool_loop_calls(
+        self, agent_with_config_prompt
+    ):
+        """System prompt override survives messages=None in tool loops."""
+        agent, client = agent_with_config_prompt
+
+        # First call sets the override
+        await agent.run_async(
+            messages=[
+                {"role": "system", "content": "Tool loop prompt"},
+                {"role": "user", "content": "Use a tool"},
+            ]
+        )
+        assert "Tool loop prompt" in client.last_messages[0]["content"]
+
+        # Subsequent call with messages=None (tool iteration)
+        await agent.run_async(messages=None)
+        assert "Tool loop prompt" in client.last_messages[0]["content"]
+        assert "Config system prompt" not in str(client.last_messages)
+
+    @pytest.mark.asyncio
+    async def test_none_content_not_stringified(
+        self, agent_with_config_prompt
+    ):
+        """None content should not become the string 'None'."""
+        agent, client = agent_with_config_prompt
+
+        await agent.run_async(
+            messages=[
+                {"role": "system", "content": None},
+                {"role": "user", "content": "Hello"},
+            ]
+        )
+
+        msgs = client.last_messages
+        # Should use empty string, not "None"
+        assert msgs[0]["role"] == "system"
+        assert "None" not in msgs[0]["content"]
+
 
 class TestToolCallRequest:
     """Test suite for ToolCallRequest."""


### PR DESCRIPTION
## Summary
- API-provided system messages (`role: "system"`) now override config-defined system prompts instead of coexisting alongside them
- System messages are no longer persisted in conversation history — they're request-scoped context
- Context providers (RAG, project context) still append to whichever system prompt is active

## Problem
When an API caller sent a system message via the OpenAI-compatible chat endpoint, the message was added to conversation history as a regular entry. The config-defined system prompt was always prepended separately, so the model saw **both** — the config prompt at position 0 and the API system message buried in history. This caused unexpected model behavior and defeated the purpose of per-request system prompts.

## Solution
In `LFAgent.run_async()` and `run_async_stream()`, system messages are now extracted from incoming messages before they enter history. The extracted system prompt is stored as `_request_system_prompt` (reset each request). In `_prepare_messages()`, if an API system prompt exists it replaces the config system prompt; otherwise the config prompt is used as before.

## Test plan
- [x] API system message overrides config system prompt
- [x] API system message is NOT persisted in history
- [x] Context providers (RAG) still append to API system prompt
- [x] No API system message falls back to config system prompt
- [x] Successive requests can send different system prompts
- [x] After API system prompt, next request without one falls back to config
- [x] Streaming respects the same override behavior
- [x] All 499 existing server tests pass (voice e2e excluded — requires running TTS runtime)