### PR TITLE
feat: LlamaFarm Python & TypeScript SDKs

### DIFF
--- a/packages/llamafarm-sdk-ts/README.md
+++ b/packages/llamafarm-sdk-ts/README.md
@@ -1,0 +1,47 @@
+# 🦙 LlamaFarm TypeScript SDK
+
+> **Alpha** — API may change between releases.
+
+TypeScript client for [LlamaFarm](https://llamafarm.com) — local AI infrastructure.
+
+## Install
+
+```bash
+npm install llamafarm
+```
+
+## Quick Start
+
+```typescript
+import { LlamaFarm } from 'llamafarm'
+
+const lf = new LlamaFarm()
+const project = lf.project('default', 'my-app')
+
+// Chat
+const response = await project.chat('What is the meaning of life?')
+console.log(response.text)
+
+// Stream
+const stream = await project.chatStream('Tell me a story')
+const reader = stream.getReader()
+while (true) {
+  const { done, value } = await reader.read()
+  if (done) break
+  process.stdout.write(value.content)
+}
+```
+
+## Features
+
+- **Chat** — sync and streaming with OpenAI-compatible API
+- **RAG** — query, health, stats, database management
+- **Vision** — detect, classify (YOLO + CLIP)
+- **Fine-Tuning** — SFT, CPT, job management
+- **KV Cache** — prepare, stats, garbage collection
+- **Zero dependencies** — uses native `fetch`
+
+## Requirements
+
+- Node.js 18+ (for native `fetch`)
+- A running LlamaFarm server (`lf start`)

--- a/packages/llamafarm-sdk-ts/examples/live_test.ts
+++ b/packages/llamafarm-sdk-ts/examples/live_test.ts
@@ -1,0 +1,98 @@
+#!/usr/bin/env npx tsx
+/**
+ * Live integration test — TypeScript SDK against running LlamaFarm server.
+ */
+
+import { LlamaFarm } from '../src/index.js'
+
+const NAMESPACE = 'default'
+const PROJECT = 'sdk-test'
+
+async function main() {
+  const lf = new LlamaFarm()
+  console.log(`SDK url: ${lf.url}`)
+  console.log(`Runtime: ${lf.runtimeUrl}\n`)
+
+  // 1. Health check
+  console.log('── Health ──')
+  const h = await lf.health()
+  console.log(`  Status: ${h.status}`)
+  console.log(`  Summary: ${h.summary ?? 'n/a'}\n`)
+
+  // 2. List models
+  console.log('── Models (first 5) ──')
+  const models = await lf.models()
+  for (const m of models.slice(0, 5)) {
+    console.log(`  • ${m.id}`)
+  }
+  console.log()
+
+  // 3. List projects
+  console.log("── Projects in 'default' (first 5) ──")
+  const projects = await lf.projects(NAMESPACE)
+  for (const p of projects.slice(0, 5)) {
+    console.log(`  • ${p.name}`)
+  }
+  console.log()
+
+  // 4. Chat (non-streaming)
+  console.log('── Chat (sync) ──')
+  const p = lf.project(NAMESPACE, PROJECT)
+  const resp = await p.chat('What is 2 + 2? Answer in one sentence.', { stateless: true, max_tokens: 60 })
+  console.log(`  Model: ${resp.model}`)
+  console.log(`  Reply: ${resp.text}`)
+  console.log(`  Usage: ${JSON.stringify(resp.usage)}\n`)
+
+  // 5. Chat streaming
+  console.log('── Chat (streaming) ──')
+  process.stdout.write('  ')
+  const stream = await p.chatStream('Name 3 colors. One word each, comma-separated.', { stateless: true, max_tokens: 30 })
+  const reader = stream.getReader()
+  const parts: string[] = []
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    process.stdout.write(value.content)
+    parts.push(value.content)
+  }
+  console.log(`\n  (collected: ${parts.join('')})\n`)
+
+  // 6. Vision (if available)
+  console.log('── Vision ──')
+  console.log('  Vision API accessible via lf.vision')
+
+  // 7. OpenAI compatibility
+  console.log('\n── OpenAI Compatibility ──')
+  console.log(`  Base URL: ${lf.openaiBaseUrl}`)
+
+  // 8. ML APIs (graceful — these may 404 if backends not loaded)
+  console.log('\n── ML APIs ──')
+  const mlTests: [string, () => Promise<unknown>][] = [
+    ['anomaly.backends', () => lf.anomaly.backends()],
+    ['anomaly.models', () => lf.anomaly.models()],
+    ['classifier.models', () => lf.classifier.models()],
+    ['timeseries.backends', () => lf.timeseries.backends()],
+    ['timeseries.models', () => lf.timeseries.models()],
+    ['adtk.detectors', () => lf.adtk.detectors()],
+    ['catboost.info', () => lf.catboost.info()],
+    ['drift.detectors', () => lf.drift.detectors()],
+    ['explain.explainers', () => lf.explain.explainers()],
+    ['polars.buffers', () => lf.polars.buffers()],
+    ['nlp.embeddings', () => lf.nlp.embeddings('test')],
+  ]
+  for (const [name, fn] of mlTests) {
+    try {
+      const r = await fn()
+      console.log(`  ✅ ${name}: ${JSON.stringify(r).slice(0, 80)}`)
+    } catch (e: any) {
+      console.log(`  ⚠️  ${name}: ${e.message?.slice(0, 60)}`)
+    }
+  }
+
+  console.log('\n✅ All live tests passed!')
+}
+
+main().catch(err => {
+  console.error('❌ Error:', err.message)
+  process.exit(1)
+})

--- a/packages/llamafarm-sdk-ts/examples/ml_demo.ts
+++ b/packages/llamafarm-sdk-ts/examples/ml_demo.ts
@@ -1,0 +1,83 @@
+/**
+ * ML APIs demo — exercises all ML/AI endpoints.
+ *
+ * Usage: npx tsx examples/ml_demo.ts
+ */
+
+import { LlamaFarm } from '../src/index.js'
+
+const lf = new LlamaFarm()
+
+async function tryApi(name: string, fn: () => Promise<unknown>) {
+  try {
+    const result = await fn()
+    console.log(`✅ ${name}:`, JSON.stringify(result).slice(0, 200))
+  } catch (e: any) {
+    console.log(`⚠️  ${name}: ${e.message?.slice(0, 100)}`)
+  }
+}
+
+async function main() {
+  console.log('=== LlamaFarm ML APIs Demo ===\n')
+
+  // NLP
+  console.log('--- NLP ---')
+  await tryApi('nlp.embeddings', () => lf.nlp.embeddings('hello world'))
+  await tryApi('nlp.classify', () => lf.nlp.classify('I love this!', ['positive', 'negative']))
+  await tryApi('nlp.ner', () => lf.nlp.ner('John works at Google in NYC'))
+  await tryApi('nlp.rerank', () => lf.nlp.rerank('AI models', ['deep learning paper', 'cooking recipe', 'neural networks']))
+
+  // Anomaly Detection
+  console.log('\n--- Anomaly Detection ---')
+  const normalData = Array.from({ length: 50 }, () => [Math.random(), Math.random()])
+  await tryApi('anomaly.fit', () => lf.anomaly.fit(normalData, { model_name: 'demo-iforest' }))
+  await tryApi('anomaly.detect', () => lf.anomaly.detect([[0.5, 0.5], [99, 99]], { explain: true }))
+  await tryApi('anomaly.models', () => lf.anomaly.models())
+  await tryApi('anomaly.backends', () => lf.anomaly.backends())
+
+  // Classifier
+  console.log('\n--- Classifier ---')
+  const X = [[1, 0], [0, 1], [1, 1], [0, 0]]
+  const y = [1, 1, 0, 0]
+  await tryApi('classifier.fit', () => lf.classifier.fit(X, y, { model_name: 'demo-clf' }))
+  await tryApi('classifier.predict', () => lf.classifier.predict([[0.5, 0.5]]))
+  await tryApi('classifier.models', () => lf.classifier.models())
+
+  // Time Series
+  console.log('\n--- Time Series ---')
+  const ts = Array.from({ length: 100 }, (_, i) => Math.sin(i / 10) + Math.random() * 0.1)
+  await tryApi('timeseries.fit', () => lf.timeseries.fit(ts, { model_name: 'demo-ts' }))
+  await tryApi('timeseries.predict', () => lf.timeseries.predict(10))
+  await tryApi('timeseries.models', () => lf.timeseries.models())
+  await tryApi('timeseries.backends', () => lf.timeseries.backends())
+
+  // ADTK
+  console.log('\n--- ADTK ---')
+  await tryApi('adtk.detectors', () => lf.adtk.detectors())
+  await tryApi('adtk.models', () => lf.adtk.models())
+
+  // CatBoost
+  console.log('\n--- CatBoost ---')
+  await tryApi('catboost.info', () => lf.catboost.info())
+  await tryApi('catboost.models', () => lf.catboost.models())
+  await tryApi('catboost.fit', () => lf.catboost.fit(X, y, { model_name: 'demo-cb' }))
+
+  // Drift Detection
+  console.log('\n--- Drift ---')
+  await tryApi('drift.detectors', () => lf.drift.detectors())
+  await tryApi('drift.models', () => lf.drift.models())
+
+  // Explainability
+  console.log('\n--- Explain ---')
+  await tryApi('explain.explainers', () => lf.explain.explainers())
+  await tryApi('explain.shap', () => lf.explain.shap([[1, 2, 3]]))
+
+  // Polars
+  console.log('\n--- Polars ---')
+  await tryApi('polars.buffers', () => lf.polars.buffers())
+  await tryApi('polars.createBuffer', () => lf.polars.createBuffer({ name: 'demo', schema: { col1: 'f64', col2: 'f64' } }))
+
+  console.log('\n=== Done ===')
+}
+
+main().catch(console.error)

--- a/packages/llamafarm-sdk-ts/examples/openai_compat.ts
+++ b/packages/llamafarm-sdk-ts/examples/openai_compat.ts
@@ -1,0 +1,55 @@
+/**
+ * OpenAI SDK compatibility demo.
+ *
+ * Shows how to use LlamaFarm as an OpenAI-compatible backend.
+ * Requires: npm install openai (dev dependency only for this example)
+ *
+ * Usage: npx tsx examples/openai_compat.ts
+ */
+
+import { LlamaFarm } from '../src/index.js'
+
+async function main() {
+  const lf = new LlamaFarm()
+
+  console.log('=== OpenAI Compatibility Demo ===\n')
+  console.log(`OpenAI Base URL: ${lf.openaiBaseUrl}`)
+  console.log()
+
+  // You can use this URL with the OpenAI SDK:
+  //
+  //   import OpenAI from 'openai'
+  //   const client = new OpenAI({ baseURL: lf.openaiBaseUrl, apiKey: 'not-needed' })
+  //   const completion = await client.chat.completions.create({
+  //     model: 'Qwen/Qwen3-8B',
+  //     messages: [{ role: 'user', content: 'Hello!' }],
+  //   })
+  //   console.log(completion.choices[0].message.content)
+  //
+
+  // Direct test via fetch to the OpenAI-compatible endpoint
+  try {
+    const res = await fetch(`${lf.openaiBaseUrl}/models`)
+    if (res.ok) {
+      const data = await res.json() as { data?: unknown[] }
+      console.log(`Models available via OpenAI-compat endpoint: ${(data.data ?? []).length}`)
+    }
+  } catch (e) {
+    console.log('Runtime not available — skipping direct fetch test')
+  }
+
+  // Also works with LlamaFarm native SDK
+  try {
+    const models = await lf.models()
+    console.log(`\nModels via LlamaFarm SDK: ${models.length}`)
+    for (const m of models.slice(0, 5)) {
+      console.log(`  - ${m.id} (loaded: ${m.loaded})`)
+    }
+  } catch (e) {
+    console.log('Server not available — skipping models list')
+  }
+
+  console.log('\n✅ OpenAI compatibility ready')
+}
+
+main().catch(console.error)

--- a/packages/llamafarm-sdk-ts/package-lock.json
+++ b/packages/llamafarm-sdk-ts/package-lock.json
@@ -1,0 +1,1437 @@
+{
+  "name": "llamafarm",
+  "version": "0.1.0-alpha.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "llamafarm",
+      "version": "0.1.0-alpha.1",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "typescript": "^5.5.0",
+        "vitest": "^2.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.58.0.tgz",
+      "integrity": "sha512-mr0tmS/4FoVk1cnaeN244A/wjvGDNItZKR8hRhnmCzygyRXYtKF5jVDSIILR1U97CTzAYmbgIj/Dukg62ggG5w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.58.0.tgz",
+      "integrity": "sha512-+s++dbp+/RTte62mQD9wLSbiMTV+xr/PeRJEc/sFZFSBRlHPNPVaf5FXlzAL77Mr8FtSfQqCN+I598M8U41ccQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.58.0.tgz",
+      "integrity": "sha512-MFWBwTcYs0jZbINQBXHfSrpSQJq3IUOakcKPzfeSznONop14Pxuqa0Kg19GD0rNBMPQI2tFtu3UzapZpH0Uc1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.58.0.tgz",
+      "integrity": "sha512-yiKJY7pj9c9JwzuKYLFaDZw5gma3fI9bkPEIyofvVfsPqjCWPglSHdpdwXpKGvDeYDms3Qal8qGMEHZ1M/4Udg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.58.0.tgz",
+      "integrity": "sha512-x97kCoBh5MOevpn/CNK9W1x8BEzO238541BGWBc315uOlN0AD/ifZ1msg+ZQB05Ux+VF6EcYqpiagfLJ8U3LvQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.58.0.tgz",
+      "integrity": "sha512-Aa8jPoZ6IQAG2eIrcXPpjRcMjROMFxCt1UYPZZtCxRV68WkuSigYtQ/7Zwrcr2IvtNJo7T2JfDXyMLxq5L4Jlg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.58.0.tgz",
+      "integrity": "sha512-Ob8YgT5kD/lSIYW2Rcngs5kNB/44Q2RzBSPz9brf2WEtcGR7/f/E9HeHn1wYaAwKBni+bdXEwgHvUd0x12lQSA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.58.0.tgz",
+      "integrity": "sha512-K+RI5oP1ceqoadvNt1FecL17Qtw/n9BgRSzxif3rTL2QlIu88ccvY+Y9nnHe/cmT5zbH9+bpiJuG1mGHRVwF4Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.58.0.tgz",
+      "integrity": "sha512-T+17JAsCKUjmbopcKepJjHWHXSjeW7O5PL7lEFaeQmiVyw4kkc5/lyYKzrv6ElWRX/MrEWfPiJWqbTvfIvjM1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.58.0.tgz",
+      "integrity": "sha512-cCePktb9+6R9itIJdeCFF9txPU7pQeEHB5AbHu/MKsfH/k70ZtOeq1k4YAtBv9Z7mmKI5/wOLYjQ+B9QdxR6LA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.58.0.tgz",
+      "integrity": "sha512-iekUaLkfliAsDl4/xSdoCJ1gnnIXvoNz85C8U8+ZxknM5pBStfZjeXgB8lXobDQvvPRCN8FPmmuTtH+z95HTmg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.58.0.tgz",
+      "integrity": "sha512-68ofRgJNl/jYJbxFjCKE7IwhbfxOl1muPN4KbIqAIe32lm22KmU7E8OPvyy68HTNkI2iV/c8y2kSPSm2mW/Q9Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.58.0.tgz",
+      "integrity": "sha512-dpz8vT0i+JqUKuSNPCP5SYyIV2Lh0sNL1+FhM7eLC457d5B9/BC3kDPp5BBftMmTNsBarcPcoz5UGSsnCiw4XQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.58.0.tgz",
+      "integrity": "sha512-4gdkkf9UJ7tafnweBCR/mk4jf3Jfl0cKX9Np80t5i78kjIH0ZdezUv/JDI2VtruE5lunfACqftJ8dIMGN4oHew==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.58.0.tgz",
+      "integrity": "sha512-YFS4vPnOkDTD/JriUeeZurFYoJhPf9GQQEF/v4lltp3mVcBmnsAdjEWhr2cjUCZzZNzxCG0HZOvJU44UGHSdzw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.58.0.tgz",
+      "integrity": "sha512-x2xgZlFne+QVNKV8b4wwaCS8pwq3y14zedZ5DqLzjdRITvreBk//4Knbcvm7+lWmms9V9qFp60MtUd0/t/PXPw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.58.0.tgz",
+      "integrity": "sha512-jIhrujyn4UnWF8S+DHSkAkDEO3hLX0cjzxJZPLF80xFyzyUIYgSMRcYQ3+uqEoyDD2beGq7Dj7edi8OnJcS/hg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.58.0.tgz",
+      "integrity": "sha512-+410Srdoh78MKSJxTQ+hZ/Mx+ajd6RjjPwBPNd0R3J9FtL6ZA0GqiiyNjCO9In0IzZkCNrpGymSfn+kgyPQocg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.58.0.tgz",
+      "integrity": "sha512-ZjMyby5SICi227y1MTR3VYBpFTdZs823Rs/hpakufleBoufoOIB6jtm9FEoxn/cgO7l6PM2rCEl5Kre5vX0QrQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.58.0.tgz",
+      "integrity": "sha512-ds4iwfYkSQ0k1nb8LTcyXw//ToHOnNTJtceySpL3fa7tc/AsE+UpUFphW126A6fKBGJD5dhRvg8zw1rvoGFxmw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.58.0.tgz",
+      "integrity": "sha512-fd/zpJniln4ICdPkjWFhZYeY/bpnaN9pGa6ko+5WD38I0tTqk9lXMgXZg09MNdhpARngmxiCg0B0XUamNw/5BQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.58.0.tgz",
+      "integrity": "sha512-YpG8dUOip7DCz3nr/JUfPbIUo+2d/dy++5bFzgi4ugOGBIox+qMbbqt/JoORwvI/C9Kn2tz6+Bieoqd5+B1CjA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.58.0.tgz",
+      "integrity": "sha512-b9DI8jpFQVh4hIXFr0/+N/TzLdpBIoPzjt0Rt4xJbW3mzguV3mduR9cNgiuFcuL/TeORejJhCWiAXe3E/6PxWA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.58.0.tgz",
+      "integrity": "sha512-CSrVpmoRJFN06LL9xhkitkwUcTZtIotYAF5p6XOR2zW0Zz5mzb3IPpcoPhB02frzMHFNo1reQ9xSF5fFm3hUsQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.58.0.tgz",
+      "integrity": "sha512-QFsBgQNTnh5K0t/sBsjJLq24YVqEIVkGpfN2VHsnN90soZyhaiA9UUHufcctVNL4ypJY0wrwad0wslx2KJQ1/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.58.0.tgz",
+      "integrity": "sha512-wbT0mBmWbIvvq8NeEYWWvevvxnOyhKChir47S66WCxw1SXqhw7ssIYejnQEVt7XYQpsj2y8F9PM+Cr3SNEa0gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.58.0",
+        "@rollup/rollup-android-arm64": "4.58.0",
+        "@rollup/rollup-darwin-arm64": "4.58.0",
+        "@rollup/rollup-darwin-x64": "4.58.0",
+        "@rollup/rollup-freebsd-arm64": "4.58.0",
+        "@rollup/rollup-freebsd-x64": "4.58.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.58.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.58.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.58.0",
+        "@rollup/rollup-linux-arm64-musl": "4.58.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.58.0",
+        "@rollup/rollup-linux-loong64-musl": "4.58.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.58.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.58.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.58.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.58.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.58.0",
+        "@rollup/rollup-linux-x64-gnu": "4.58.0",
+        "@rollup/rollup-linux-x64-musl": "4.58.0",
+        "@rollup/rollup-openbsd-x64": "4.58.0",
+        "@rollup/rollup-openharmony-arm64": "4.58.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.58.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.58.0",
+        "@rollup/rollup-win32-x64-gnu": "4.58.0",
+        "@rollup/rollup-win32-x64-msvc": "4.58.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/packages/llamafarm-sdk-ts/package.json
+++ b/packages/llamafarm-sdk-ts/package.json
@@ -1,0 +1,65 @@
+{
+  "name": "llamafarm",
+  "version": "0.1.0-alpha.1",
+  "description": "TypeScript SDK for LlamaFarm — local AI infrastructure",
+  "author": "LlamaFarm <hello@llamafarm.ai>",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/llama-farm/llamafarm#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/llama-farm/llamafarm",
+    "directory": "packages/llamafarm-sdk-ts"
+  },
+  "bugs": {
+    "url": "https://github.com/llama-farm/llamafarm/issues"
+  },
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "keywords": [
+    "llm",
+    "ai",
+    "local",
+    "inference",
+    "llamafarm",
+    "llama",
+    "gguf",
+    "vision",
+    "rag",
+    "fine-tuning",
+    "sdk"
+  ],
+  "scripts": {
+    "build": "tsc && npm run build:cjs",
+    "build:cjs": "tsc -p tsconfig.cjs.json && node scripts/fix-cjs.js",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "tsc --noEmit",
+    "clean": "rm -rf dist",
+    "prepublishOnly": "npm run clean && npm run build && npm test"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.0",
+    "vitest": "^2.0.0"
+  }
+}

--- a/packages/llamafarm-sdk-ts/scripts/fix-cjs.js
+++ b/packages/llamafarm-sdk-ts/scripts/fix-cjs.js
@@ -1,0 +1,22 @@
+/**
+ * Rename .js → .cjs in the CJS output directory and fix internal imports.
+ */
+import { readdirSync, renameSync, readFileSync, writeFileSync } from 'fs'
+import { join } from 'path'
+
+const dir = join(import.meta.dirname, '..', 'dist', 'cjs')
+
+for (const file of readdirSync(dir)) {
+  if (!file.endsWith('.js')) continue
+  const oldPath = join(dir, file)
+  const newPath = join(dir, file.replace(/\.js$/, '.cjs'))
+
+  // Fix require('./foo.js') → require('./foo.cjs')
+  let content = readFileSync(oldPath, 'utf8')
+  content = content.replace(/require\("\.\/([^"]+)\.js"\)/g, 'require("./$1.cjs")')
+  writeFileSync(oldPath, content)
+
+  renameSync(oldPath, newPath)
+}
+
+// Rename .d.ts is fine as-is (TypeScript resolves .d.ts from .cjs via exports map)

--- a/packages/llamafarm-sdk-ts/src/client.ts
+++ b/packages/llamafarm-sdk-ts/src/client.ts
@@ -371,6 +371,11 @@ class VisionAPI {
       time_ms: (data.time_ms ?? 0) as number,
     }
   }
+
+  /** List all saved vision models. */
+  async models(): Promise<Record<string, unknown>> {
+    return this.client._req('GET', '/v1/vision/models') as Promise<Record<string, unknown>>
+  }
 }
 
 class FineTuneAPI {
@@ -523,16 +528,18 @@ class AnomalyAPI {
 class ClassifierAPI {
   constructor(private readonly client: LlamaFarm) {}
 
-  async fit(X: number[][], y: (string | number)[], options: Record<string, unknown> = {}): Promise<Record<string, unknown>> {
-    return this.client._req('POST', '/v1/ml/classifier/fit', { X, y, ...options }) as Promise<Record<string, unknown>>
+  /** Fit a text classifier using SetFit few-shot learning. */
+  async fit(model: string, trainingData: { text: string; label: string }[], options: Record<string, unknown> = {}): Promise<Record<string, unknown>> {
+    return this.client._req('POST', '/v1/ml/classifier/fit', { model, training_data: trainingData, ...options }) as Promise<Record<string, unknown>>
   }
 
-  async predict(X: number[][], options: { model?: string } = {}): Promise<Record<string, unknown>> {
-    return this.client._req('POST', '/v1/ml/classifier/predict', { X, ...options }) as Promise<Record<string, unknown>>
+  /** Classify texts using a fitted model. */
+  async predict(model: string, texts: string[], options: Record<string, unknown> = {}): Promise<Record<string, unknown>> {
+    return this.client._req('POST', '/v1/ml/classifier/predict', { model, texts, ...options }) as Promise<Record<string, unknown>>
   }
 
-  async load(modelPath: string): Promise<Record<string, unknown>> {
-    return this.client._req('POST', '/v1/ml/classifier/load', { model_path: modelPath }) as Promise<Record<string, unknown>>
+  async load(model: string): Promise<Record<string, unknown>> {
+    return this.client._req('POST', '/v1/ml/classifier/load', { model }) as Promise<Record<string, unknown>>
   }
 
   async models(): Promise<Record<string, unknown>[]> {

--- a/packages/llamafarm-sdk-ts/src/client.ts
+++ b/packages/llamafarm-sdk-ts/src/client.ts
@@ -1,0 +1,744 @@
+/**
+ * LlamaFarm TypeScript client.
+ *
+ * @alpha — API may change between releases.
+ */
+
+import { ConnectionError, LlamaFarmError, NotFoundError, ServerError, ValidationError } from './errors.js'
+import type {
+  LlamaFarmOptions,
+  ChatMessage,
+  ChatOptions,
+  ChatResponse,
+  StreamChunk,
+  Model,
+  Project,
+  CreateProjectOptions,
+  Detection,
+  DetectResponse,
+  ClassifyResponse,
+  FineTuneJob,
+  CacheStats,
+  RAGQueryRequest,
+  RAGQueryResponse,
+} from './types.js'
+
+const DEFAULT_URL = 'http://localhost:14345'
+const DEFAULT_RUNTIME_URL = 'http://localhost:11540'
+const DEFAULT_TIMEOUT = 120_000
+
+// ======================================================================
+// LlamaFarm Client
+// ======================================================================
+
+export class LlamaFarm {
+  readonly url: string
+  readonly runtimeUrl: string
+  private readonly apiKey?: string
+  private readonly timeoutMs: number
+
+  constructor(options: LlamaFarmOptions = {}) {
+    this.url = (options.url ?? process.env.LLAMAFARM_URL ?? DEFAULT_URL).replace(/\/$/, '')
+    this.runtimeUrl = (options.runtimeUrl ?? process.env.LLAMAFARM_RUNTIME_URL ?? DEFAULT_RUNTIME_URL).replace(/\/$/, '')
+    this.apiKey = options.apiKey ?? process.env.LLAMAFARM_API_KEY
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT
+  }
+
+  // ------------------------------------------------------------------
+  // HTTP helpers
+  // ------------------------------------------------------------------
+
+  private headers(): Record<string, string> {
+    const h: Record<string, string> = { 'Content-Type': 'application/json' }
+    if (this.apiKey) h['Authorization'] = `Bearer ${this.apiKey}`
+    return h
+  }
+
+  private async request(base: string, method: string, path: string, body?: unknown): Promise<unknown> {
+    const url = `${base}${path}`
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs)
+
+    try {
+      const res = await fetch(url, {
+        method,
+        headers: this.headers(),
+        body: body ? JSON.stringify(body) : undefined,
+        signal: controller.signal,
+      })
+      clearTimeout(timer)
+
+      if (!res.ok) {
+        let detail: string
+        try {
+          const err = await res.json() as { detail?: string }
+          detail = err.detail ?? res.statusText
+        } catch {
+          detail = res.statusText
+        }
+        if (res.status === 404) throw new NotFoundError(`Not found: ${detail}`, detail)
+        if (res.status === 422) throw new ValidationError(`Validation error: ${detail}`, detail)
+        if (res.status >= 500) throw new ServerError(`Server error: ${detail}`, res.status, detail)
+        throw new LlamaFarmError(`HTTP ${res.status}: ${detail}`, res.status, detail)
+      }
+
+      return await res.json()
+    } catch (e) {
+      clearTimeout(timer)
+      if (e instanceof LlamaFarmError) throw e
+      if (e instanceof TypeError && (e.message.includes('fetch') || e.message.includes('connect'))) {
+        throw new ConnectionError(`Cannot connect to LlamaFarm at ${base}. Is the server running?`)
+      }
+      throw e
+    }
+  }
+
+  private req(method: string, path: string, body?: unknown) {
+    return this.request(this.url, method, path, body)
+  }
+
+  private runtimeReq(method: string, path: string, body?: unknown) {
+    return this.request(this.runtimeUrl, method, path, body)
+  }
+
+  // ------------------------------------------------------------------
+  // Health
+  // ------------------------------------------------------------------
+
+  async health(): Promise<Record<string, unknown>> {
+    return this.req('GET', '/health') as Promise<Record<string, unknown>>
+  }
+
+  // ------------------------------------------------------------------
+  // Models
+  // ------------------------------------------------------------------
+
+  async models(): Promise<Model[]> {
+    const data = await this.req('GET', '/v1/models') as { data?: Model[]; models?: Model[] }
+    return data.data ?? data.models ?? []
+  }
+
+  // ------------------------------------------------------------------
+  // Projects
+  // ------------------------------------------------------------------
+
+  async createProject(namespace: string, name: string, options: CreateProjectOptions = {}): Promise<ProjectHandle> {
+    await this.req('POST', `/v1/projects/${namespace}`, {
+      name,
+      config_template: options.configTemplate ?? null,
+    })
+    return new ProjectHandle(this, namespace, name)
+  }
+
+  project(namespace: string, projectId: string): ProjectHandle {
+    return new ProjectHandle(this, namespace, projectId)
+  }
+
+  async projects(namespace: string): Promise<Project[]> {
+    const data = await this.req('GET', `/v1/projects/${namespace}`) as { projects?: Project[] }
+    return data.projects ?? []
+  }
+
+  // ------------------------------------------------------------------
+  // Vision (server-level)
+  // ------------------------------------------------------------------
+
+  get vision(): VisionAPI {
+    return new VisionAPI(this)
+  }
+
+  // ------------------------------------------------------------------
+  // Fine-Tuning (runtime-level)
+  // ------------------------------------------------------------------
+
+  get finetune(): FineTuneAPI {
+    return new FineTuneAPI(this)
+  }
+
+  // ------------------------------------------------------------------
+  // Cache (runtime-level)
+  // ------------------------------------------------------------------
+
+  get cache(): CacheAPI {
+    return new CacheAPI(this)
+  }
+
+  // ------------------------------------------------------------------
+  // OpenAI Compatibility
+  // ------------------------------------------------------------------
+
+  /** Base URL for use with the OpenAI SDK. */
+  get openaiBaseUrl(): string { return `${this.runtimeUrl}/v1` }
+
+  // ------------------------------------------------------------------
+  // NLP
+  // ------------------------------------------------------------------
+
+  get nlp(): NLPAPI { return new NLPAPI(this) }
+
+  // ------------------------------------------------------------------
+  // Anomaly Detection
+  // ------------------------------------------------------------------
+
+  get anomaly(): AnomalyAPI { return new AnomalyAPI(this) }
+
+  // ------------------------------------------------------------------
+  // Classifier
+  // ------------------------------------------------------------------
+
+  get classifier(): ClassifierAPI { return new ClassifierAPI(this) }
+
+  // ------------------------------------------------------------------
+  // Time Series
+  // ------------------------------------------------------------------
+
+  get timeseries(): TimeSeriesAPI { return new TimeSeriesAPI(this) }
+
+  // ------------------------------------------------------------------
+  // ADTK
+  // ------------------------------------------------------------------
+
+  get adtk(): ADTKAPI { return new ADTKAPI(this) }
+
+  // ------------------------------------------------------------------
+  // CatBoost
+  // ------------------------------------------------------------------
+
+  get catboost(): CatBoostAPI { return new CatBoostAPI(this) }
+
+  // ------------------------------------------------------------------
+  // Drift Detection
+  // ------------------------------------------------------------------
+
+  get drift(): DriftAPI { return new DriftAPI(this) }
+
+  // ------------------------------------------------------------------
+  // Explainability
+  // ------------------------------------------------------------------
+
+  get explain(): ExplainAPI { return new ExplainAPI(this) }
+
+  // ------------------------------------------------------------------
+  // Polars Data Processing
+  // ------------------------------------------------------------------
+
+  get polars(): PolarsAPI { return new PolarsAPI(this) }
+
+  /** @internal */
+  _req(method: string, path: string, body?: unknown) { return this.req(method, path, body) }
+  /** @internal */
+  _runtimeReq(method: string, path: string, body?: unknown) { return this.runtimeReq(method, path, body) }
+  /** @internal */
+  async _stream(path: string, body: unknown): Promise<ReadableStream<StreamChunk>> {
+    const url = `${this.url}${path}`
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: this.headers(),
+      body: JSON.stringify(body),
+    })
+    if (!res.ok || !res.body) throw new ServerError('Stream failed', res.status)
+
+    const reader = res.body.getReader()
+    const decoder = new TextDecoder()
+    let buffer = ''
+
+    return new ReadableStream<StreamChunk>({
+      async pull(controller) {
+        const { done, value } = await reader.read()
+        if (done) { controller.close(); return }
+
+        buffer += decoder.decode(value, { stream: true })
+        const lines = buffer.split('\n')
+        buffer = lines.pop() ?? ''
+
+        for (const line of lines) {
+          const trimmed = line.trim()
+          if (!trimmed.startsWith('data: ')) continue
+          const data = trimmed.slice(6)
+          if (data === '[DONE]') { controller.close(); return }
+          try {
+            const parsed = JSON.parse(data)
+            const choices = parsed.choices ?? []
+            if (choices.length > 0) {
+              controller.enqueue({
+                content: choices[0].delta?.content ?? '',
+                finish_reason: choices[0].finish_reason ?? null,
+                model: parsed.model ?? '',
+                x_cache: parsed.x_cache,
+              })
+            }
+          } catch { /* skip malformed */ }
+        }
+      }
+    })
+  }
+}
+
+// ======================================================================
+// ProjectHandle
+// ======================================================================
+
+export class ProjectHandle {
+  constructor(
+    private readonly client: LlamaFarm,
+    readonly namespace: string,
+    readonly projectId: string,
+  ) {}
+
+  private path(suffix: string): string {
+    return `/v1/projects/${this.namespace}/${this.projectId}${suffix}`
+  }
+
+  // Chat
+  async chat(message: string | ChatMessage[], options: ChatOptions = {}): Promise<ChatResponse> {
+    const messages = typeof message === 'string'
+      ? [{ role: 'user' as const, content: message }]
+      : message
+
+    const body: Record<string, unknown> = { messages, stream: false }
+    if (options.model) body.model = options.model
+    if (options.temperature != null) body.temperature = options.temperature
+    if (options.max_tokens != null) body.max_tokens = options.max_tokens
+    if (options.tools) body.tools = options.tools
+    if (options.cache_key) body.cache_key = options.cache_key
+    if (options.return_cache_key) body.return_cache_key = true
+
+    const headers: Record<string, string> = {}
+    if (options.session_id) headers['X-Session-ID'] = options.session_id
+    if (options.stateless) headers['X-No-Session'] = 'true'
+
+    const data = await this.client._req('POST', this.path('/chat/completions'), body) as ChatResponse
+    return {
+      ...data,
+      get text() { return data.choices?.[0]?.message?.content ?? '' },
+    }
+  }
+
+  async chatStream(message: string | ChatMessage[], options: ChatOptions = {}): Promise<ReadableStream<StreamChunk>> {
+    const messages = typeof message === 'string'
+      ? [{ role: 'user' as const, content: message }]
+      : message
+
+    const body: Record<string, unknown> = { messages, stream: true }
+    if (options.model) body.model = options.model
+    if (options.temperature != null) body.temperature = options.temperature
+    if (options.max_tokens != null) body.max_tokens = options.max_tokens
+
+    return this.client._stream(this.path('/chat/completions'), body)
+  }
+
+  // RAG
+  get rag(): RAGAPI {
+    return new RAGAPI(this.client, this.namespace, this.projectId)
+  }
+
+  // Datasets
+  get datasets(): DatasetsAPI {
+    return new DatasetsAPI(this.client, this.namespace, this.projectId)
+  }
+
+  // Delete
+  async delete(): Promise<void> {
+    await this.client._req('DELETE', this.path(''))
+  }
+}
+
+// ======================================================================
+// Sub-APIs
+// ======================================================================
+
+class VisionAPI {
+  constructor(private readonly client: LlamaFarm) {}
+
+  async detect(imageBase64: string, options: { model?: string; confidence?: number; classes?: string[] } = {}): Promise<DetectResponse> {
+    const body: Record<string, unknown> = { image: imageBase64, model: options.model ?? 'yolov8n', confidence_threshold: options.confidence ?? 0.5 }
+    if (options.classes) body.classes = options.classes
+    const data = await this.client._req('POST', '/v1/vision/detect', body) as Record<string, unknown>
+    return {
+      detections: (data.detections ?? data.boxes ?? []) as Detection[],
+      model: (data.model ?? options.model ?? 'yolov8n') as string,
+      time_ms: (data.time_ms ?? data.detection_time_ms ?? 0) as number,
+    }
+  }
+
+  async classify(imageBase64: string, classes: string[], options: { model?: string; topK?: number } = {}): Promise<ClassifyResponse> {
+    const data = await this.client._req('POST', '/v1/vision/classify', {
+      image: imageBase64, model: options.model ?? 'clip-vit-base', classes, top_k: options.topK ?? 3,
+    }) as Record<string, unknown>
+    return {
+      classification: (data.class_name ? data : null) as ClassifyResponse['classification'],
+      model: (data.model ?? '') as string,
+      time_ms: (data.time_ms ?? 0) as number,
+    }
+  }
+}
+
+class FineTuneAPI {
+  constructor(private readonly client: LlamaFarm) {}
+
+  async sft(model: string, dataset: Record<string, unknown>[], options: Record<string, unknown> = {}): Promise<FineTuneJob> {
+    return this.client._runtimeReq('POST', '/v1/finetune/sft', { model, dataset, ...options }) as Promise<FineTuneJob>
+  }
+
+  async cpt(model: string, dataset: Record<string, unknown>[], options: Record<string, unknown> = {}): Promise<FineTuneJob> {
+    return this.client._runtimeReq('POST', '/v1/finetune/cpt', { model, dataset, ...options }) as Promise<FineTuneJob>
+  }
+
+  async status(jobId: string): Promise<FineTuneJob> {
+    return this.client._runtimeReq('GET', `/v1/finetune/jobs/${jobId}`) as Promise<FineTuneJob>
+  }
+
+  async jobs(): Promise<FineTuneJob[]> {
+    const data = await this.client._runtimeReq('GET', '/v1/finetune/jobs') as { jobs?: FineTuneJob[] }
+    return data.jobs ?? []
+  }
+
+  async cancel(jobId: string): Promise<FineTuneJob> {
+    return this.client._runtimeReq('DELETE', `/v1/finetune/jobs/${jobId}`) as Promise<FineTuneJob>
+  }
+
+  async validate(dataset: Record<string, unknown>[], format?: string): Promise<Record<string, unknown>> {
+    const body: Record<string, unknown> = { dataset }
+    if (format) body.dataset_format = format
+    return this.client._runtimeReq('POST', '/v1/finetune/validate', body) as Promise<Record<string, unknown>>
+  }
+
+  async templates(): Promise<string[]> {
+    const data = await this.client._runtimeReq('GET', '/v1/finetune/templates') as { templates?: string[] }
+    return data.templates ?? []
+  }
+}
+
+class CacheAPI {
+  constructor(private readonly client: LlamaFarm) {}
+
+  async prepare(messages: ChatMessage[], options: { model?: string; tools?: Record<string, unknown>[]; warm?: boolean } = {}): Promise<Record<string, unknown>> {
+    return this.client._runtimeReq('POST', '/v1/cache/prepare', { messages, warm: options.warm ?? true, ...options }) as Promise<Record<string, unknown>>
+  }
+
+  async stats(): Promise<CacheStats> {
+    return this.client._runtimeReq('GET', '/v1/cache/stats') as Promise<CacheStats>
+  }
+
+  async gc(): Promise<Record<string, unknown>> {
+    return this.client._runtimeReq('POST', '/v1/cache/gc') as Promise<Record<string, unknown>>
+  }
+
+  async clear(key: string): Promise<Record<string, unknown>> {
+    return this.client._runtimeReq('DELETE', `/v1/cache/${key}`) as Promise<Record<string, unknown>>
+  }
+}
+
+class RAGAPI {
+  constructor(
+    private readonly client: LlamaFarm,
+    private readonly namespace: string,
+    private readonly project: string,
+  ) {}
+
+  private path(suffix: string): string {
+    return `/v1/projects/${this.namespace}/${this.project}/rag${suffix}`
+  }
+
+  async query(request: RAGQueryRequest): Promise<RAGQueryResponse> {
+    return this.client._req('POST', this.path('/query'), request) as Promise<RAGQueryResponse>
+  }
+
+  async health(): Promise<Record<string, unknown>> {
+    return this.client._req('GET', this.path('/health')) as Promise<Record<string, unknown>>
+  }
+
+  async stats(): Promise<Record<string, unknown>> {
+    return this.client._req('GET', this.path('/stats')) as Promise<Record<string, unknown>>
+  }
+
+  async databases(): Promise<Record<string, unknown>[]> {
+    const data = await this.client._req('GET', this.path('/databases')) as { databases?: Record<string, unknown>[] }
+    return data.databases ?? []
+  }
+}
+
+// ======================================================================
+// NLP API
+// ======================================================================
+
+class NLPAPI {
+  constructor(private readonly client: LlamaFarm) {}
+
+  async embeddings(input: string | string[], options: { model?: string } = {}): Promise<Record<string, unknown>> {
+    return this.client._req('POST', '/v1/nlp/embeddings', { input, ...options }) as Promise<Record<string, unknown>>
+  }
+
+  async classify(text: string, labels: string[], options: { model?: string; multi_label?: boolean } = {}): Promise<Record<string, unknown>> {
+    return this.client._req('POST', '/v1/nlp/classify', { text, labels, ...options }) as Promise<Record<string, unknown>>
+  }
+
+  async ner(text: string, options: { model?: string } = {}): Promise<Record<string, unknown>> {
+    return this.client._req('POST', '/v1/nlp/ner', { text, ...options }) as Promise<Record<string, unknown>>
+  }
+
+  async rerank(query: string, documents: string[], options: { model?: string; top_k?: number } = {}): Promise<Record<string, unknown>> {
+    return this.client._req('POST', '/v1/nlp/rerank', { query, documents, ...options }) as Promise<Record<string, unknown>>
+  }
+}
+
+// ======================================================================
+// Anomaly Detection API
+// ======================================================================
+
+class AnomalyAPI {
+  constructor(private readonly client: LlamaFarm) {}
+
+  async fit(data: number[][], options: Record<string, unknown> = {}): Promise<Record<string, unknown>> {
+    return this.client._req('POST', '/v1/ml/anomaly/fit', { data, ...options }) as Promise<Record<string, unknown>>
+  }
+
+  async detect(data: number[][], options: { model?: string; explain?: boolean } = {}): Promise<Record<string, unknown>> {
+    return this.client._req('POST', '/v1/ml/anomaly/detect', { data, ...options }) as Promise<Record<string, unknown>>
+  }
+
+  async score(data: number[][], options: { model?: string } = {}): Promise<Record<string, unknown>> {
+    return this.client._req('POST', '/v1/ml/anomaly/score', { data, ...options }) as Promise<Record<string, unknown>>
+  }
+
+  async load(modelPath: string): Promise<Record<string, unknown>> {
+    return this.client._req('POST', '/v1/ml/anomaly/load', { model_path: modelPath }) as Promise<Record<string, unknown>>
+  }
+
+  async models(): Promise<Record<string, unknown>[]> {
+    const data = await this.client._req('GET', '/v1/ml/anomaly/models') as Record<string, unknown>
+    return (data.models ?? data) as Record<string, unknown>[]
+  }
+
+  async backends(): Promise<Record<string, unknown>[]> {
+    const data = await this.client._req('GET', '/v1/ml/anomaly/backends') as Record<string, unknown>
+    return (data.backends ?? data) as Record<string, unknown>[]
+  }
+}
+
+// ======================================================================
+// Classifier API
+// ======================================================================
+
+class ClassifierAPI {
+  constructor(private readonly client: LlamaFarm) {}
+
+  async fit(X: number[][], y: (string | number)[], options: Record<string, unknown> = {}): Promise<Record<string, unknown>> {
+    return this.client._req('POST', '/v1/ml/classifier/fit', { X, y, ...options }) as Promise<Record<string, unknown>>
+  }
+
+  async predict(X: number[][], options: { model?: string } = {}): Promise<Record<string, unknown>> {
+    return this.client._req('POST', '/v1/ml/classifier/predict', { X, ...options }) as Promise<Record<string, unknown>>
+  }
+
+  async load(modelPath: string): Promise<Record<string, unknown>> {
+    return this.client._req('POST', '/v1/ml/classifier/load', { model_path: modelPath }) as Promise<Record<string, unknown>>
+  }
+
+  async models(): Promise<Record<string, unknown>[]> {
+    const data = await this.client._req('GET', '/v1/ml/classifier/models') as Record<string, unknown>
+    return (data.models ?? data) as Record<string, unknown>[]
+  }
+}
+
+// ======================================================================
+// Time Series API
+// ======================================================================
+
+class TimeSeriesAPI {
+  constructor(private readonly client: LlamaFarm) {}
+
+  async fit(data: number[], options: Record<string, unknown> = {}): Promise<Record<string, unknown>> {
+    return this.client._req('POST', '/v1/timeseries/fit', { data, ...options }) as Promise<Record<string, unknown>>
+  }
+
+  async predict(steps: number, options: { model?: string } = {}): Promise<Record<string, unknown>> {
+    return this.client._req('POST', '/v1/timeseries/predict', { steps, ...options }) as Promise<Record<string, unknown>>
+  }
+
+  async load(modelPath: string): Promise<Record<string, unknown>> {
+    return this.client._req('POST', '/v1/timeseries/load', { model_path: modelPath }) as Promise<Record<string, unknown>>
+  }
+
+  async models(): Promise<Record<string, unknown>[]> {
+    const data = await this.client._req('GET', '/v1/timeseries/models') as Record<string, unknown>
+    return (data.models ?? data) as Record<string, unknown>[]
+  }
+
+  async backends(): Promise<Record<string, unknown>[]> {
+    const data = await this.client._req('GET', '/v1/timeseries/backends') as Record<string, unknown>
+    return (data.backends ?? data) as Record<string, unknown>[]
+  }
+}
+
+// ======================================================================
+// ADTK API
+// ======================================================================
+
+class ADTKAPI {
+  constructor(private readonly client: LlamaFarm) {}
+
+  async fit(data: number[], options: Record<string, unknown> = {}): Promise<Record<string, unknown>> {
+    return this.client._req('POST', '/v1/adtk/fit', { data, ...options }) as Promise<Record<string, unknown>>
+  }
+
+  async detect(data: number[], options: { model?: string } = {}): Promise<Record<string, unknown>> {
+    return this.client._req('POST', '/v1/adtk/detect', { data, ...options }) as Promise<Record<string, unknown>>
+  }
+
+  async load(modelPath: string): Promise<Record<string, unknown>> {
+    return this.client._req('POST', '/v1/adtk/load', { model_path: modelPath }) as Promise<Record<string, unknown>>
+  }
+
+  async models(): Promise<Record<string, unknown>[]> {
+    const data = await this.client._req('GET', '/v1/adtk/models') as Record<string, unknown>
+    return (data.models ?? data) as Record<string, unknown>[]
+  }
+
+  async detectors(): Promise<Record<string, unknown>[]> {
+    const data = await this.client._req('GET', '/v1/adtk/detectors') as Record<string, unknown>
+    return (data.detectors ?? data) as Record<string, unknown>[]
+  }
+}
+
+// ======================================================================
+// CatBoost API
+// ======================================================================
+
+class CatBoostAPI {
+  constructor(private readonly client: LlamaFarm) {}
+
+  async fit(X: number[][], y: (string | number)[], options: Record<string, unknown> = {}): Promise<Record<string, unknown>> {
+    return this.client._req('POST', '/v1/catboost/fit', { X, y, ...options }) as Promise<Record<string, unknown>>
+  }
+
+  async predict(X: number[][], options: { model?: string } = {}): Promise<Record<string, unknown>> {
+    return this.client._req('POST', '/v1/catboost/predict', { X, ...options }) as Promise<Record<string, unknown>>
+  }
+
+  async load(modelPath: string): Promise<Record<string, unknown>> {
+    return this.client._req('POST', '/v1/catboost/load', { model_path: modelPath }) as Promise<Record<string, unknown>>
+  }
+
+  async update(X: number[][], y: (string | number)[], options: { model?: string } = {}): Promise<Record<string, unknown>> {
+    return this.client._req('POST', '/v1/catboost/update', { X, y, ...options }) as Promise<Record<string, unknown>>
+  }
+
+  async models(): Promise<Record<string, unknown>[]> {
+    const data = await this.client._req('GET', '/v1/catboost/models') as Record<string, unknown>
+    return (data.models ?? data) as Record<string, unknown>[]
+  }
+
+  async info(): Promise<Record<string, unknown>> {
+    return this.client._req('GET', '/v1/catboost/info') as Promise<Record<string, unknown>>
+  }
+
+  async importance(modelId: string): Promise<Record<string, unknown>> {
+    return this.client._req('GET', `/v1/catboost/${modelId}/importance`) as Promise<Record<string, unknown>>
+  }
+}
+
+// ======================================================================
+// Drift Detection API
+// ======================================================================
+
+class DriftAPI {
+  constructor(private readonly client: LlamaFarm) {}
+
+  async fit(referenceData: number[][], options: Record<string, unknown> = {}): Promise<Record<string, unknown>> {
+    return this.client._req('POST', '/v1/drift/fit', { reference_data: referenceData, ...options }) as Promise<Record<string, unknown>>
+  }
+
+  async detect(data: number[][], options: { model?: string } = {}): Promise<Record<string, unknown>> {
+    return this.client._req('POST', '/v1/drift/detect', { data, ...options }) as Promise<Record<string, unknown>>
+  }
+
+  async load(modelPath: string): Promise<Record<string, unknown>> {
+    return this.client._req('POST', '/v1/drift/load', { model_path: modelPath }) as Promise<Record<string, unknown>>
+  }
+
+  async models(): Promise<Record<string, unknown>[]> {
+    const data = await this.client._req('GET', '/v1/drift/models') as Record<string, unknown>
+    return (data.models ?? data) as Record<string, unknown>[]
+  }
+
+  async detectors(): Promise<Record<string, unknown>[]> {
+    const data = await this.client._req('GET', '/v1/drift/detectors') as Record<string, unknown>
+    return (data.detectors ?? data) as Record<string, unknown>[]
+  }
+
+  async status(modelName: string): Promise<Record<string, unknown>> {
+    return this.client._req('GET', `/v1/drift/status/${modelName}`) as Promise<Record<string, unknown>>
+  }
+}
+
+// ======================================================================
+// Explainability API
+// ======================================================================
+
+class ExplainAPI {
+  constructor(private readonly client: LlamaFarm) {}
+
+  async shap(data: number[][], options: Record<string, unknown> = {}): Promise<Record<string, unknown>> {
+    return this.client._req('POST', '/v1/explain/shap', { data, ...options }) as Promise<Record<string, unknown>>
+  }
+
+  async importance(data: number[][], options: Record<string, unknown> = {}): Promise<Record<string, unknown>> {
+    return this.client._req('POST', '/v1/explain/importance', { data, ...options }) as Promise<Record<string, unknown>>
+  }
+
+  async explainers(): Promise<Record<string, unknown>[]> {
+    const data = await this.client._req('GET', '/v1/explain/explainers') as Record<string, unknown>
+    return (data.explainers ?? data) as Record<string, unknown>[]
+  }
+}
+
+// ======================================================================
+// Polars Data Processing API
+// ======================================================================
+
+class PolarsAPI {
+  constructor(private readonly client: LlamaFarm) {}
+
+  async createBuffer(options: Record<string, unknown> = {}): Promise<Record<string, unknown>> {
+    return this.client._req('POST', '/v1/ml/polars/buffers', options) as Promise<Record<string, unknown>>
+  }
+
+  async append(bufferId: string, data: Record<string, unknown>[]): Promise<Record<string, unknown>> {
+    return this.client._req('POST', '/v1/ml/polars/append', { buffer_id: bufferId, data }) as Promise<Record<string, unknown>>
+  }
+
+  async features(bufferId: string, options: Record<string, unknown> = {}): Promise<Record<string, unknown>> {
+    return this.client._req('POST', '/v1/ml/polars/features', { buffer_id: bufferId, ...options }) as Promise<Record<string, unknown>>
+  }
+
+  async buffers(): Promise<Record<string, unknown>[]> {
+    const data = await this.client._req('GET', '/v1/ml/polars/buffers') as Record<string, unknown>
+    return (data.buffers ?? data) as Record<string, unknown>[]
+  }
+
+  async buffer(bufferId: string): Promise<Record<string, unknown>> {
+    return this.client._req('GET', `/v1/ml/polars/buffers/${bufferId}`) as Promise<Record<string, unknown>>
+  }
+
+  async bufferData(bufferId: string): Promise<Record<string, unknown>> {
+    return this.client._req('GET', `/v1/ml/polars/buffers/${bufferId}/data`) as Promise<Record<string, unknown>>
+  }
+}
+
+class DatasetsAPI {
+  constructor(
+    private readonly client: LlamaFarm,
+    private readonly namespace: string,
+    private readonly project: string,
+  ) {}
+
+  private path(suffix: string): string {
+    return `/v1/projects/${this.namespace}/${this.project}/datasets${suffix}`
+  }
+
+  async list(): Promise<Record<string, unknown>[]> {
+    const data = await this.client._req('GET', this.path('')) as { datasets?: Record<string, unknown>[] }
+    return data.datasets ?? (Array.isArray(data) ? data : []) as Record<string, unknown>[]
+  }
+}

--- a/packages/llamafarm-sdk-ts/src/errors.ts
+++ b/packages/llamafarm-sdk-ts/src/errors.ts
@@ -1,0 +1,44 @@
+/** Base error for all LlamaFarm SDK errors. */
+export class LlamaFarmError extends Error {
+  readonly statusCode?: number
+  readonly detail?: string
+
+  constructor(message: string, statusCode?: number, detail?: string) {
+    super(message)
+    this.name = 'LlamaFarmError'
+    this.statusCode = statusCode
+    this.detail = detail
+  }
+}
+
+/** Cannot connect to LlamaFarm server. */
+export class ConnectionError extends LlamaFarmError {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ConnectionError'
+  }
+}
+
+/** Resource not found (project, model, job, etc.). */
+export class NotFoundError extends LlamaFarmError {
+  constructor(message: string, detail?: string) {
+    super(message, 404, detail)
+    this.name = 'NotFoundError'
+  }
+}
+
+/** Request validation failed. */
+export class ValidationError extends LlamaFarmError {
+  constructor(message: string, detail?: string) {
+    super(message, 422, detail)
+    this.name = 'ValidationError'
+  }
+}
+
+/** Server-side error. */
+export class ServerError extends LlamaFarmError {
+  constructor(message: string, statusCode?: number, detail?: string) {
+    super(message, statusCode ?? 500, detail)
+    this.name = 'ServerError'
+  }
+}

--- a/packages/llamafarm-sdk-ts/src/index.ts
+++ b/packages/llamafarm-sdk-ts/src/index.ts
@@ -1,0 +1,38 @@
+/**
+ * LlamaFarm TypeScript SDK — local AI infrastructure client.
+ *
+ * @example
+ * ```ts
+ * import { LlamaFarm } from 'llamafarm'
+ *
+ * const lf = new LlamaFarm()
+ * const project = await lf.createProject('default', 'my-app', { model: 'Qwen/Qwen3-8B' })
+ * const response = await project.chat('Hello!')
+ * console.log(response.text)
+ * ```
+ *
+ * @alpha
+ * @packageDocumentation
+ */
+
+export { LlamaFarm } from './client.js'
+export type {
+  LlamaFarmOptions,
+  ChatMessage,
+  ChatResponse,
+  ChatChoice,
+  StreamChunk,
+  Model,
+  Project,
+  ProjectConfig,
+  Detection,
+  Classification,
+  DetectResponse,
+  ClassifyResponse,
+  FineTuneJob,
+  CacheStats,
+  RAGQueryRequest,
+  RAGQueryResponse,
+  RAGQueryResult,
+} from './types.js'
+export { LlamaFarmError, ConnectionError, NotFoundError, ValidationError, ServerError } from './errors.js'

--- a/packages/llamafarm-sdk-ts/src/types.ts
+++ b/packages/llamafarm-sdk-ts/src/types.ts
@@ -1,0 +1,215 @@
+// ---------------------------------------------------------------------------
+// Client
+// ---------------------------------------------------------------------------
+
+/** Options for creating a LlamaFarm client. */
+export interface LlamaFarmOptions {
+  /** Server URL (auto-discovered if not provided). */
+  url?: string
+  /** Universal Runtime URL for direct access (fine-tuning, cache). */
+  runtimeUrl?: string
+  /** API key for authentication. */
+  apiKey?: string
+  /** Request timeout in milliseconds. */
+  timeoutMs?: number
+}
+
+// ---------------------------------------------------------------------------
+// Chat
+// ---------------------------------------------------------------------------
+
+export interface ChatMessage {
+  role: 'system' | 'user' | 'assistant' | 'tool'
+  content: string
+  name?: string
+  tool_calls?: Record<string, unknown>[]
+  tool_call_id?: string
+}
+
+export interface ChatChoice {
+  index: number
+  message: ChatMessage
+  finish_reason: string | null
+}
+
+export interface ChatUsage {
+  prompt_tokens: number
+  completion_tokens: number
+  total_tokens: number
+}
+
+export interface ChatResponse {
+  id: string
+  object: string
+  model: string
+  choices: ChatChoice[]
+  usage: ChatUsage
+  /** LlamaFarm KV cache info. */
+  x_cache?: Record<string, unknown>
+  /** Shortcut: first choice content. */
+  readonly text: string
+}
+
+export interface StreamChunk {
+  content: string
+  finish_reason: string | null
+  model: string
+  x_cache?: Record<string, unknown>
+}
+
+export interface ChatOptions {
+  model?: string
+  temperature?: number
+  max_tokens?: number
+  tools?: Record<string, unknown>[]
+  /** KV cache key from a previous response. */
+  cache_key?: string
+  /** Request a cache key in the response. */
+  return_cache_key?: boolean
+  /** Session ID for stateful conversations. */
+  session_id?: string
+  /** Stateless mode (no session persistence). */
+  stateless?: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Models
+// ---------------------------------------------------------------------------
+
+export interface Model {
+  id: string
+  object: string
+  owned_by: string
+  type?: string
+  size_bytes?: number
+  context_length?: number
+  loaded: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Projects
+// ---------------------------------------------------------------------------
+
+export interface ProjectConfig {
+  model: string
+  provider: string
+  system_prompt: string
+  temperature: number
+  max_tokens?: number
+  tools: Record<string, unknown>[]
+  rag?: Record<string, unknown>
+}
+
+export interface Project {
+  namespace: string
+  name: string
+  config: ProjectConfig | Record<string, unknown>
+  validation_error?: string
+  last_modified?: string
+}
+
+export interface CreateProjectOptions {
+  /** Model name (e.g., "Qwen/Qwen3-8B"). */
+  model?: string
+  /** System prompt. */
+  systemPrompt?: string
+  /** Config template name. */
+  configTemplate?: string
+  /** Sampling temperature. */
+  temperature?: number
+}
+
+// ---------------------------------------------------------------------------
+// Vision
+// ---------------------------------------------------------------------------
+
+export interface Detection {
+  x1: number
+  y1: number
+  x2: number
+  y2: number
+  class_name: string
+  class_id: number
+  confidence: number
+}
+
+export interface Classification {
+  class_name: string
+  confidence: number
+  all_scores: Record<string, number>
+}
+
+export interface DetectResponse {
+  detections: Detection[]
+  model: string
+  time_ms: number
+}
+
+export interface ClassifyResponse {
+  classification: Classification | null
+  model: string
+  time_ms: number
+}
+
+// ---------------------------------------------------------------------------
+// Fine-Tuning
+// ---------------------------------------------------------------------------
+
+export interface FineTuneJob {
+  job_id: string
+  status: 'queued' | 'running' | 'completed' | 'failed' | 'cancelled'
+  type: 'sft' | 'cpt'
+  model: string
+  progress: number
+  metrics?: Record<string, unknown>
+  output_dir?: string
+  error?: string
+  created_at: number
+  started_at?: number
+  completed_at?: number
+}
+
+// ---------------------------------------------------------------------------
+// Cache
+// ---------------------------------------------------------------------------
+
+export interface CacheStats {
+  entries: number
+  total_bytes: number
+  hit_rate: number
+  ram_bytes: number
+  disk_bytes: number
+}
+
+// ---------------------------------------------------------------------------
+// RAG
+// ---------------------------------------------------------------------------
+
+export interface RAGQueryRequest {
+  query: string
+  database?: string
+  retrieval_strategy?: string
+  top_k?: number
+  score_threshold?: number
+  metadata_filters?: Record<string, unknown>
+  hybrid_alpha?: number
+  rerank_model?: string
+  query_expansion?: boolean
+}
+
+export interface RAGQueryResult {
+  content: string
+  score: number
+  metadata: Record<string, unknown>
+  chunk_id?: string
+  document_id?: string
+}
+
+export interface RAGQueryResponse {
+  query: string
+  results: RAGQueryResult[]
+  total_results: number
+  processing_time_ms?: number
+  retrieval_strategy_used: string
+  database_used: string
+}

--- a/packages/llamafarm-sdk-ts/tests/client.test.ts
+++ b/packages/llamafarm-sdk-ts/tests/client.test.ts
@@ -1,0 +1,595 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { LlamaFarm } from '../src/client.js'
+import { LlamaFarmError, ConnectionError, NotFoundError, ValidationError, ServerError } from '../src/errors.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mockFetch(status: number, body: unknown, headers?: Record<string, string>) {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: `Status ${status}`,
+    headers: new Headers(headers),
+    json: () => Promise.resolve(body),
+    body: null,
+  })
+}
+
+function mockStream(chunks: string[]) {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    body: new ReadableStream({
+      start(controller) {
+        for (const c of chunks) controller.enqueue(new TextEncoder().encode(c))
+        controller.close()
+      },
+    }),
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Constructor & Discovery
+// ---------------------------------------------------------------------------
+
+describe('LlamaFarm constructor', () => {
+  const orig = process.env
+
+  beforeEach(() => { process.env = { ...orig } })
+  afterEach(() => { process.env = orig })
+
+  it('uses defaults', () => {
+    const lf = new LlamaFarm()
+    expect(lf.url).toBe('http://localhost:14345')
+    expect(lf.runtimeUrl).toBe('http://localhost:11540')
+  })
+
+  it('reads env vars', () => {
+    process.env.LLAMAFARM_URL = 'http://my-server:9000/'
+    process.env.LLAMAFARM_RUNTIME_URL = 'http://my-runtime:9001/'
+    const lf = new LlamaFarm()
+    expect(lf.url).toBe('http://my-server:9000')
+    expect(lf.runtimeUrl).toBe('http://my-runtime:9001')
+  })
+
+  it('explicit options override env', () => {
+    process.env.LLAMAFARM_URL = 'http://env:1'
+    const lf = new LlamaFarm({ url: 'http://opt:2' })
+    expect(lf.url).toBe('http://opt:2')
+  })
+
+  it('strips trailing slash', () => {
+    const lf = new LlamaFarm({ url: 'http://host:1234/' })
+    expect(lf.url).toBe('http://host:1234')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Error handling
+// ---------------------------------------------------------------------------
+
+describe('error handling', () => {
+  it('throws NotFoundError on 404', async () => {
+    vi.stubGlobal('fetch', mockFetch(404, { detail: 'gone' }))
+    const lf = new LlamaFarm()
+    await expect(lf.health()).rejects.toThrow(NotFoundError)
+    vi.unstubAllGlobals()
+  })
+
+  it('throws ValidationError on 422', async () => {
+    vi.stubGlobal('fetch', mockFetch(422, { detail: 'bad input' }))
+    const lf = new LlamaFarm()
+    await expect(lf.health()).rejects.toThrow(ValidationError)
+    vi.unstubAllGlobals()
+  })
+
+  it('throws ServerError on 500', async () => {
+    vi.stubGlobal('fetch', mockFetch(500, { detail: 'boom' }))
+    const lf = new LlamaFarm()
+    await expect(lf.health()).rejects.toThrow(ServerError)
+    vi.unstubAllGlobals()
+  })
+
+  it('error hierarchy extends LlamaFarmError', () => {
+    expect(new NotFoundError('x')).toBeInstanceOf(LlamaFarmError)
+    expect(new ValidationError('x')).toBeInstanceOf(LlamaFarmError)
+    expect(new ServerError('x')).toBeInstanceOf(LlamaFarmError)
+    expect(new ConnectionError('x')).toBeInstanceOf(LlamaFarmError)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Health
+// ---------------------------------------------------------------------------
+
+describe('health', () => {
+  it('returns health data', async () => {
+    vi.stubGlobal('fetch', mockFetch(200, { status: 'ok', version: '0.0.27' }))
+    const lf = new LlamaFarm()
+    const h = await lf.health()
+    expect(h.status).toBe('ok')
+    vi.unstubAllGlobals()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Models
+// ---------------------------------------------------------------------------
+
+describe('models', () => {
+  it('parses models list (data key)', async () => {
+    vi.stubGlobal('fetch', mockFetch(200, { data: [{ id: 'qwen3-8b', object: 'model', owned_by: 'local', loaded: true }] }))
+    const lf = new LlamaFarm()
+    const models = await lf.models()
+    expect(models).toHaveLength(1)
+    expect(models[0].id).toBe('qwen3-8b')
+    vi.unstubAllGlobals()
+  })
+
+  it('handles models key fallback', async () => {
+    vi.stubGlobal('fetch', mockFetch(200, { models: [{ id: 'phi-4' }] }))
+    const lf = new LlamaFarm()
+    const models = await lf.models()
+    expect(models[0].id).toBe('phi-4')
+    vi.unstubAllGlobals()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Projects
+// ---------------------------------------------------------------------------
+
+describe('projects', () => {
+  it('creates project and returns handle', async () => {
+    vi.stubGlobal('fetch', mockFetch(200, { name: 'my-app' }))
+    const lf = new LlamaFarm()
+    const p = await lf.createProject('default', 'my-app')
+    expect(p.namespace).toBe('default')
+    expect(p.projectId).toBe('my-app')
+    vi.unstubAllGlobals()
+  })
+
+  it('project() returns lazy handle (no API call)', () => {
+    const lf = new LlamaFarm()
+    const p = lf.project('ns', 'pid')
+    expect(p.namespace).toBe('ns')
+    expect(p.projectId).toBe('pid')
+  })
+
+  it('lists projects', async () => {
+    vi.stubGlobal('fetch', mockFetch(200, { projects: [{ name: 'a' }, { name: 'b' }] }))
+    const lf = new LlamaFarm()
+    const ps = await lf.projects('default')
+    expect(ps).toHaveLength(2)
+    vi.unstubAllGlobals()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Chat
+// ---------------------------------------------------------------------------
+
+describe('chat', () => {
+  it('sends string message and gets text shortcut', async () => {
+    const mockResp = {
+      id: 'chat-1',
+      object: 'chat.completion',
+      model: 'qwen3-8b',
+      choices: [{ index: 0, message: { role: 'assistant', content: 'Hello back!' }, finish_reason: 'stop' }],
+      usage: { prompt_tokens: 5, completion_tokens: 3, total_tokens: 8 },
+    }
+    vi.stubGlobal('fetch', mockFetch(200, mockResp))
+    const lf = new LlamaFarm()
+    const p = lf.project('default', 'test')
+    const resp = await p.chat('Hello!')
+    expect(resp.text).toBe('Hello back!')
+    expect(resp.model).toBe('qwen3-8b')
+    vi.unstubAllGlobals()
+  })
+
+  it('sends message array', async () => {
+    const f = mockFetch(200, { choices: [{ message: { content: 'ok' } }] })
+    vi.stubGlobal('fetch', f)
+    const lf = new LlamaFarm()
+    const p = lf.project('ns', 'pid')
+    await p.chat([{ role: 'system', content: 'be helpful' }, { role: 'user', content: 'hi' }])
+    const body = JSON.parse(f.mock.calls[0][1].body)
+    expect(body.messages).toHaveLength(2)
+    expect(body.messages[0].role).toBe('system')
+    vi.unstubAllGlobals()
+  })
+
+  it('includes optional chat params', async () => {
+    const f = mockFetch(200, { choices: [{ message: { content: '' } }] })
+    vi.stubGlobal('fetch', f)
+    const lf = new LlamaFarm()
+    await lf.project('ns', 'p').chat('hi', {
+      model: 'phi-4',
+      temperature: 0.7,
+      max_tokens: 100,
+      cache_key: 'abc123',
+      return_cache_key: true,
+    })
+    const body = JSON.parse(f.mock.calls[0][1].body)
+    expect(body.model).toBe('phi-4')
+    expect(body.temperature).toBe(0.7)
+    expect(body.max_tokens).toBe(100)
+    expect(body.cache_key).toBe('abc123')
+    expect(body.return_cache_key).toBe(true)
+    vi.unstubAllGlobals()
+  })
+
+  it('builds correct URL path', async () => {
+    const f = mockFetch(200, { choices: [{ message: { content: '' } }] })
+    vi.stubGlobal('fetch', f)
+    const lf = new LlamaFarm()
+    await lf.project('acme', 'agent').chat('hi')
+    const url = f.mock.calls[0][0]
+    expect(url).toBe('http://localhost:14345/v1/projects/acme/agent/chat/completions')
+    vi.unstubAllGlobals()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Streaming
+// ---------------------------------------------------------------------------
+
+describe('streaming', () => {
+  it('parses SSE chunks', async () => {
+    const sseData = [
+      'data: {"choices":[{"delta":{"content":"Hello"},"finish_reason":null}],"model":"q3"}\n\n',
+      'data: {"choices":[{"delta":{"content":" world"},"finish_reason":null}],"model":"q3"}\n\n',
+      'data: [DONE]\n\n',
+    ]
+    vi.stubGlobal('fetch', mockStream(sseData))
+    const lf = new LlamaFarm()
+    const stream = await lf.project('ns', 'p').chatStream('hi')
+    const reader = stream.getReader()
+    const chunks: string[] = []
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      chunks.push(value.content)
+    }
+    expect(chunks.join('')).toBe('Hello world')
+    vi.unstubAllGlobals()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Vision
+// ---------------------------------------------------------------------------
+
+describe('vision', () => {
+  it('detect returns detections', async () => {
+    vi.stubGlobal('fetch', mockFetch(200, {
+      detections: [{ x1: 0, y1: 0, x2: 100, y2: 100, class_name: 'person', class_id: 0, confidence: 0.95 }],
+      model: 'yolov8n',
+      time_ms: 42,
+    }))
+    const lf = new LlamaFarm()
+    const r = await lf.vision.detect('base64data')
+    expect(r.detections).toHaveLength(1)
+    expect(r.detections[0].class_name).toBe('person')
+    vi.unstubAllGlobals()
+  })
+
+  it('classify returns classification', async () => {
+    vi.stubGlobal('fetch', mockFetch(200, {
+      class_name: 'cat',
+      confidence: 0.92,
+      all_scores: { cat: 0.92, dog: 0.08 },
+      model: 'clip-vit-base',
+      time_ms: 15,
+    }))
+    const lf = new LlamaFarm()
+    const r = await lf.vision.classify('base64data', ['cat', 'dog'])
+    expect(r.classification?.class_name).toBe('cat')
+    vi.unstubAllGlobals()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Fine-Tuning
+// ---------------------------------------------------------------------------
+
+describe('finetune', () => {
+  it('submits SFT job', async () => {
+    vi.stubGlobal('fetch', mockFetch(200, { job_id: 'ft-1', status: 'queued', type: 'sft' }))
+    const lf = new LlamaFarm()
+    const job = await lf.finetune.sft('model-id', [{ instruction: 'hi', output: 'hello' }])
+    expect(job.job_id).toBe('ft-1')
+    // Verify it hits runtime URL
+    const url = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+    expect(url).toContain('localhost:11540')
+    vi.unstubAllGlobals()
+  })
+
+  it('lists jobs', async () => {
+    vi.stubGlobal('fetch', mockFetch(200, { jobs: [{ job_id: 'ft-1' }, { job_id: 'ft-2' }] }))
+    const lf = new LlamaFarm()
+    const jobs = await lf.finetune.jobs()
+    expect(jobs).toHaveLength(2)
+    vi.unstubAllGlobals()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Cache
+// ---------------------------------------------------------------------------
+
+describe('cache', () => {
+  it('returns stats', async () => {
+    vi.stubGlobal('fetch', mockFetch(200, { entries: 5, total_bytes: 1024, hit_rate: 0.8, ram_bytes: 512, disk_bytes: 512 }))
+    const lf = new LlamaFarm()
+    const s = await lf.cache.stats()
+    expect(s.entries).toBe(5)
+    expect(s.hit_rate).toBe(0.8)
+    vi.unstubAllGlobals()
+  })
+
+  it('prepare hits runtime URL', async () => {
+    const f = mockFetch(200, { cache_key: 'abc', cached_tokens: 100 })
+    vi.stubGlobal('fetch', f)
+    const lf = new LlamaFarm()
+    await lf.cache.prepare([{ role: 'system', content: 'be helpful' }])
+    const url = f.mock.calls[0][0]
+    expect(url).toContain('localhost:11540')
+    vi.unstubAllGlobals()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// RAG
+// ---------------------------------------------------------------------------
+
+describe('rag', () => {
+  it('queries RAG via project', async () => {
+    vi.stubGlobal('fetch', mockFetch(200, {
+      query: 'test', results: [{ content: 'answer', score: 0.9 }],
+      total_results: 1, retrieval_strategy_used: 'hybrid', database_used: 'default',
+    }))
+    const lf = new LlamaFarm()
+    const r = await lf.project('ns', 'p').rag.query({ query: 'test' })
+    expect(r.results).toHaveLength(1)
+    // Verify URL path
+    const url = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+    expect(url).toContain('/v1/projects/ns/p/rag/query')
+    vi.unstubAllGlobals()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Datasets
+// ---------------------------------------------------------------------------
+
+describe('datasets', () => {
+  it('lists datasets via project', async () => {
+    vi.stubGlobal('fetch', mockFetch(200, { datasets: [{ name: 'ds1' }] }))
+    const lf = new LlamaFarm()
+    const ds = await lf.project('ns', 'p').datasets.list()
+    expect(ds).toHaveLength(1)
+    vi.unstubAllGlobals()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// OpenAI Compatibility
+// ---------------------------------------------------------------------------
+
+describe('openaiBaseUrl', () => {
+  it('returns runtime URL with /v1', () => {
+    const lf = new LlamaFarm()
+    expect(lf.openaiBaseUrl).toBe('http://localhost:11540/v1')
+  })
+
+  it('uses custom runtime URL', () => {
+    const lf = new LlamaFarm({ runtimeUrl: 'http://gpu:8080' })
+    expect(lf.openaiBaseUrl).toBe('http://gpu:8080/v1')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// NLP API
+// ---------------------------------------------------------------------------
+
+describe('nlp', () => {
+  it('embeddings sends correct request', async () => {
+    const f = mockFetch(200, { embeddings: [[0.1, 0.2]], model: 'bge-small' })
+    vi.stubGlobal('fetch', f)
+    const lf = new LlamaFarm()
+    const r = await lf.nlp.embeddings('hello')
+    expect(r.embeddings).toBeDefined()
+    const url = f.mock.calls[0][0]
+    expect(url).toContain('/v1/nlp/embeddings')
+    vi.unstubAllGlobals()
+  })
+
+  it('classify sends text and labels', async () => {
+    const f = mockFetch(200, { label: 'positive', scores: { positive: 0.9, negative: 0.1 } })
+    vi.stubGlobal('fetch', f)
+    const lf = new LlamaFarm()
+    await lf.nlp.classify('great movie', ['positive', 'negative'])
+    const body = JSON.parse(f.mock.calls[0][1].body)
+    expect(body.text).toBe('great movie')
+    expect(body.labels).toEqual(['positive', 'negative'])
+    vi.unstubAllGlobals()
+  })
+
+  it('ner extracts entities', async () => {
+    vi.stubGlobal('fetch', mockFetch(200, { entities: [{ text: 'Paris', label: 'LOC' }] }))
+    const lf = new LlamaFarm()
+    const r = await lf.nlp.ner('I live in Paris')
+    expect(r.entities).toBeDefined()
+    vi.unstubAllGlobals()
+  })
+
+  it('rerank sends query and documents', async () => {
+    const f = mockFetch(200, { results: [{ index: 0, score: 0.95 }] })
+    vi.stubGlobal('fetch', f)
+    const lf = new LlamaFarm()
+    await lf.nlp.rerank('query', ['doc1', 'doc2'])
+    const body = JSON.parse(f.mock.calls[0][1].body)
+    expect(body.query).toBe('query')
+    expect(body.documents).toEqual(['doc1', 'doc2'])
+    vi.unstubAllGlobals()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Anomaly Detection API
+// ---------------------------------------------------------------------------
+
+describe('anomaly', () => {
+  it('detect sends data with options', async () => {
+    const f = mockFetch(200, { anomalies: [0, 1, 0], scores: [-0.1, 2.5, -0.2] })
+    vi.stubGlobal('fetch', f)
+    const lf = new LlamaFarm()
+    await lf.anomaly.detect([[1, 2], [99, 99], [1, 3]], { explain: true })
+    const body = JSON.parse(f.mock.calls[0][1].body)
+    expect(body.data).toHaveLength(3)
+    expect(body.explain).toBe(true)
+    vi.unstubAllGlobals()
+  })
+
+  it('models returns list', async () => {
+    vi.stubGlobal('fetch', mockFetch(200, { models: [{ id: 'iforest-1' }] }))
+    const lf = new LlamaFarm()
+    const m = await lf.anomaly.models()
+    expect(m).toHaveLength(1)
+    vi.unstubAllGlobals()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Classifier API
+// ---------------------------------------------------------------------------
+
+describe('classifier', () => {
+  it('fit sends X and y', async () => {
+    const f = mockFetch(200, { model_id: 'clf-1', accuracy: 0.95 })
+    vi.stubGlobal('fetch', f)
+    const lf = new LlamaFarm()
+    await lf.classifier.fit([[1], [2], [3]], [0, 1, 0])
+    const body = JSON.parse(f.mock.calls[0][1].body)
+    expect(body.X).toHaveLength(3)
+    expect(body.y).toEqual([0, 1, 0])
+    vi.unstubAllGlobals()
+  })
+
+  it('predict returns predictions', async () => {
+    vi.stubGlobal('fetch', mockFetch(200, { predictions: [0, 1] }))
+    const lf = new LlamaFarm()
+    const r = await lf.classifier.predict([[1], [2]])
+    expect(r.predictions).toBeDefined()
+    vi.unstubAllGlobals()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Time Series API
+// ---------------------------------------------------------------------------
+
+describe('timeseries', () => {
+  it('predict sends steps', async () => {
+    const f = mockFetch(200, { forecast: [1.1, 1.2, 1.3] })
+    vi.stubGlobal('fetch', f)
+    const lf = new LlamaFarm()
+    await lf.timeseries.predict(3)
+    const body = JSON.parse(f.mock.calls[0][1].body)
+    expect(body.steps).toBe(3)
+    vi.unstubAllGlobals()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// CatBoost API
+// ---------------------------------------------------------------------------
+
+describe('catboost', () => {
+  it('importance hits correct URL', async () => {
+    const f = mockFetch(200, { importance: [0.5, 0.3, 0.2] })
+    vi.stubGlobal('fetch', f)
+    const lf = new LlamaFarm()
+    await lf.catboost.importance('my-model')
+    const url = f.mock.calls[0][0]
+    expect(url).toContain('/v1/catboost/my-model/importance')
+    vi.unstubAllGlobals()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Drift Detection API
+// ---------------------------------------------------------------------------
+
+describe('drift', () => {
+  it('status hits correct URL', async () => {
+    const f = mockFetch(200, { drifted: false, p_value: 0.45 })
+    vi.stubGlobal('fetch', f)
+    const lf = new LlamaFarm()
+    await lf.drift.status('prod-model')
+    const url = f.mock.calls[0][0]
+    expect(url).toContain('/v1/drift/status/prod-model')
+    vi.unstubAllGlobals()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Explainability API
+// ---------------------------------------------------------------------------
+
+describe('explain', () => {
+  it('shap sends data', async () => {
+    const f = mockFetch(200, { shap_values: [[0.1, -0.2]] })
+    vi.stubGlobal('fetch', f)
+    const lf = new LlamaFarm()
+    await lf.explain.shap([[1, 2]])
+    const body = JSON.parse(f.mock.calls[0][1].body)
+    expect(body.data).toEqual([[1, 2]])
+    vi.unstubAllGlobals()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Polars API
+// ---------------------------------------------------------------------------
+
+describe('polars', () => {
+  it('bufferData hits correct URL', async () => {
+    const f = mockFetch(200, { data: [{ col1: 1 }] })
+    vi.stubGlobal('fetch', f)
+    const lf = new LlamaFarm()
+    await lf.polars.bufferData('buf-123')
+    const url = f.mock.calls[0][0]
+    expect(url).toContain('/v1/ml/polars/buffers/buf-123/data')
+    vi.unstubAllGlobals()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Auth header
+// ---------------------------------------------------------------------------
+
+describe('auth', () => {
+  it('sends Bearer token when apiKey set', async () => {
+    const f = mockFetch(200, { status: 'ok' })
+    vi.stubGlobal('fetch', f)
+    const lf = new LlamaFarm({ apiKey: 'sk-test-123' })
+    await lf.health()
+    const headers = f.mock.calls[0][1].headers
+    expect(headers['Authorization']).toBe('Bearer sk-test-123')
+    vi.unstubAllGlobals()
+  })
+
+  it('no auth header without apiKey', async () => {
+    const f = mockFetch(200, { status: 'ok' })
+    vi.stubGlobal('fetch', f)
+    const lf = new LlamaFarm()
+    await lf.health()
+    const headers = f.mock.calls[0][1].headers
+    expect(headers['Authorization']).toBeUndefined()
+    vi.unstubAllGlobals()
+  })
+})

--- a/packages/llamafarm-sdk-ts/tests/client.test.ts
+++ b/packages/llamafarm-sdk-ts/tests/client.test.ts
@@ -468,21 +468,25 @@ describe('anomaly', () => {
 // ---------------------------------------------------------------------------
 
 describe('classifier', () => {
-  it('fit sends X and y', async () => {
-    const f = mockFetch(200, { model_id: 'clf-1', accuracy: 0.95 })
+  it('fit sends model and training_data', async () => {
+    const f = mockFetch(200, { model: 'intent', labels: ['cancel', 'book'] })
     vi.stubGlobal('fetch', f)
     const lf = new LlamaFarm()
-    await lf.classifier.fit([[1], [2], [3]], [0, 1, 0])
+    await lf.classifier.fit('intent', [
+      { text: 'cancel trip', label: 'cancel' },
+      { text: 'book hotel', label: 'book' },
+    ])
     const body = JSON.parse(f.mock.calls[0][1].body)
-    expect(body.X).toHaveLength(3)
-    expect(body.y).toEqual([0, 1, 0])
+    expect(body.model).toBe('intent')
+    expect(body.training_data).toHaveLength(2)
+    expect(body.training_data[0].text).toBe('cancel trip')
     vi.unstubAllGlobals()
   })
 
-  it('predict returns predictions', async () => {
-    vi.stubGlobal('fetch', mockFetch(200, { predictions: [0, 1] }))
+  it('predict sends model and texts', async () => {
+    vi.stubGlobal('fetch', mockFetch(200, { predictions: ['cancel', 'book'] }))
     const lf = new LlamaFarm()
-    const r = await lf.classifier.predict([[1], [2]])
+    const r = await lf.classifier.predict('intent', ['cancel my flight', 'book a room'])
     expect(r.predictions).toBeDefined()
     vi.unstubAllGlobals()
   })

--- a/packages/llamafarm-sdk-ts/tsconfig.cjs.json
+++ b/packages/llamafarm-sdk-ts/tsconfig.cjs.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "outDir": "dist/cjs",
+    "declaration": true,
+    "declarationMap": false,
+    "sourceMap": false
+  }
+}

--- a/packages/llamafarm-sdk-ts/tsconfig.json
+++ b/packages/llamafarm-sdk-ts/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/llamafarm-sdk/README.md
+++ b/packages/llamafarm-sdk/README.md
@@ -1,0 +1,135 @@
+# 🦙 LlamaFarm Python SDK
+
+> **Alpha** — API may change between releases.
+
+Python client for [LlamaFarm](https://llamafarm.com) — local AI infrastructure.
+
+## Install
+
+```bash
+pip install llamafarm
+```
+
+## Quick Start
+
+```python
+from llamafarm import LlamaFarm
+
+# Auto-discovers local server (localhost:14345)
+lf = LlamaFarm()
+
+# Create a project
+project = lf.create_project("my-app", model="Qwen/Qwen3-8B")
+
+# Chat
+response = project.chat("What is the meaning of life?")
+print(response.text)
+
+# Stream
+for chunk in project.chat_stream("Tell me a story"):
+    print(chunk.content, end="", flush=True)
+```
+
+## Async
+
+```python
+import asyncio
+from llamafarm import LlamaFarm
+
+async def main():
+    lf = LlamaFarm()
+    project = lf.project("my-app")
+    
+    response = await project.achat("Hello!")
+    print(response.text)
+    
+    async for chunk in project.achat_stream("Tell me a story"):
+        print(chunk.content, end="", flush=True)
+
+asyncio.run(main())
+```
+
+## Vision
+
+```python
+import base64
+
+# Detect objects
+result = project.vision.detect(
+    base64.b64encode(open("photo.jpg", "rb").read()),
+    model="yolov8n",
+    confidence=0.5,
+)
+for det in result.detections:
+    print(f"{det.class_name}: {det.confidence:.2f}")
+
+# Classify
+result = project.vision.classify(
+    base64.b64encode(open("photo.jpg", "rb").read()),
+    classes=["cat", "dog", "bird"],
+)
+print(result.classification.class_name)
+```
+
+## Fine-Tuning
+
+```python
+# SFT
+job = project.finetune.sft(
+    model="google/gemma-3-4b-it",
+    dataset=[
+        {"conversations": [
+            {"from": "human", "value": "What is LlamaFarm?"},
+            {"from": "gpt", "value": "A local AI platform."},
+        ]}
+    ],
+    epochs=3,
+)
+print(f"Job {job.job_id}: {job.status}")
+
+# Check status
+status = project.finetune.status(job.job_id)
+print(f"Progress: {status.progress:.0%}")
+```
+
+## KV Cache
+
+```python
+# Pre-warm cache for a system prompt
+result = project.cache.prepare(
+    messages=[{"role": "system", "content": "You are a medical assistant..."}],
+    warm=True,
+)
+
+# Use cache key in chat
+response = project.chat(
+    "What are the symptoms of diabetes?",
+    cache_key=result["cache_key"],
+    return_cache_key=True,
+)
+# Next turn reuses cache
+next_response = project.chat(
+    "What about treatment options?",
+    cache_key=response.x_cache["new_cache_key"],
+)
+```
+
+## Configuration
+
+```python
+# Explicit URL
+lf = LlamaFarm(url="http://my-server:14345")
+
+# With API key
+lf = LlamaFarm(api_key="sk-...")
+
+# Environment variables
+# LLAMAFARM_URL=http://localhost:14345
+# LLAMAFARM_API_KEY=sk-...
+```
+
+## Requirements
+
+- Python 3.10+
+- `httpx` and `pydantic` (installed automatically)
+- A running LlamaFarm server (`lf start`)

--- a/packages/llamafarm-sdk/examples/live_test.py
+++ b/packages/llamafarm-sdk/examples/live_test.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Live integration test — Python SDK against running LlamaFarm server."""
+
+import asyncio
+import sys
+
+from llamafarm import LlamaFarm
+
+NAMESPACE = "default"
+PROJECT = "sdk-test"
+
+
+def main():
+    lf = LlamaFarm()
+    print(f"SDK url: {lf.url}")
+    print(f"Runtime: {lf.runtime_url}\n")
+
+    # 1. Health check
+    print("── Health ──")
+    h = lf.health()
+    print(f"  Status: {h['status']}")
+    print(f"  Summary: {h.get('summary', 'n/a')}\n")
+
+    # 2. List models
+    print("── Models (first 5) ──")
+    models = lf.models()
+    for m in models.get("data", models)[:5]:
+        name = m.get("id", m.get("name", "?"))
+        print(f"  • {name}")
+    print()
+
+    # 3. List projects
+    print("── Projects in 'default' (first 5) ──")
+    projects = lf.projects(NAMESPACE)
+    for p in projects[:5]:
+        print(f"  • {p.name}")
+    print()
+
+    # 4. Chat (sync, non-streaming)
+    print("── Chat (sync) ──")
+    p = lf.project(NAMESPACE, PROJECT)
+    resp = p.chat("What is 2 + 2? Answer in one sentence.", stateless=True, max_tokens=60)
+    print(f"  Model: {resp.model}")
+    print(f"  Reply: {resp.text}")
+    print(f"  Usage: {resp.usage}\n")
+
+    # 5. Chat streaming
+    print("── Chat (streaming) ──")
+    print("  ", end="", flush=True)
+    full = []
+    for chunk in p.chat_stream("Name 3 colors. One word each, comma-separated.", stateless=True, max_tokens=30):
+        print(chunk.delta_content or "", end="", flush=True)
+        full.append(chunk.delta_content or "")
+    print(f"\n  (collected: {''.join(full)})\n")
+
+    # 6. Async chat
+    print("── Chat (async) ──")
+
+    async def async_chat():
+        resp = await p.achat("What planet is closest to the sun? One word.", stateless=True, max_tokens=20)
+        print(f"  Reply: {resp.text}")
+
+        # Async streaming
+        print("  Streaming: ", end="", flush=True)
+        async for chunk in p.achat_stream("Say goodbye briefly.", stateless=True, max_tokens=20):
+            print(chunk.delta_content or "", end="", flush=True)
+        print()
+
+    asyncio.run(async_chat())
+
+    # 7. Vision (if available)
+    print("\n── Vision ──")
+    try:
+        models_list = lf.vision.models()
+        print(f"  Vision models: {len(models_list)}")
+    except Exception as e:
+        print(f"  Vision not available: {e}")
+
+    print("\n✅ All live tests passed!")
+    lf.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/llamafarm-sdk/examples/ml_demo.py
+++ b/packages/llamafarm-sdk/examples/ml_demo.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""ML API demo — exercise anomaly, classifier, timeseries, NLP, and other ML endpoints."""
+
+from llamafarm import LlamaFarm
+
+
+def safe_call(name: str, fn, *args, **kwargs):
+    """Call an API and handle errors gracefully."""
+    try:
+        result = fn(*args, **kwargs)
+        print(f"  ✅ {name}: {result}")
+        return result
+    except Exception as e:
+        print(f"  ⚠️  {name}: {e}")
+        return None
+
+
+def main():
+    lf = LlamaFarm()
+    print(f"LlamaFarm: {lf}")
+    print(f"OpenAI base URL: {lf.openai_base_url}\n")
+
+    # --- NLP ---
+    print("=== NLP API ===")
+    safe_call("embeddings", lf.nlp.embeddings, "Hello world")
+    safe_call("classify", lf.nlp.classify, "I love this product!", labels=["positive", "negative"])
+    safe_call("ner", lf.nlp.ner, "John works at Google in Mountain View.")
+    safe_call("rerank", lf.nlp.rerank, "machine learning", ["ML is great", "I like cats", "Deep learning rocks"])
+
+    # --- Anomaly Detection ---
+    print("\n=== Anomaly Detection API ===")
+    sample_data = [[1.0, 2.0], [1.1, 2.1], [1.0, 1.9], [10.0, 10.0]]
+    safe_call("backends", lf.anomaly.backends)
+    safe_call("models", lf.anomaly.models)
+    safe_call("fit", lf.anomaly.fit, sample_data[:3], algorithm="IsolationForest")
+    safe_call("detect", lf.anomaly.detect, sample_data, explain=True)
+    safe_call("score", lf.anomaly.score, sample_data)
+
+    # --- Classifier ---
+    print("\n=== Classifier API ===")
+    safe_call("models", lf.classifier.models)
+    safe_call("fit", lf.classifier.fit, [[1, 0], [0, 1], [1, 1]], [0, 1, 1])
+    safe_call("predict", lf.classifier.predict, [[1, 0], [0, 1]])
+
+    # --- Time Series ---
+    print("\n=== Time Series API ===")
+    safe_call("backends", lf.timeseries.backends)
+    safe_call("models", lf.timeseries.models)
+    ts_data = [{"timestamp": f"2024-01-{i+1:02d}", "value": float(i * 10 + 5)} for i in range(30)]
+    safe_call("fit", lf.timeseries.fit, ts_data)
+    safe_call("predict", lf.timeseries.predict, horizon=7)
+
+    # --- ADTK ---
+    print("\n=== ADTK API ===")
+    safe_call("detectors", lf.adtk.detectors)
+    safe_call("models", lf.adtk.models)
+
+    # --- CatBoost ---
+    print("\n=== CatBoost API ===")
+    safe_call("info", lf.catboost.info)
+    safe_call("models", lf.catboost.models)
+
+    # --- Drift ---
+    print("\n=== Drift Detection API ===")
+    safe_call("detectors", lf.drift.detectors)
+    safe_call("models", lf.drift.models)
+
+    # --- Explainability ---
+    print("\n=== Explainability API ===")
+    safe_call("explainers", lf.explain.explainers)
+
+    # --- Polars ---
+    print("\n=== Polars API ===")
+    safe_call("list_buffers", lf.polars.list_buffers)
+
+    print("\n✅ ML demo complete!")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/llamafarm-sdk/examples/ml_demo.py
+++ b/packages/llamafarm-sdk/examples/ml_demo.py
@@ -39,8 +39,22 @@ def main():
     # --- Classifier ---
     print("\n=== Classifier API ===")
     safe_call("models", lf.classifier.models)
-    safe_call("fit", lf.classifier.fit, [[1, 0], [0, 1], [1, 1]], [0, 1, 1])
-    safe_call("predict", lf.classifier.predict, [[1, 0], [0, 1]])
+    safe_call(
+        "fit",
+        lf.classifier.fit,
+        "intent-demo",
+        [
+            {"text": "I want to cancel my trip", "label": "cancel"},
+            {"text": "Please cancel the booking", "label": "cancel"},
+            {"text": "Book me a hotel", "label": "book"},
+            {"text": "Reserve a flight", "label": "book"},
+            {"text": "What's the status?", "label": "status"},
+            {"text": "Check my order", "label": "status"},
+            {"text": "I need to cancel", "label": "cancel"},
+            {"text": "Make a reservation", "label": "book"},
+        ],
+    )
+    safe_call("predict", lf.classifier.predict, "intent-demo", ["Cancel my flight", "Book a room"])
 
     # --- Time Series ---
     print("\n=== Time Series API ===")

--- a/packages/llamafarm-sdk/examples/openai_compat.py
+++ b/packages/llamafarm-sdk/examples/openai_compat.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""OpenAI compatibility demo — use LlamaFarm as an OpenAI drop-in replacement."""
+
+from openai import OpenAI
+from llamafarm import LlamaFarm
+
+MODEL = "unsloth/Qwen3-1.7B-GGUF:Q4_K_M"
+
+
+def main():
+    lf = LlamaFarm()
+    print(f"OpenAI-compatible base URL: {lf.openai_base_url}")
+
+    # Create an OpenAI client pointing at LlamaFarm runtime
+    client = OpenAI(base_url=lf.openai_base_url, api_key="not-needed")
+
+    # List models
+    models = client.models.list()
+    print(f"\nAvailable models: {[m.id for m in models.data]}")
+
+    # Chat completion
+    print("\n--- Chat Completion ---")
+    resp = client.chat.completions.create(
+        model=MODEL,
+        messages=[
+            {"role": "system", "content": "You are a helpful assistant. Be brief."},
+            {"role": "user", "content": "What is 2+2? Answer in one word."},
+        ],
+        max_tokens=32,
+        temperature=0.1,
+    )
+    print(f"Response: {resp.choices[0].message.content}")
+
+    # Streaming chat
+    print("\n--- Streaming Chat ---")
+    stream = client.chat.completions.create(
+        model=MODEL,
+        messages=[{"role": "user", "content": "Count from 1 to 5."}],
+        max_tokens=64,
+        stream=True,
+    )
+    for chunk in stream:
+        if chunk.choices and chunk.choices[0].delta.content:
+            print(chunk.choices[0].delta.content, end="", flush=True)
+    print()
+
+    # Embeddings
+    print("\n--- Embeddings ---")
+    try:
+        emb = client.embeddings.create(model=MODEL, input="Hello world")
+        print(f"Embedding dim: {len(emb.data[0].embedding)}")
+    except Exception as e:
+        print(f"Embeddings not available: {e}")
+
+    print("\n✅ OpenAI compatibility demo complete!")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/llamafarm-sdk/examples/quickstart.py
+++ b/packages/llamafarm-sdk/examples/quickstart.py
@@ -1,0 +1,47 @@
+"""LlamaFarm SDK quickstart — run against a live server."""
+
+from llamafarm import LlamaFarm
+
+# Connect (auto-discovers localhost:14345)
+lf = LlamaFarm()
+print(f"Connected: {lf}")
+
+# Health check
+print("Health:", lf.health())
+
+# Create a project
+project = lf.create_project(
+    "default",
+    "quickstart-demo",
+    model="unsloth/Qwen3-1.7B-GGUF:Q4_K_M",
+    system_prompt="You are a concise, helpful assistant.",
+    temperature=0.7,
+)
+print(f"Created: {project}")
+
+# Chat
+response = project.chat("What is LlamaFarm?")
+print(f"Response: {response.text}")
+
+# Streaming
+print("Streaming: ", end="", flush=True)
+for chunk in project.chat_stream("Tell me a short joke"):
+    if chunk.delta_content:
+        print(chunk.delta_content, end="", flush=True)
+print()
+
+# RAG query (if configured)
+try:
+    results = project.rag.query("How do I configure models?")
+    for r in results.results:
+        print(f"  [{r.score:.2f}] {r.content[:80]}...")
+except Exception as e:
+    print(f"RAG not configured: {e}")
+
+# List projects
+for p in lf.projects("default"):
+    print(f"  Project: {p.name} ({p.id})")
+
+# Clean up
+project.delete()
+print("Deleted project")

--- a/packages/llamafarm-sdk/pyproject.toml
+++ b/packages/llamafarm-sdk/pyproject.toml
@@ -1,0 +1,53 @@
+[project]
+name = "llamafarm"
+version = "0.1.0a1"
+description = "Python SDK for LlamaFarm — local AI infrastructure"
+readme = "README.md"
+license = "Apache-2.0"
+requires-python = ">=3.10"
+authors = [{ name = "LlamaFarm", email = "hello@llamafarm.com" }]
+keywords = ["llm", "ai", "local", "inference", "fine-tuning", "vision"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
+dependencies = [
+    "httpx>=0.25.0",
+    "pydantic>=2.0.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.23",
+    "respx>=0.21",
+    "ruff>=0.4",
+]
+
+[project.urls]
+Homepage = "https://llamafarm.com"
+Documentation = "https://docs.llamafarm.com"
+Repository = "https://github.com/llama-farm/llamafarm"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/llamafarm"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+
+[dependency-groups]
+dev = [
+    "pytest-asyncio>=1.3.0",
+    "respx>=0.22.0",
+    "ruff>=0.15.2",
+]

--- a/packages/llamafarm-sdk/src/llamafarm/__init__.py
+++ b/packages/llamafarm-sdk/src/llamafarm/__init__.py
@@ -1,0 +1,80 @@
+"""LlamaFarm Python SDK — local AI infrastructure."""
+
+from .client import (
+    ADTKAPI,
+    AnomalyAPI,
+    CacheAPI,
+    CatBoostAPI,
+    ClassifierAPI,
+    DatasetsAPI,
+    DriftAPI,
+    ExplainAPI,
+    FineTuneAPI,
+    LlamaFarm,
+    NLPAPI,
+    PolarsAPI,
+    ProjectHandle,
+    RAGAPI,
+    TimeSeriesAPI,
+    VisionAPI,
+)
+from .errors import ConnectionError, LlamaFarmError, NotFoundError, ServerError, ValidationError
+from .types import (
+    CacheStats,
+    ChatMessage,
+    ChatResponse,
+    ClassifyResponse,
+    DatabaseInfo,
+    Detection,
+    DetectResponse,
+    FineTuneJob,
+    FineTuneTemplate,
+    ProjectInfo,
+    QueryResponse,
+    RAGResult,
+    StreamChunk,
+    build_project_config,
+)
+
+__version__ = "0.1.0a1"
+
+__all__ = [
+    # Client
+    "LlamaFarm",
+    "ProjectHandle",
+    "RAGAPI",
+    "DatasetsAPI",
+    "VisionAPI",
+    "FineTuneAPI",
+    "CacheAPI",
+    "NLPAPI",
+    "AnomalyAPI",
+    "ClassifierAPI",
+    "TimeSeriesAPI",
+    "ADTKAPI",
+    "CatBoostAPI",
+    "DriftAPI",
+    "ExplainAPI",
+    "PolarsAPI",
+    # Types
+    "ChatMessage",
+    "ChatResponse",
+    "StreamChunk",
+    "ProjectInfo",
+    "QueryResponse",
+    "RAGResult",
+    "DatabaseInfo",
+    "DetectResponse",
+    "Detection",
+    "ClassifyResponse",
+    "FineTuneJob",
+    "FineTuneTemplate",
+    "CacheStats",
+    "build_project_config",
+    # Errors
+    "LlamaFarmError",
+    "ConnectionError",
+    "NotFoundError",
+    "ValidationError",
+    "ServerError",
+]

--- a/packages/llamafarm-sdk/src/llamafarm/client.py
+++ b/packages/llamafarm-sdk/src/llamafarm/client.py
@@ -292,6 +292,18 @@ class VisionAPI:
         _raise_for_status(r)
         return r.json()
 
+    def models(self) -> dict[str, Any]:
+        """List all saved vision models."""
+        r = self._client.get(f"{self._base}/models")
+        _raise_for_status(r)
+        return r.json()
+
+    async def amodels(self) -> dict[str, Any]:
+        """List all saved vision models (async)."""
+        r = await self._aclient.get(f"{self._base}/models")
+        _raise_for_status(r)
+        return r.json()
+
     def train(self, model: str, dataset: str, **kwargs: Any) -> dict[str, Any]:
         body: dict[str, Any] = {"model": model, "dataset": dataset, **kwargs}
         r = self._client.post(f"{self._base}/train", json=body)
@@ -570,35 +582,64 @@ class AnomalyAPI:
 
 
 class ClassifierAPI:
-    """ML classifier operations."""
+    """ML text classifier operations (SetFit few-shot learning)."""
 
     def __init__(self, client: httpx.Client, aclient: httpx.AsyncClient, base_url: str):
         self._client = client
         self._aclient = aclient
         self._base = f"{base_url}/ml/classifier"
 
-    def fit(self, data: list, labels: list, **kwargs: Any) -> dict[str, Any]:
-        body: dict[str, Any] = {"data": data, "labels": labels, **kwargs}
+    def fit(
+        self,
+        model: str,
+        training_data: list[dict[str, str]],
+        *,
+        base_model: str | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """Fit a text classifier using SetFit few-shot learning.
+
+        Args:
+            model: Model identifier (for caching/saving).
+            training_data: List of ``{"text": ..., "label": ...}`` examples.
+            base_model: Optional base sentence-transformer model.
+        """
+        body: dict[str, Any] = {"model": model, "training_data": training_data, **kwargs}
+        if base_model:
+            body["base_model"] = base_model
         r = self._client.post(f"{self._base}/fit", json=body)
         _raise_for_status(r)
         return r.json()
 
-    async def afit(self, data: list, labels: list, **kwargs: Any) -> dict[str, Any]:
-        body: dict[str, Any] = {"data": data, "labels": labels, **kwargs}
+    async def afit(
+        self,
+        model: str,
+        training_data: list[dict[str, str]],
+        *,
+        base_model: str | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {"model": model, "training_data": training_data, **kwargs}
+        if base_model:
+            body["base_model"] = base_model
         r = await self._aclient.post(f"{self._base}/fit", json=body)
         _raise_for_status(r)
         return r.json()
 
-    def predict(self, data: list, *, model: str | None = None, **kwargs: Any) -> dict[str, Any]:
-        body: dict[str, Any] = {"data": data, **kwargs}
-        if model:
-            body["model"] = model
+    def predict(self, model: str, texts: list[str], **kwargs: Any) -> dict[str, Any]:
+        """Classify texts using a fitted model.
+
+        Args:
+            model: Model identifier (must be fitted first via :meth:`fit`).
+            texts: List of texts to classify.
+        """
+        body: dict[str, Any] = {"model": model, "texts": texts, **kwargs}
         r = self._client.post(f"{self._base}/predict", json=body)
         _raise_for_status(r)
         return r.json()
 
-    async def apredict(self, data: list, **kwargs: Any) -> dict[str, Any]:
-        body: dict[str, Any] = {"data": data, **kwargs}
+    async def apredict(self, model: str, texts: list[str], **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"model": model, "texts": texts, **kwargs}
         r = await self._aclient.post(f"{self._base}/predict", json=body)
         _raise_for_status(r)
         return r.json()

--- a/packages/llamafarm-sdk/src/llamafarm/client.py
+++ b/packages/llamafarm-sdk/src/llamafarm/client.py
@@ -1,0 +1,1515 @@
+"""LlamaFarm SDK — main client, project handles, and sub-API classes."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, AsyncIterator, Iterator
+
+import httpx
+
+from .errors import ConnectionError, _raise_for_status
+from .types import (
+    CacheStats,
+    ChatMessage,
+    ChatResponse,
+    ClassifyResponse,
+    DatabaseInfo,
+    DetectResponse,
+    FineTuneJob,
+    FineTuneTemplate,
+    ProjectInfo,
+    QueryResponse,
+    StreamChunk,
+    build_project_config,
+)
+
+__all__ = [
+    "LlamaFarm", "ProjectHandle", "RAGAPI", "DatasetsAPI", "VisionAPI", "FineTuneAPI", "CacheAPI",
+    "NLPAPI", "AnomalyAPI", "ClassifierAPI", "TimeSeriesAPI", "ADTKAPI", "CatBoostAPI",
+    "DriftAPI", "ExplainAPI", "PolarsAPI",
+]
+
+_DEFAULT_URL = "http://localhost:14345"
+_DEFAULT_RUNTIME_URL = "http://localhost:11540"
+_DEFAULT_TIMEOUT = 120.0
+
+
+def _normalize_messages(messages: str | list[str | dict | ChatMessage]) -> list[dict[str, str]]:
+    """Normalize various message formats into OpenAI-compatible dicts."""
+    if isinstance(messages, str):
+        return [{"role": "user", "content": messages}]
+    result = []
+    for m in messages:
+        if isinstance(m, str):
+            result.append({"role": "user", "content": m})
+        elif isinstance(m, ChatMessage):
+            result.append(m.model_dump(exclude_none=True))
+        elif isinstance(m, dict):
+            result.append(m)
+        else:
+            raise TypeError(f"Unsupported message type: {type(m)}")
+    return result
+
+
+def _parse_sse_line(line: str) -> dict[str, Any] | None:
+    """Parse a single SSE data line into a dict, or None for non-data/done lines."""
+    line = line.strip()
+    if not line or not line.startswith("data:"):
+        return None
+    data = line[5:].strip()
+    if data == "[DONE]":
+        return None
+    try:
+        return json.loads(data)
+    except json.JSONDecodeError:
+        return None
+
+
+def _discover_url(env_var: str, default: str) -> str:
+    """Discover server URL from env vars or config file."""
+    val = os.environ.get(env_var)
+    if val:
+        return val.rstrip("/")
+    config_path = Path.home() / ".llamafarm" / "config.json"
+    if config_path.exists():
+        try:
+            cfg = json.loads(config_path.read_text())
+            key = "url" if env_var == "LLAMAFARM_URL" else "runtime_url"
+            if key in cfg:
+                return cfg[key].rstrip("/")
+        except Exception:
+            pass
+    return default
+
+
+# ── Sub-APIs ─────────────────────────────────────────────────────────────────
+
+
+class RAGAPI:
+    """RAG operations scoped to a project."""
+
+    def __init__(self, client: httpx.Client, aclient: httpx.AsyncClient, base: str):
+        self._client = client
+        self._aclient = aclient
+        self._base = base  # e.g. /projects/{ns}/{pid}/rag
+
+    def query(
+        self,
+        query: str,
+        *,
+        database: str | None = None,
+        retrieval_strategy: str | None = None,
+        top_k: int | None = None,
+        score_threshold: float | None = None,
+        metadata_filters: dict[str, Any] | None = None,
+        hybrid_alpha: float | None = None,
+        rerank_model: str | None = None,
+        query_expansion: bool | None = None,
+    ) -> QueryResponse:
+        """Search project knowledge bases."""
+        body: dict[str, Any] = {"query": query}
+        for k, v in {
+            "database": database, "retrieval_strategy": retrieval_strategy,
+            "top_k": top_k, "score_threshold": score_threshold,
+            "metadata_filters": metadata_filters, "hybrid_alpha": hybrid_alpha,
+            "rerank_model": rerank_model, "query_expansion": query_expansion,
+        }.items():
+            if v is not None:
+                body[k] = v
+        r = self._client.post(f"{self._base}/query", json=body)
+        _raise_for_status(r)
+        return QueryResponse.model_validate(r.json())
+
+    async def aquery(self, query: str, **kwargs: Any) -> QueryResponse:
+        """Async variant of query."""
+        body: dict[str, Any] = {"query": query}
+        body.update({k: v for k, v in kwargs.items() if v is not None})
+        r = await self._aclient.post(f"{self._base}/query", json=body)
+        _raise_for_status(r)
+        return QueryResponse.model_validate(r.json())
+
+    def health(self) -> dict[str, Any]:
+        r = self._client.get(f"{self._base}/health")
+        _raise_for_status(r)
+        return r.json()
+
+    async def ahealth(self) -> dict[str, Any]:
+        r = await self._aclient.get(f"{self._base}/health")
+        _raise_for_status(r)
+        return r.json()
+
+    def stats(self) -> dict[str, Any]:
+        r = self._client.get(f"{self._base}/stats")
+        _raise_for_status(r)
+        return r.json()
+
+    async def astats(self) -> dict[str, Any]:
+        r = await self._aclient.get(f"{self._base}/stats")
+        _raise_for_status(r)
+        return r.json()
+
+    def databases(self) -> list[DatabaseInfo]:
+        r = self._client.get(f"{self._base}/databases")
+        _raise_for_status(r)
+        return [DatabaseInfo.model_validate(d) for d in r.json()]
+
+    async def adatabases(self) -> list[DatabaseInfo]:
+        r = await self._aclient.get(f"{self._base}/databases")
+        _raise_for_status(r)
+        return [DatabaseInfo.model_validate(d) for d in r.json()]
+
+    def create_database(self, name: str, type: str = "ChromaStore", **kwargs: Any) -> dict[str, Any]:
+        body = {"name": name, "type": type, **kwargs}
+        r = self._client.post(f"{self._base}/databases", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    async def acreate_database(self, name: str, type: str = "ChromaStore", **kwargs: Any) -> dict[str, Any]:
+        body = {"name": name, "type": type, **kwargs}
+        r = await self._aclient.post(f"{self._base}/databases", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    def documents(self) -> list[dict[str, Any]]:
+        r = self._client.get(f"{self._base}/documents")
+        _raise_for_status(r)
+        return r.json()
+
+    async def adocuments(self) -> list[dict[str, Any]]:
+        r = await self._aclient.get(f"{self._base}/documents")
+        _raise_for_status(r)
+        return r.json()
+
+
+class DatasetsAPI:
+    """Dataset operations scoped to a project."""
+
+    def __init__(self, client: httpx.Client, aclient: httpx.AsyncClient, base: str):
+        self._client = client
+        self._aclient = aclient
+        self._base = base  # /projects/{ns}/{pid}/datasets
+
+    def list(self) -> list[dict[str, Any]]:
+        r = self._client.get(self._base)
+        _raise_for_status(r)
+        return r.json()
+
+    async def alist(self) -> list[dict[str, Any]]:
+        r = await self._aclient.get(self._base)
+        _raise_for_status(r)
+        return r.json()
+
+    def upload(self, dataset_name: str, file_path: str | Path) -> dict[str, Any]:
+        """Upload a file to a dataset."""
+        fp = Path(file_path)
+        with fp.open("rb") as f:
+            r = self._client.post(
+                f"{self._base}/{dataset_name}/upload",
+                files={"file": (fp.name, f)},
+            )
+        _raise_for_status(r)
+        return r.json()
+
+    async def aupload(self, dataset_name: str, file_path: str | Path) -> dict[str, Any]:
+        fp = Path(file_path)
+        with fp.open("rb") as f:
+            r = await self._aclient.post(
+                f"{self._base}/{dataset_name}/upload",
+                files={"file": (fp.name, f)},
+            )
+        _raise_for_status(r)
+        return r.json()
+
+    def delete_file(self, dataset_name: str, file_id: str) -> dict[str, Any]:
+        r = self._client.delete(f"{self._base}/{dataset_name}/{file_id}")
+        _raise_for_status(r)
+        return r.json()
+
+    async def adelete_file(self, dataset_name: str, file_id: str) -> dict[str, Any]:
+        r = await self._aclient.delete(f"{self._base}/{dataset_name}/{file_id}")
+        _raise_for_status(r)
+        return r.json()
+
+
+class VisionAPI:
+    """Vision operations (server-level, proxied through main server)."""
+
+    def __init__(self, client: httpx.Client, aclient: httpx.AsyncClient, base_url: str):
+        self._client = client
+        self._aclient = aclient
+        self._base = f"{base_url}/vision"
+
+    def _image_payload(self, image: str | Path, **extra: Any) -> tuple[dict | None, dict | None]:
+        """Build either JSON or multipart payload depending on image type."""
+        p = Path(image) if not str(image).startswith(("http://", "https://")) else None
+        if p and p.exists():
+            return None, None  # caller should use files=
+        return {"image": str(image), **extra}, None
+
+    def detect(self, image: str | Path, *, model: str | None = None, confidence: float | None = None) -> DetectResponse:
+        body: dict[str, Any] = {}
+        if model:
+            body["model"] = model
+        if confidence is not None:
+            body["confidence"] = confidence
+        p = Path(image) if not str(image).startswith(("http://", "https://")) else None
+        if p and p.exists():
+            with p.open("rb") as f:
+                r = self._client.post(f"{self._base}/detect", data=body, files={"image": (p.name, f)})
+        else:
+            body["image"] = str(image)
+            r = self._client.post(f"{self._base}/detect", json=body)
+        _raise_for_status(r)
+        return DetectResponse.model_validate(r.json())
+
+    async def adetect(self, image: str | Path, **kwargs: Any) -> DetectResponse:
+        body: dict[str, Any] = {"image": str(image)}
+        body.update({k: v for k, v in kwargs.items() if v is not None})
+        r = await self._aclient.post(f"{self._base}/detect", json=body)
+        _raise_for_status(r)
+        return DetectResponse.model_validate(r.json())
+
+    def classify(self, image: str | Path, classes: list[str], **kwargs: Any) -> ClassifyResponse:
+        body: dict[str, Any] = {"image": str(image), "classes": classes}
+        body.update({k: v for k, v in kwargs.items() if v is not None})
+        r = self._client.post(f"{self._base}/classify", json=body)
+        _raise_for_status(r)
+        return ClassifyResponse.model_validate(r.json())
+
+    async def aclassify(self, image: str | Path, classes: list[str], **kwargs: Any) -> ClassifyResponse:
+        body: dict[str, Any] = {"image": str(image), "classes": classes}
+        body.update({k: v for k, v in kwargs.items() if v is not None})
+        r = await self._aclient.post(f"{self._base}/classify", json=body)
+        _raise_for_status(r)
+        return ClassifyResponse.model_validate(r.json())
+
+    def detect_classify(self, image: str | Path, classes: list[str], **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"image": str(image), "classes": classes}
+        body.update({k: v for k, v in kwargs.items() if v is not None})
+        r = self._client.post(f"{self._base}/detect_classify", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    def train(self, model: str, dataset: str, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"model": model, "dataset": dataset, **kwargs}
+        r = self._client.post(f"{self._base}/train", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+
+class FineTuneAPI:
+    """Fine-tuning operations (runtime-level, port 11540)."""
+
+    def __init__(self, client: httpx.Client, aclient: httpx.AsyncClient, runtime_url: str):
+        self._client = client
+        self._aclient = aclient
+        self._base = f"{runtime_url}/v1/finetune"
+
+    def sft(self, model: str, dataset: str, **kwargs: Any) -> FineTuneJob:
+        body: dict[str, Any] = {"model": model, "dataset": dataset, **kwargs}
+        r = self._client.post(f"{self._base}/sft", json=body)
+        _raise_for_status(r)
+        return FineTuneJob.model_validate(r.json())
+
+    async def asft(self, model: str, dataset: str, **kwargs: Any) -> FineTuneJob:
+        body: dict[str, Any] = {"model": model, "dataset": dataset, **kwargs}
+        r = await self._aclient.post(f"{self._base}/sft", json=body)
+        _raise_for_status(r)
+        return FineTuneJob.model_validate(r.json())
+
+    def cpt(self, model: str, dataset: str, **kwargs: Any) -> FineTuneJob:
+        body: dict[str, Any] = {"model": model, "dataset": dataset, **kwargs}
+        r = self._client.post(f"{self._base}/cpt", json=body)
+        _raise_for_status(r)
+        return FineTuneJob.model_validate(r.json())
+
+    async def acpt(self, model: str, dataset: str, **kwargs: Any) -> FineTuneJob:
+        body: dict[str, Any] = {"model": model, "dataset": dataset, **kwargs}
+        r = await self._aclient.post(f"{self._base}/cpt", json=body)
+        _raise_for_status(r)
+        return FineTuneJob.model_validate(r.json())
+
+    def status(self, job_id: str) -> FineTuneJob:
+        r = self._client.get(f"{self._base}/jobs/{job_id}")
+        _raise_for_status(r)
+        return FineTuneJob.model_validate(r.json())
+
+    async def astatus(self, job_id: str) -> FineTuneJob:
+        r = await self._aclient.get(f"{self._base}/jobs/{job_id}")
+        _raise_for_status(r)
+        return FineTuneJob.model_validate(r.json())
+
+    def jobs(self) -> list[FineTuneJob]:
+        r = self._client.get(f"{self._base}/jobs")
+        _raise_for_status(r)
+        return [FineTuneJob.model_validate(j) for j in r.json()]
+
+    async def ajobs(self) -> list[FineTuneJob]:
+        r = await self._aclient.get(f"{self._base}/jobs")
+        _raise_for_status(r)
+        return [FineTuneJob.model_validate(j) for j in r.json()]
+
+    def cancel(self, job_id: str) -> FineTuneJob:
+        r = self._client.delete(f"{self._base}/jobs/{job_id}")
+        _raise_for_status(r)
+        return FineTuneJob.model_validate(r.json())
+
+    async def acancel(self, job_id: str) -> FineTuneJob:
+        r = await self._aclient.delete(f"{self._base}/jobs/{job_id}")
+        _raise_for_status(r)
+        return FineTuneJob.model_validate(r.json())
+
+    def validate(self, dataset: str, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"dataset": dataset, **kwargs}
+        r = self._client.post(f"{self._base}/validate", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    async def avalidate(self, dataset: str, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"dataset": dataset, **kwargs}
+        r = await self._aclient.post(f"{self._base}/validate", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    def templates(self) -> list[FineTuneTemplate]:
+        r = self._client.get(f"{self._base}/templates")
+        _raise_for_status(r)
+        return [FineTuneTemplate.model_validate(t) for t in r.json()]
+
+    async def atemplates(self) -> list[FineTuneTemplate]:
+        r = await self._aclient.get(f"{self._base}/templates")
+        _raise_for_status(r)
+        return [FineTuneTemplate.model_validate(t) for t in r.json()]
+
+
+class NLPAPI:
+    """NLP operations: embeddings, classification, NER, reranking."""
+
+    def __init__(self, client: httpx.Client, aclient: httpx.AsyncClient, base_url: str, runtime_url: str):
+        self._client = client
+        self._aclient = aclient
+        self._base = f"{base_url}/nlp"
+        self._runtime = runtime_url
+
+    def embeddings(self, input: str | list[str], *, model: str | None = None, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"input": input, **kwargs}
+        if model:
+            body["model"] = model
+        r = self._client.post(f"{self._base}/embeddings", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    async def aembeddings(self, input: str | list[str], *, model: str | None = None, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"input": input, **kwargs}
+        if model:
+            body["model"] = model
+        r = await self._aclient.post(f"{self._base}/embeddings", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    def classify(self, text: str, *, labels: list[str] | None = None, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"text": text, **kwargs}
+        if labels:
+            body["labels"] = labels
+        r = self._client.post(f"{self._base}/classify", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    async def aclassify(self, text: str, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"text": text, **kwargs}
+        r = await self._aclient.post(f"{self._base}/classify", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    def ner(self, text: str, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"text": text, **kwargs}
+        r = self._client.post(f"{self._base}/ner", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    async def aner(self, text: str, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"text": text, **kwargs}
+        r = await self._aclient.post(f"{self._base}/ner", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    def rerank(self, query: str, documents: list[str], *, model: str | None = None, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"query": query, "documents": documents, **kwargs}
+        if model:
+            body["model"] = model
+        r = self._client.post(f"{self._base}/rerank", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    async def arerank(self, query: str, documents: list[str], **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"query": query, "documents": documents, **kwargs}
+        r = await self._aclient.post(f"{self._base}/rerank", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+
+class AnomalyAPI:
+    """Anomaly detection operations."""
+
+    def __init__(self, client: httpx.Client, aclient: httpx.AsyncClient, base_url: str):
+        self._client = client
+        self._aclient = aclient
+        self._base = f"{base_url}/ml/anomaly"
+
+    def fit(self, data: list, *, model: str | None = None, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"data": data, **kwargs}
+        if model:
+            body["model"] = model
+        r = self._client.post(f"{self._base}/fit", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    async def afit(self, data: list, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"data": data, **kwargs}
+        r = await self._aclient.post(f"{self._base}/fit", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    def detect(self, data: list, *, model: str | None = None, explain: bool = False, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"data": data, **kwargs}
+        if model:
+            body["model"] = model
+        if explain:
+            body["explain"] = True
+        r = self._client.post(f"{self._base}/detect", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    async def adetect(self, data: list, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"data": data, **kwargs}
+        r = await self._aclient.post(f"{self._base}/detect", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    def score(self, data: list, *, model: str | None = None, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"data": data, **kwargs}
+        if model:
+            body["model"] = model
+        r = self._client.post(f"{self._base}/score", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    async def ascore(self, data: list, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"data": data, **kwargs}
+        r = await self._aclient.post(f"{self._base}/score", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    def load(self, model_id: str, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"model_id": model_id, **kwargs}
+        r = self._client.post(f"{self._base}/load", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    async def aload(self, model_id: str, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"model_id": model_id, **kwargs}
+        r = await self._aclient.post(f"{self._base}/load", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    def save(self, model_id: str, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"model_id": model_id, **kwargs}
+        r = self._client.post(f"{self._base}/save", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    async def asave(self, model_id: str, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"model_id": model_id, **kwargs}
+        r = await self._aclient.post(f"{self._base}/save", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    def models(self) -> dict[str, Any]:
+        r = self._client.get(f"{self._base}/models")
+        _raise_for_status(r)
+        return r.json()
+
+    async def amodels(self) -> dict[str, Any]:
+        r = await self._aclient.get(f"{self._base}/models")
+        _raise_for_status(r)
+        return r.json()
+
+    def backends(self) -> dict[str, Any]:
+        r = self._client.get(f"{self._base}/backends")
+        _raise_for_status(r)
+        return r.json()
+
+    async def abackends(self) -> dict[str, Any]:
+        r = await self._aclient.get(f"{self._base}/backends")
+        _raise_for_status(r)
+        return r.json()
+
+    def stream(self, data: list, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"data": data, **kwargs}
+        r = self._client.post(f"{self._base}/stream", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    async def astream(self, data: list, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"data": data, **kwargs}
+        r = await self._aclient.post(f"{self._base}/stream", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    def stream_status(self, model_id: str) -> dict[str, Any]:
+        r = self._client.get(f"{self._base}/stream/{model_id}")
+        _raise_for_status(r)
+        return r.json()
+
+    async def astream_status(self, model_id: str) -> dict[str, Any]:
+        r = await self._aclient.get(f"{self._base}/stream/{model_id}")
+        _raise_for_status(r)
+        return r.json()
+
+
+class ClassifierAPI:
+    """ML classifier operations."""
+
+    def __init__(self, client: httpx.Client, aclient: httpx.AsyncClient, base_url: str):
+        self._client = client
+        self._aclient = aclient
+        self._base = f"{base_url}/ml/classifier"
+
+    def fit(self, data: list, labels: list, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"data": data, "labels": labels, **kwargs}
+        r = self._client.post(f"{self._base}/fit", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    async def afit(self, data: list, labels: list, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"data": data, "labels": labels, **kwargs}
+        r = await self._aclient.post(f"{self._base}/fit", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    def predict(self, data: list, *, model: str | None = None, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"data": data, **kwargs}
+        if model:
+            body["model"] = model
+        r = self._client.post(f"{self._base}/predict", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    async def apredict(self, data: list, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"data": data, **kwargs}
+        r = await self._aclient.post(f"{self._base}/predict", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    def load(self, model_id: str, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"model_id": model_id, **kwargs}
+        r = self._client.post(f"{self._base}/load", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    async def aload(self, model_id: str, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"model_id": model_id, **kwargs}
+        r = await self._aclient.post(f"{self._base}/load", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    def save(self, model_id: str, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"model_id": model_id, **kwargs}
+        r = self._client.post(f"{self._base}/save", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    async def asave(self, model_id: str, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"model_id": model_id, **kwargs}
+        r = await self._aclient.post(f"{self._base}/save", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    def models(self) -> dict[str, Any]:
+        r = self._client.get(f"{self._base}/models")
+        _raise_for_status(r)
+        return r.json()
+
+    async def amodels(self) -> dict[str, Any]:
+        r = await self._aclient.get(f"{self._base}/models")
+        _raise_for_status(r)
+        return r.json()
+
+
+class TimeSeriesAPI:
+    """Time series forecasting operations."""
+
+    def __init__(self, client: httpx.Client, aclient: httpx.AsyncClient, base_url: str):
+        self._client = client
+        self._aclient = aclient
+        self._base = f"{base_url}/timeseries"
+
+    def fit(self, data: list, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"data": data, **kwargs}
+        r = self._client.post(f"{self._base}/fit", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    async def afit(self, data: list, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"data": data, **kwargs}
+        r = await self._aclient.post(f"{self._base}/fit", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    def predict(self, *, model: str | None = None, horizon: int | None = None, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {**kwargs}
+        if model:
+            body["model"] = model
+        if horizon is not None:
+            body["horizon"] = horizon
+        r = self._client.post(f"{self._base}/predict", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    async def apredict(self, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {**kwargs}
+        r = await self._aclient.post(f"{self._base}/predict", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    def load(self, model_id: str, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"model_id": model_id, **kwargs}
+        r = self._client.post(f"{self._base}/load", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    async def aload(self, model_id: str, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"model_id": model_id, **kwargs}
+        r = await self._aclient.post(f"{self._base}/load", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    def models(self) -> dict[str, Any]:
+        r = self._client.get(f"{self._base}/models")
+        _raise_for_status(r)
+        return r.json()
+
+    async def amodels(self) -> dict[str, Any]:
+        r = await self._aclient.get(f"{self._base}/models")
+        _raise_for_status(r)
+        return r.json()
+
+    def backends(self) -> dict[str, Any]:
+        r = self._client.get(f"{self._base}/backends")
+        _raise_for_status(r)
+        return r.json()
+
+    async def abackends(self) -> dict[str, Any]:
+        r = await self._aclient.get(f"{self._base}/backends")
+        _raise_for_status(r)
+        return r.json()
+
+
+class ADTKAPI:
+    """ADTK anomaly detection toolkit operations."""
+
+    def __init__(self, client: httpx.Client, aclient: httpx.AsyncClient, base_url: str):
+        self._client = client
+        self._aclient = aclient
+        self._base = f"{base_url}/adtk"
+
+    def fit(self, data: list, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"data": data, **kwargs}
+        r = self._client.post(f"{self._base}/fit", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    async def afit(self, data: list, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"data": data, **kwargs}
+        r = await self._aclient.post(f"{self._base}/fit", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    def detect(self, data: list, *, model: str | None = None, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"data": data, **kwargs}
+        if model:
+            body["model"] = model
+        r = self._client.post(f"{self._base}/detect", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    async def adetect(self, data: list, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"data": data, **kwargs}
+        r = await self._aclient.post(f"{self._base}/detect", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    def load(self, model_id: str, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"model_id": model_id, **kwargs}
+        r = self._client.post(f"{self._base}/load", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    async def aload(self, model_id: str, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"model_id": model_id, **kwargs}
+        r = await self._aclient.post(f"{self._base}/load", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    def models(self) -> dict[str, Any]:
+        r = self._client.get(f"{self._base}/models")
+        _raise_for_status(r)
+        return r.json()
+
+    async def amodels(self) -> dict[str, Any]:
+        r = await self._aclient.get(f"{self._base}/models")
+        _raise_for_status(r)
+        return r.json()
+
+    def detectors(self) -> dict[str, Any]:
+        r = self._client.get(f"{self._base}/detectors")
+        _raise_for_status(r)
+        return r.json()
+
+    async def adetectors(self) -> dict[str, Any]:
+        r = await self._aclient.get(f"{self._base}/detectors")
+        _raise_for_status(r)
+        return r.json()
+
+
+class CatBoostAPI:
+    """CatBoost ML operations."""
+
+    def __init__(self, client: httpx.Client, aclient: httpx.AsyncClient, base_url: str):
+        self._client = client
+        self._aclient = aclient
+        self._base = f"{base_url}/catboost"
+
+    def fit(self, data: list, labels: list, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"data": data, "labels": labels, **kwargs}
+        r = self._client.post(f"{self._base}/fit", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    async def afit(self, data: list, labels: list, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"data": data, "labels": labels, **kwargs}
+        r = await self._aclient.post(f"{self._base}/fit", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    def predict(self, data: list, *, model: str | None = None, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"data": data, **kwargs}
+        if model:
+            body["model"] = model
+        r = self._client.post(f"{self._base}/predict", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    async def apredict(self, data: list, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"data": data, **kwargs}
+        r = await self._aclient.post(f"{self._base}/predict", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    def load(self, model_id: str, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"model_id": model_id, **kwargs}
+        r = self._client.post(f"{self._base}/load", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    async def aload(self, model_id: str, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"model_id": model_id, **kwargs}
+        r = await self._aclient.post(f"{self._base}/load", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    def update(self, data: list, labels: list, *, model: str | None = None, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"data": data, "labels": labels, **kwargs}
+        if model:
+            body["model"] = model
+        r = self._client.post(f"{self._base}/update", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    async def aupdate(self, data: list, labels: list, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"data": data, "labels": labels, **kwargs}
+        r = await self._aclient.post(f"{self._base}/update", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    def models(self) -> dict[str, Any]:
+        r = self._client.get(f"{self._base}/models")
+        _raise_for_status(r)
+        return r.json()
+
+    async def amodels(self) -> dict[str, Any]:
+        r = await self._aclient.get(f"{self._base}/models")
+        _raise_for_status(r)
+        return r.json()
+
+    def info(self) -> dict[str, Any]:
+        r = self._client.get(f"{self._base}/info")
+        _raise_for_status(r)
+        return r.json()
+
+    async def ainfo(self) -> dict[str, Any]:
+        r = await self._aclient.get(f"{self._base}/info")
+        _raise_for_status(r)
+        return r.json()
+
+    def importance(self, model_id: str) -> dict[str, Any]:
+        r = self._client.get(f"{self._base}/{model_id}/importance")
+        _raise_for_status(r)
+        return r.json()
+
+    async def aimportance(self, model_id: str) -> dict[str, Any]:
+        r = await self._aclient.get(f"{self._base}/{model_id}/importance")
+        _raise_for_status(r)
+        return r.json()
+
+
+class DriftAPI:
+    """Drift detection operations."""
+
+    def __init__(self, client: httpx.Client, aclient: httpx.AsyncClient, base_url: str):
+        self._client = client
+        self._aclient = aclient
+        self._base = f"{base_url}/drift"
+
+    def fit(self, data: list, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"data": data, **kwargs}
+        r = self._client.post(f"{self._base}/fit", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    async def afit(self, data: list, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"data": data, **kwargs}
+        r = await self._aclient.post(f"{self._base}/fit", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    def detect(self, data: list, *, model: str | None = None, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"data": data, **kwargs}
+        if model:
+            body["model"] = model
+        r = self._client.post(f"{self._base}/detect", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    async def adetect(self, data: list, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"data": data, **kwargs}
+        r = await self._aclient.post(f"{self._base}/detect", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    def load(self, model_id: str, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"model_id": model_id, **kwargs}
+        r = self._client.post(f"{self._base}/load", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    async def aload(self, model_id: str, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"model_id": model_id, **kwargs}
+        r = await self._aclient.post(f"{self._base}/load", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    def models(self) -> dict[str, Any]:
+        r = self._client.get(f"{self._base}/models")
+        _raise_for_status(r)
+        return r.json()
+
+    async def amodels(self) -> dict[str, Any]:
+        r = await self._aclient.get(f"{self._base}/models")
+        _raise_for_status(r)
+        return r.json()
+
+    def detectors(self) -> dict[str, Any]:
+        r = self._client.get(f"{self._base}/detectors")
+        _raise_for_status(r)
+        return r.json()
+
+    async def adetectors(self) -> dict[str, Any]:
+        r = await self._aclient.get(f"{self._base}/detectors")
+        _raise_for_status(r)
+        return r.json()
+
+    def status(self, model_name: str) -> dict[str, Any]:
+        r = self._client.get(f"{self._base}/status/{model_name}")
+        _raise_for_status(r)
+        return r.json()
+
+    async def astatus(self, model_name: str) -> dict[str, Any]:
+        r = await self._aclient.get(f"{self._base}/status/{model_name}")
+        _raise_for_status(r)
+        return r.json()
+
+
+class ExplainAPI:
+    """Explainability operations (SHAP, feature importance)."""
+
+    def __init__(self, client: httpx.Client, aclient: httpx.AsyncClient, base_url: str):
+        self._client = client
+        self._aclient = aclient
+        self._base = f"{base_url}/explain"
+
+    def shap(self, data: list, *, model: str | None = None, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"data": data, **kwargs}
+        if model:
+            body["model"] = model
+        r = self._client.post(f"{self._base}/shap", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    async def ashap(self, data: list, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"data": data, **kwargs}
+        r = await self._aclient.post(f"{self._base}/shap", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    def importance(self, *, model: str | None = None, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {**kwargs}
+        if model:
+            body["model"] = model
+        r = self._client.post(f"{self._base}/importance", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    async def aimportance(self, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {**kwargs}
+        r = await self._aclient.post(f"{self._base}/importance", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    def explainers(self) -> dict[str, Any]:
+        r = self._client.get(f"{self._base}/explainers")
+        _raise_for_status(r)
+        return r.json()
+
+    async def aexplainers(self) -> dict[str, Any]:
+        r = await self._aclient.get(f"{self._base}/explainers")
+        _raise_for_status(r)
+        return r.json()
+
+
+class PolarsAPI:
+    """Polars data processing buffer operations."""
+
+    def __init__(self, client: httpx.Client, aclient: httpx.AsyncClient, base_url: str):
+        self._client = client
+        self._aclient = aclient
+        self._base = f"{base_url}/ml/polars"
+
+    def create_buffer(self, **kwargs: Any) -> dict[str, Any]:
+        r = self._client.post(f"{self._base}/buffers", json=kwargs)
+        _raise_for_status(r)
+        return r.json()
+
+    async def acreate_buffer(self, **kwargs: Any) -> dict[str, Any]:
+        r = await self._aclient.post(f"{self._base}/buffers", json=kwargs)
+        _raise_for_status(r)
+        return r.json()
+
+    def append(self, buffer_id: str, data: list, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"buffer_id": buffer_id, "data": data, **kwargs}
+        r = self._client.post(f"{self._base}/append", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    async def aappend(self, buffer_id: str, data: list, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"buffer_id": buffer_id, "data": data, **kwargs}
+        r = await self._aclient.post(f"{self._base}/append", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    def features(self, buffer_id: str, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"buffer_id": buffer_id, **kwargs}
+        r = self._client.post(f"{self._base}/features", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    async def afeatures(self, buffer_id: str, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"buffer_id": buffer_id, **kwargs}
+        r = await self._aclient.post(f"{self._base}/features", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    def list_buffers(self) -> dict[str, Any]:
+        r = self._client.get(f"{self._base}/buffers")
+        _raise_for_status(r)
+        return r.json()
+
+    async def alist_buffers(self) -> dict[str, Any]:
+        r = await self._aclient.get(f"{self._base}/buffers")
+        _raise_for_status(r)
+        return r.json()
+
+    def get_buffer(self, buffer_id: str) -> dict[str, Any]:
+        r = self._client.get(f"{self._base}/buffers/{buffer_id}")
+        _raise_for_status(r)
+        return r.json()
+
+    async def aget_buffer(self, buffer_id: str) -> dict[str, Any]:
+        r = await self._aclient.get(f"{self._base}/buffers/{buffer_id}")
+        _raise_for_status(r)
+        return r.json()
+
+    def get_buffer_data(self, buffer_id: str) -> dict[str, Any]:
+        r = self._client.get(f"{self._base}/buffers/{buffer_id}/data")
+        _raise_for_status(r)
+        return r.json()
+
+    async def aget_buffer_data(self, buffer_id: str) -> dict[str, Any]:
+        r = await self._aclient.get(f"{self._base}/buffers/{buffer_id}/data")
+        _raise_for_status(r)
+        return r.json()
+
+
+class CacheAPI:
+    """KV cache operations (runtime-level, port 11540)."""
+
+    def __init__(self, client: httpx.Client, aclient: httpx.AsyncClient, runtime_url: str):
+        self._client = client
+        self._aclient = aclient
+        self._base = f"{runtime_url}/v1/cache"
+
+    def prepare(self, messages: list[dict[str, str]], **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"messages": messages, **kwargs}
+        r = self._client.post(f"{self._base}/prepare", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    async def aprepare(self, messages: list[dict[str, str]], **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"messages": messages, **kwargs}
+        r = await self._aclient.post(f"{self._base}/prepare", json=body)
+        _raise_for_status(r)
+        return r.json()
+
+    def stats(self) -> CacheStats:
+        r = self._client.get(f"{self._base}/stats")
+        _raise_for_status(r)
+        return CacheStats.model_validate(r.json())
+
+    async def astats(self) -> CacheStats:
+        r = await self._aclient.get(f"{self._base}/stats")
+        _raise_for_status(r)
+        return CacheStats.model_validate(r.json())
+
+    def gc(self) -> dict[str, Any]:
+        r = self._client.post(f"{self._base}/gc")
+        _raise_for_status(r)
+        return r.json()
+
+    async def agc(self) -> dict[str, Any]:
+        r = await self._aclient.post(f"{self._base}/gc")
+        _raise_for_status(r)
+        return r.json()
+
+    def clear(self, key: str) -> dict[str, Any]:
+        r = self._client.delete(f"{self._base}/{key}")
+        _raise_for_status(r)
+        return r.json()
+
+    async def aclear(self, key: str) -> dict[str, Any]:
+        r = await self._aclient.delete(f"{self._base}/{key}")
+        _raise_for_status(r)
+        return r.json()
+
+
+# ── ProjectHandle ────────────────────────────────────────────────────────────
+
+
+class ProjectHandle:
+    """Handle to a specific project, providing chat, RAG, and dataset operations."""
+
+    def __init__(
+        self,
+        client: httpx.Client,
+        aclient: httpx.AsyncClient,
+        base_url: str,
+        namespace: str,
+        project_id: str,
+    ):
+        self._client = client
+        self._aclient = aclient
+        self._base_url = base_url
+        self.namespace = namespace
+        self.project_id = project_id
+        self._path = f"{base_url}/projects/{namespace}/{project_id}"
+
+    @property
+    def rag(self) -> RAGAPI:
+        return RAGAPI(self._client, self._aclient, f"{self._path}/rag")
+
+    @property
+    def datasets(self) -> DatasetsAPI:
+        return DatasetsAPI(self._client, self._aclient, f"{self._path}/datasets")
+
+    def info(self) -> ProjectInfo:
+        """Get project info."""
+        r = self._client.get(self._path)
+        _raise_for_status(r)
+        return ProjectInfo.model_validate(r.json())
+
+    async def ainfo(self) -> ProjectInfo:
+        r = await self._aclient.get(self._path)
+        _raise_for_status(r)
+        return ProjectInfo.model_validate(r.json())
+
+    def update_config(self, config: dict[str, Any]) -> dict[str, Any]:
+        """Update the project configuration."""
+        r = self._client.put(self._path, json=config)
+        _raise_for_status(r)
+        return r.json()
+
+    async def aupdate_config(self, config: dict[str, Any]) -> dict[str, Any]:
+        r = await self._aclient.put(self._path, json=config)
+        _raise_for_status(r)
+        return r.json()
+
+    def delete(self) -> dict[str, Any]:
+        """Delete this project."""
+        r = self._client.delete(self._path)
+        _raise_for_status(r)
+        return r.json()
+
+    async def adelete(self) -> dict[str, Any]:
+        r = await self._aclient.delete(self._path)
+        _raise_for_status(r)
+        return r.json()
+
+    def chat(
+        self,
+        messages: str | list[str | dict | ChatMessage],
+        *,
+        model: str | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        session_id: str | None = None,
+        stateless: bool = False,
+        **kwargs: Any,
+    ) -> ChatResponse:
+        """Send a chat completion request.
+
+        Args:
+            messages: A string, list of strings, or list of message dicts/ChatMessage objects.
+            model: Override the project's default model.
+            temperature: Sampling temperature.
+            max_tokens: Maximum tokens to generate.
+            tools: Tool definitions for function calling.
+            session_id: Session ID for conversation continuity.
+            stateless: If True, don't create/use sessions.
+        """
+        body: dict[str, Any] = {"messages": _normalize_messages(messages), "stream": False}
+        for k, v in {"model": model, "temperature": temperature, "max_tokens": max_tokens, "tools": tools}.items():
+            if v is not None:
+                body[k] = v
+        body.update(kwargs)
+        headers: dict[str, str] = {}
+        if session_id:
+            headers["X-Session-ID"] = session_id
+        if stateless:
+            headers["X-No-Session"] = "true"
+        r = self._client.post(f"{self._path}/chat/completions", json=body, headers=headers)
+        _raise_for_status(r)
+        return ChatResponse.model_validate(r.json())
+
+    async def achat(
+        self,
+        messages: str | list[str | dict | ChatMessage],
+        *,
+        model: str | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        session_id: str | None = None,
+        stateless: bool = False,
+        **kwargs: Any,
+    ) -> ChatResponse:
+        """Async variant of chat."""
+        body: dict[str, Any] = {"messages": _normalize_messages(messages), "stream": False}
+        for k, v in {"model": model, "temperature": temperature, "max_tokens": max_tokens, "tools": tools}.items():
+            if v is not None:
+                body[k] = v
+        body.update(kwargs)
+        headers: dict[str, str] = {}
+        if session_id:
+            headers["X-Session-ID"] = session_id
+        if stateless:
+            headers["X-No-Session"] = "true"
+        r = await self._aclient.post(f"{self._path}/chat/completions", json=body, headers=headers)
+        _raise_for_status(r)
+        return ChatResponse.model_validate(r.json())
+
+    def chat_stream(
+        self,
+        messages: str | list[str | dict | ChatMessage],
+        *,
+        model: str | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        session_id: str | None = None,
+        stateless: bool = False,
+        **kwargs: Any,
+    ) -> Iterator[StreamChunk]:
+        """Stream a chat completion, yielding chunks."""
+        body: dict[str, Any] = {"messages": _normalize_messages(messages), "stream": True}
+        for k, v in {"model": model, "temperature": temperature, "max_tokens": max_tokens}.items():
+            if v is not None:
+                body[k] = v
+        body.update(kwargs)
+        headers: dict[str, str] = {}
+        if session_id:
+            headers["X-Session-ID"] = session_id
+        if stateless:
+            headers["X-No-Session"] = "true"
+        with self._client.stream("POST", f"{self._path}/chat/completions", json=body, headers=headers) as r:
+            _raise_for_status(r)
+            for line in r.iter_lines():
+                parsed = _parse_sse_line(line)
+                if parsed is not None:
+                    yield StreamChunk.model_validate(parsed)
+
+    async def achat_stream(
+        self,
+        messages: str | list[str | dict | ChatMessage],
+        *,
+        model: str | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        session_id: str | None = None,
+        stateless: bool = False,
+        **kwargs: Any,
+    ) -> AsyncIterator[StreamChunk]:
+        """Async stream a chat completion."""
+        body: dict[str, Any] = {"messages": _normalize_messages(messages), "stream": True}
+        for k, v in {"model": model, "temperature": temperature, "max_tokens": max_tokens}.items():
+            if v is not None:
+                body[k] = v
+        body.update(kwargs)
+        headers: dict[str, str] = {}
+        if session_id:
+            headers["X-Session-ID"] = session_id
+        if stateless:
+            headers["X-No-Session"] = "true"
+        async with self._aclient.stream("POST", f"{self._path}/chat/completions", json=body, headers=headers) as r:
+            _raise_for_status(r)
+            async for line in r.aiter_lines():
+                parsed = _parse_sse_line(line)
+                if parsed is not None:
+                    yield StreamChunk.model_validate(parsed)
+
+    def __repr__(self) -> str:
+        return f"ProjectHandle({self.namespace}/{self.project_id})"
+
+
+# ── Main Client ──────────────────────────────────────────────────────────────
+
+
+class LlamaFarm:
+    """LlamaFarm SDK client.
+
+    Args:
+        url: Main server URL (default: auto-discover or http://localhost:14345).
+        api_key: API key for authentication (optional).
+        runtime_url: Universal Runtime URL for fine-tuning/cache (default: http://localhost:11540).
+        timeout: Request timeout in seconds.
+    """
+
+    def __init__(
+        self,
+        url: str | None = None,
+        *,
+        api_key: str | None = None,
+        runtime_url: str | None = None,
+        timeout: float = _DEFAULT_TIMEOUT,
+    ):
+        self._raw_url = (url or _discover_url("LLAMAFARM_URL", _DEFAULT_URL)).rstrip("/")
+        self.url = f"{self._raw_url}/v1"
+        self.runtime_url = (runtime_url or _discover_url("LLAMAFARM_RUNTIME_URL", _DEFAULT_RUNTIME_URL)).rstrip("/")
+
+        headers: dict[str, str] = {}
+        api_key = api_key or os.environ.get("LLAMAFARM_API_KEY")
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+
+        self._client = httpx.Client(base_url="", headers=headers, timeout=timeout)
+        self._aclient = httpx.AsyncClient(base_url="", headers=headers, timeout=timeout)
+
+    def close(self) -> None:
+        self._client.close()
+
+    async def aclose(self) -> None:
+        await self._aclient.aclose()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        await self.aclose()
+
+    # ── Top-level operations ─────────────────────────────────────────────
+
+    def health(self) -> dict[str, Any]:
+        """Check main server health."""
+        try:
+            r = self._client.get(f"{self._raw_url}/health")
+            return r.json()
+        except httpx.ConnectError as e:
+            raise ConnectionError(f"Cannot connect to LlamaFarm at {self._raw_url}") from e
+
+    async def ahealth(self) -> dict[str, Any]:
+        try:
+            r = await self._aclient.get(f"{self._raw_url}/health")
+            return r.json()
+        except httpx.ConnectError as e:
+            raise ConnectionError(f"Cannot connect to LlamaFarm at {self._raw_url}") from e
+
+    def models(self) -> list[dict[str, Any]]:
+        """List available models."""
+        r = self._client.get(f"{self.url}/models")
+        _raise_for_status(r)
+        return r.json()
+
+    async def amodels(self) -> list[dict[str, Any]]:
+        r = await self._aclient.get(f"{self.url}/models")
+        _raise_for_status(r)
+        return r.json()
+
+    # ── Project operations ───────────────────────────────────────────────
+
+    def projects(self, namespace: str = "default") -> list[ProjectInfo]:
+        """List projects in a namespace."""
+        r = self._client.get(f"{self.url}/projects/{namespace}")
+        _raise_for_status(r)
+        data = r.json()
+        items = data.get("projects", data) if isinstance(data, dict) else data
+        return [ProjectInfo.model_validate(p) for p in items]
+
+    async def aprojects(self, namespace: str = "default") -> list[ProjectInfo]:
+        r = await self._aclient.get(f"{self.url}/projects/{namespace}")
+        _raise_for_status(r)
+        data = r.json()
+        items = data.get("projects", data) if isinstance(data, dict) else data
+        return [ProjectInfo.model_validate(p) for p in items]
+
+    def project(self, namespace: str, project_id: str) -> ProjectHandle:
+        """Get a handle to an existing project (no API call — lazy)."""
+        return ProjectHandle(self._client, self._aclient, self.url, namespace, project_id)
+
+    def create_project(
+        self,
+        namespace: str,
+        name: str,
+        *,
+        model: str = "unsloth/Qwen3-1.7B-GGUF:Q4_K_M",
+        provider: str = "universal",
+        system_prompt: str = "You are a helpful assistant.",
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        config_template: dict[str, Any] | None = None,
+    ) -> ProjectHandle:
+        """Create a new project and return a handle.
+
+        If config_template is provided, it's used directly. Otherwise, a config
+        is generated from the convenience parameters (model, system_prompt, etc.).
+        """
+        if config_template is None:
+            config_template = build_project_config(
+                name, namespace,
+                model=model, provider=provider, system_prompt=system_prompt,
+                temperature=temperature, max_tokens=max_tokens,
+            )
+        body = {"name": name, "config_template": config_template}
+        r = self._client.post(f"{self.url}/projects/{namespace}", json=body)
+        _raise_for_status(r)
+        data = r.json()
+        pid = data.get("id", data.get("project_id", name))
+        return ProjectHandle(self._client, self._aclient, self.url, namespace, pid)
+
+    async def acreate_project(
+        self,
+        namespace: str,
+        name: str,
+        *,
+        model: str = "unsloth/Qwen3-1.7B-GGUF:Q4_K_M",
+        provider: str = "universal",
+        system_prompt: str = "You are a helpful assistant.",
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        config_template: dict[str, Any] | None = None,
+    ) -> ProjectHandle:
+        if config_template is None:
+            config_template = build_project_config(
+                name, namespace,
+                model=model, provider=provider, system_prompt=system_prompt,
+                temperature=temperature, max_tokens=max_tokens,
+            )
+        body = {"name": name, "config_template": config_template}
+        r = await self._aclient.post(f"{self.url}/projects/{namespace}", json=body)
+        _raise_for_status(r)
+        data = r.json()
+        pid = data.get("id", data.get("project_id", name))
+        return ProjectHandle(self._client, self._aclient, self.url, namespace, pid)
+
+    # ── Sub-API accessors ────────────────────────────────────────────────
+
+    @property
+    def openai_base_url(self) -> str:
+        """Return URL compatible with ``openai.OpenAI(base_url=...)``."""
+        return f"{self.runtime_url}/v1"
+
+    @property
+    def vision(self) -> VisionAPI:
+        return VisionAPI(self._client, self._aclient, self.url)
+
+    @property
+    def finetune(self) -> FineTuneAPI:
+        return FineTuneAPI(self._client, self._aclient, self.runtime_url)
+
+    @property
+    def cache(self) -> CacheAPI:
+        return CacheAPI(self._client, self._aclient, self.runtime_url)
+
+    @property
+    def nlp(self) -> NLPAPI:
+        return NLPAPI(self._client, self._aclient, self.url, self.runtime_url)
+
+    @property
+    def anomaly(self) -> AnomalyAPI:
+        return AnomalyAPI(self._client, self._aclient, self.url)
+
+    @property
+    def classifier(self) -> ClassifierAPI:
+        return ClassifierAPI(self._client, self._aclient, self.url)
+
+    @property
+    def timeseries(self) -> TimeSeriesAPI:
+        return TimeSeriesAPI(self._client, self._aclient, self.url)
+
+    @property
+    def adtk(self) -> ADTKAPI:
+        return ADTKAPI(self._client, self._aclient, self.url)
+
+    @property
+    def catboost(self) -> CatBoostAPI:
+        return CatBoostAPI(self._client, self._aclient, self.url)
+
+    @property
+    def drift(self) -> DriftAPI:
+        return DriftAPI(self._client, self._aclient, self.url)
+
+    @property
+    def explain(self) -> ExplainAPI:
+        return ExplainAPI(self._client, self._aclient, self.url)
+
+    @property
+    def polars(self) -> PolarsAPI:
+        return PolarsAPI(self._client, self._aclient, self.url)
+
+    def __repr__(self) -> str:
+        return f"LlamaFarm(url={self.url!r})"

--- a/packages/llamafarm-sdk/src/llamafarm/errors.py
+++ b/packages/llamafarm-sdk/src/llamafarm/errors.py
@@ -1,0 +1,53 @@
+"""LlamaFarm SDK errors."""
+
+from __future__ import annotations
+
+
+class LlamaFarmError(Exception):
+    """Base error for all LlamaFarm SDK errors."""
+
+    def __init__(self, message: str, status_code: int | None = None, detail: str | None = None):
+        self.status_code = status_code
+        self.detail = detail
+        super().__init__(message)
+
+
+class ConnectionError(LlamaFarmError):
+    """Cannot connect to LlamaFarm server."""
+
+
+class NotFoundError(LlamaFarmError):
+    """Resource not found (project, model, job, etc.)."""
+
+
+class ValidationError(LlamaFarmError):
+    """Request validation failed."""
+
+
+class ServerError(LlamaFarmError):
+    """Server-side error."""
+
+
+def _raise_for_status(response) -> None:
+    """Raise appropriate LlamaFarmError for non-2xx responses."""
+    if response.status_code < 400:
+        return
+
+    try:
+        body = response.json()
+        detail = body.get("detail", response.text)
+    except Exception:
+        detail = response.text
+
+    if response.status_code == 404:
+        raise NotFoundError(f"Not found: {detail}", status_code=404, detail=detail)
+    elif response.status_code == 422:
+        raise ValidationError(f"Validation error: {detail}", status_code=422, detail=detail)
+    elif response.status_code >= 500:
+        raise ServerError(f"Server error: {detail}", status_code=response.status_code, detail=detail)
+    else:
+        raise LlamaFarmError(
+            f"HTTP {response.status_code}: {detail}",
+            status_code=response.status_code,
+            detail=detail,
+        )

--- a/packages/llamafarm-sdk/src/llamafarm/types.py
+++ b/packages/llamafarm-sdk/src/llamafarm/types.py
@@ -1,0 +1,254 @@
+"""LlamaFarm SDK types — request/response models matching server APIs."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+# ── Chat ─────────────────────────────────────────────────────────────────────
+
+
+class ChatMessage(BaseModel):
+    """A single message in a chat conversation."""
+
+    role: Literal["system", "user", "assistant", "tool"] = Field(
+        description="Message role: system, user, assistant, or tool"
+    )
+    content: str | None = Field(default=None, description="Text content of the message")
+    tool_calls: list[dict[str, Any]] | None = Field(
+        default=None, description="Tool calls made by the assistant"
+    )
+    tool_call_id: str | None = Field(default=None, description="ID of the tool call being responded to")
+    name: str | None = Field(default=None, description="Optional name for the participant")
+
+
+class ChatChoice(BaseModel):
+    """A single completion choice."""
+
+    index: int = 0
+    message: ChatMessage
+    finish_reason: str | None = None
+
+
+class ChatUsage(BaseModel):
+    """Token usage statistics."""
+
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+
+
+class ChatResponse(BaseModel):
+    """Response from a chat completion request (OpenAI-compatible)."""
+
+    id: str = ""
+    object: str = "chat.completion"
+    created: int = 0
+    model: str = ""
+    choices: list[ChatChoice] = Field(default_factory=list)
+    usage: ChatUsage | None = None
+
+    @property
+    def text(self) -> str:
+        """Shortcut: get the first choice's message content."""
+        if self.choices and self.choices[0].message.content:
+            return self.choices[0].message.content
+        return ""
+
+
+class StreamChunk(BaseModel):
+    """A single SSE chunk from a streaming chat response."""
+
+    id: str = ""
+    object: str = "chat.completion.chunk"
+    created: int = 0
+    model: str = ""
+    choices: list[dict[str, Any]] = Field(default_factory=list)
+
+    @property
+    def delta_content(self) -> str | None:
+        """Extract text delta from the first choice."""
+        if self.choices:
+            delta = self.choices[0].get("delta", {})
+            return delta.get("content")
+        return None
+
+
+# ── Projects ─────────────────────────────────────────────────────────────────
+
+
+class ProjectInfo(BaseModel):
+    """Project metadata returned by list/get endpoints."""
+
+    id: str | None = Field(default=None, description="Unique project identifier")
+    name: str = Field(description="Human-readable project name")
+    namespace: str = Field(default="default", description="Project namespace")
+    config: dict[str, Any] = Field(default_factory=dict, description="Project configuration")
+    created_at: str | None = None
+    updated_at: str | None = None
+
+
+# ── RAG ──────────────────────────────────────────────────────────────────────
+
+
+class RAGResult(BaseModel):
+    """A single RAG retrieval result."""
+
+    content: str = ""
+    score: float = 0.0
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    document_id: str | None = None
+    chunk_id: str | None = None
+
+
+class QueryResponse(BaseModel):
+    """Response from a RAG query."""
+
+    results: list[RAGResult] = Field(default_factory=list)
+    query: str = ""
+    database: str | None = None
+    strategy: str | None = None
+
+
+class DatabaseInfo(BaseModel):
+    """RAG database metadata."""
+
+    name: str
+    type: str = "ChromaStore"
+    document_count: int = 0
+    chunk_count: int = 0
+
+
+# ── Vision ───────────────────────────────────────────────────────────────────
+
+
+class Detection(BaseModel):
+    """A single object detection result."""
+
+    label: str
+    confidence: float
+    bbox: list[float] = Field(default_factory=list, description="[x1, y1, x2, y2]")
+
+
+class DetectResponse(BaseModel):
+    """Response from vision detection."""
+
+    detections: list[Detection] = Field(default_factory=list)
+    model: str = ""
+    inference_time_ms: float = 0
+
+
+class Classification(BaseModel):
+    """A single classification result."""
+
+    label: str
+    confidence: float
+
+
+class ClassifyResponse(BaseModel):
+    """Response from vision classification."""
+
+    classifications: list[Classification] = Field(default_factory=list)
+    model: str = ""
+    inference_time_ms: float = 0
+
+
+# ── Fine-tuning ──────────────────────────────────────────────────────────────
+
+
+class FineTuneJob(BaseModel):
+    """Fine-tuning job status."""
+
+    job_id: str = Field(description="Unique job identifier")
+    status: str = Field(description="Job status: queued, running, completed, failed, cancelled")
+    model: str = ""
+    method: str = ""
+    progress: float = 0.0
+    metrics: dict[str, Any] = Field(default_factory=dict)
+    error: str | None = None
+    created_at: str | None = None
+    completed_at: str | None = None
+    output_model: str | None = Field(
+        default=None, description="Path to the fine-tuned model when completed"
+    )
+
+
+class FineTuneTemplate(BaseModel):
+    """A fine-tuning configuration template."""
+
+    name: str
+    method: str
+    description: str = ""
+    defaults: dict[str, Any] = Field(default_factory=dict)
+
+
+# ── KV Cache ─────────────────────────────────────────────────────────────────
+
+
+class CacheStats(BaseModel):
+    """KV cache statistics."""
+
+    total_entries: int = 0
+    total_size_bytes: int = 0
+    hit_rate: float = 0.0
+    entries: list[dict[str, Any]] = Field(default_factory=list)
+
+
+# ── Config generation ────────────────────────────────────────────────────────
+
+
+def build_project_config(
+    name: str,
+    namespace: str = "default",
+    *,
+    model: str = "unsloth/Qwen3-1.7B-GGUF:Q4_K_M",
+    provider: str = "universal",
+    system_prompt: str = "You are a helpful assistant.",
+    temperature: float | None = None,
+    max_tokens: int | None = None,
+    rag_databases: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Build a llamafarm.yaml-compatible project config dict.
+
+    Args:
+        name: Project name.
+        namespace: Project namespace.
+        model: Model identifier (e.g. "Qwen/Qwen3-8B").
+        provider: Model provider (default "universal").
+        system_prompt: Default system prompt.
+        temperature: Default temperature.
+        max_tokens: Default max tokens.
+        rag_databases: List of RAG database configs.
+
+    Returns:
+        Config dict matching the llamafarm.yaml schema.
+    """
+    model_config: dict[str, Any] = {
+        "name": "default",
+        "provider": provider,
+        "model": model,
+    }
+    if temperature is not None:
+        model_config["temperature"] = temperature
+    if max_tokens is not None:
+        model_config["max_tokens"] = max_tokens
+
+    config: dict[str, Any] = {
+        "version": "v1",
+        "name": name,
+        "namespace": namespace,
+        "runtime": {"models": [model_config]},
+        "prompts": [
+            {
+                "name": "default",
+                "messages": [{"role": "system", "content": system_prompt}],
+            }
+        ],
+    }
+
+    if rag_databases:
+        config["rag"] = {"databases": rag_databases}
+
+    return config

--- a/packages/llamafarm-sdk/tests/test_client.py
+++ b/packages/llamafarm-sdk/tests/test_client.py
@@ -1,0 +1,261 @@
+"""Tests for LlamaFarm SDK client."""
+
+from __future__ import annotations
+
+import json
+import os
+from unittest.mock import patch
+
+import httpx
+import pytest
+import respx
+
+from llamafarm import LlamaFarm, build_project_config
+from llamafarm.client import _normalize_messages, _parse_sse_line, ProjectHandle
+from llamafarm.types import ChatMessage
+
+
+# ── Message normalization ────────────────────────────────────────────────────
+
+
+class TestNormalizeMessages:
+    def test_string(self):
+        assert _normalize_messages("hello") == [{"role": "user", "content": "hello"}]
+
+    def test_list_of_strings(self):
+        result = _normalize_messages(["hi", "there"])
+        assert result == [{"role": "user", "content": "hi"}, {"role": "user", "content": "there"}]
+
+    def test_list_of_dicts(self):
+        msgs = [{"role": "system", "content": "sys"}, {"role": "user", "content": "hi"}]
+        assert _normalize_messages(msgs) == msgs
+
+    def test_chat_message_objects(self):
+        msgs = [ChatMessage(role="user", content="hello")]
+        result = _normalize_messages(msgs)
+        assert result == [{"role": "user", "content": "hello"}]
+
+    def test_mixed(self):
+        msgs = [{"role": "system", "content": "sys"}, "hello"]
+        result = _normalize_messages(msgs)
+        assert len(result) == 2
+        assert result[1] == {"role": "user", "content": "hello"}
+
+
+# ── SSE parsing ──────────────────────────────────────────────────────────────
+
+
+class TestSSEParsing:
+    def test_data_line(self):
+        data = {"id": "1", "choices": [{"delta": {"content": "hi"}}]}
+        result = _parse_sse_line(f"data: {json.dumps(data)}")
+        assert result == data
+
+    def test_done(self):
+        assert _parse_sse_line("data: [DONE]") is None
+
+    def test_empty(self):
+        assert _parse_sse_line("") is None
+        assert _parse_sse_line("   ") is None
+
+    def test_non_data(self):
+        assert _parse_sse_line("event: ping") is None
+
+    def test_invalid_json(self):
+        assert _parse_sse_line("data: {bad json") is None
+
+
+# ── Auto-discovery ───────────────────────────────────────────────────────────
+
+
+class TestAutoDiscovery:
+    def test_env_var(self):
+        with patch.dict(os.environ, {"LLAMAFARM_URL": "http://custom:9999"}):
+            lf = LlamaFarm()
+            assert lf.url == "http://custom:9999/v1"
+
+    def test_env_var_strips_trailing_slash(self):
+        with patch.dict(os.environ, {"LLAMAFARM_URL": "http://custom:9999/"}):
+            lf = LlamaFarm()
+            assert lf.url == "http://custom:9999/v1"
+
+    def test_explicit_url_wins(self):
+        with patch.dict(os.environ, {"LLAMAFARM_URL": "http://env:1111"}):
+            lf = LlamaFarm(url="http://explicit:2222")
+            assert lf.url == "http://explicit:2222/v1"
+
+    def test_default_urls(self):
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("LLAMAFARM_URL", None)
+            os.environ.pop("LLAMAFARM_RUNTIME_URL", None)
+            lf = LlamaFarm()
+            assert lf.url == "http://localhost:14345/v1"
+            assert lf.runtime_url == "http://localhost:11540"
+
+
+# ── ProjectHandle path building ──────────────────────────────────────────────
+
+
+class TestProjectHandle:
+    def test_path(self):
+        client = httpx.Client()
+        aclient = httpx.AsyncClient()
+        ph = ProjectHandle(client, aclient, "http://localhost:14345/v1", "default", "my-project")
+        assert ph._path == "http://localhost:14345/v1/projects/default/my-project"
+        assert ph.namespace == "default"
+        assert ph.project_id == "my-project"
+        client.close()
+
+    def test_repr(self):
+        client = httpx.Client()
+        aclient = httpx.AsyncClient()
+        ph = ProjectHandle(client, aclient, "http://localhost:14345/v1", "ns", "pid")
+        assert repr(ph) == "ProjectHandle(ns/pid)"
+        client.close()
+
+
+# ── Config generation ────────────────────────────────────────────────────────
+
+
+class TestConfigGeneration:
+    def test_basic(self):
+        cfg = build_project_config("test-app", "default")
+        assert cfg["version"] == "v1"
+        assert cfg["name"] == "test-app"
+        assert cfg["namespace"] == "default"
+        assert cfg["runtime"]["models"][0]["provider"] == "universal"
+        assert cfg["prompts"][0]["messages"][0]["role"] == "system"
+
+    def test_custom_model(self):
+        cfg = build_project_config("app", model="Qwen/Qwen3-8B", temperature=0.3)
+        assert cfg["runtime"]["models"][0]["model"] == "Qwen/Qwen3-8B"
+        assert cfg["runtime"]["models"][0]["temperature"] == 0.3
+
+    def test_no_rag_by_default(self):
+        cfg = build_project_config("app")
+        assert "rag" not in cfg
+
+    def test_with_rag(self):
+        cfg = build_project_config("app", rag_databases=[{"name": "db", "type": "ChromaStore"}])
+        assert cfg["rag"]["databases"][0]["name"] == "db"
+
+
+# ── API calls with respx mocks ──────────────────────────────────────────────
+
+
+class TestAPICallsMocked:
+    @respx.mock
+    def test_health(self):
+        respx.get("http://localhost:14345/health").respond(json={"status": "ok"})
+        lf = LlamaFarm()
+        assert lf.health() == {"status": "ok"}
+
+    @respx.mock
+    def test_projects_list(self):
+        respx.get("http://localhost:14345/v1/projects/default").respond(
+            json=[{"id": "p1", "name": "Project 1", "namespace": "default"}]
+        )
+        lf = LlamaFarm()
+        projects = lf.projects("default")
+        assert len(projects) == 1
+        assert projects[0].id == "p1"
+
+    @respx.mock
+    def test_create_project(self):
+        respx.post("http://localhost:14345/v1/projects/default").respond(
+            json={"id": "new-proj", "name": "My App"}
+        )
+        lf = LlamaFarm()
+        ph = lf.create_project("default", "My App", model="Qwen/Qwen3-8B")
+        assert ph.project_id == "new-proj"
+        assert ph.namespace == "default"
+
+    @respx.mock
+    def test_chat(self):
+        respx.post("http://localhost:14345/v1/projects/default/myproj/chat/completions").respond(
+            json={
+                "id": "chat-1",
+                "choices": [{"index": 0, "message": {"role": "assistant", "content": "Hello!"}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 5, "completion_tokens": 2, "total_tokens": 7},
+            }
+        )
+        lf = LlamaFarm()
+        p = lf.project("default", "myproj")
+        resp = p.chat("Hi")
+        assert resp.text == "Hello!"
+        assert resp.usage.total_tokens == 7
+
+    @respx.mock
+    def test_chat_with_session(self):
+        route = respx.post("http://localhost:14345/v1/projects/default/myproj/chat/completions").respond(
+            json={"id": "c1", "choices": [{"index": 0, "message": {"role": "assistant", "content": "ok"}}]}
+        )
+        lf = LlamaFarm()
+        p = lf.project("default", "myproj")
+        p.chat("Hi", session_id="sess-123")
+        assert route.calls[0].request.headers["X-Session-ID"] == "sess-123"
+
+    @respx.mock
+    def test_rag_query(self):
+        respx.post("http://localhost:14345/v1/projects/ns/proj/rag/query").respond(
+            json={"results": [{"content": "answer", "score": 0.95}], "query": "q"}
+        )
+        lf = LlamaFarm()
+        p = lf.project("ns", "proj")
+        result = p.rag.query("q")
+        assert result.results[0].content == "answer"
+
+    @respx.mock
+    def test_finetune_sft(self):
+        respx.post("http://localhost:11540/v1/finetune/sft").respond(
+            json={"job_id": "ft-1", "status": "queued", "model": "qwen", "method": "sft"}
+        )
+        lf = LlamaFarm()
+        job = lf.finetune.sft("qwen", "dataset.jsonl")
+        assert job.job_id == "ft-1"
+        assert job.status == "queued"
+
+    @respx.mock
+    def test_cache_stats(self):
+        respx.get("http://localhost:11540/v1/cache/stats").respond(
+            json={"total_entries": 10, "total_size_bytes": 4096, "hit_rate": 0.85, "entries": []}
+        )
+        lf = LlamaFarm()
+        stats = lf.cache.stats()
+        assert stats.total_entries == 10
+        assert stats.hit_rate == 0.85
+
+    @respx.mock
+    def test_404_raises_not_found(self):
+        respx.get("http://localhost:14345/v1/projects/ns/missing").respond(
+            status_code=404, json={"detail": "not found"}
+        )
+        from llamafarm.errors import NotFoundError
+        lf = LlamaFarm()
+        p = lf.project("ns", "missing")
+        with pytest.raises(NotFoundError):
+            p.info()
+
+
+# ── Async tests ──────────────────────────────────────────────────────────────
+
+
+class TestAsync:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_async_health(self):
+        respx.get("http://localhost:14345/health").respond(json={"status": "ok"})
+        async with LlamaFarm() as lf:
+            result = await lf.ahealth()
+            assert result == {"status": "ok"}
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_async_chat(self):
+        respx.post("http://localhost:14345/v1/projects/default/p/chat/completions").respond(
+            json={"id": "c1", "choices": [{"index": 0, "message": {"role": "assistant", "content": "hi"}}]}
+        )
+        async with LlamaFarm() as lf:
+            p = lf.project("default", "p")
+            resp = await p.achat("hello")
+            assert resp.text == "hi"

--- a/packages/llamafarm-sdk/uv.lock
+++ b/packages/llamafarm-sdk/uv.lock
@@ -1,0 +1,466 @@
+version = 1
+revision = 3
+requires-python = ">=3.10"
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592, upload-time = "2026-01-06T11:45:19.497Z" },
+]
+
+[[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/2d/a891ca51311197f6ad14a7ef42e2399f36cf2f9bd44752b3dc4eab60fdc5/certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120", size = 154268, upload-time = "2026-01-04T02:42:41.825Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/ad/3cc14f097111b4de0040c83a525973216457bbeeb63739ef1ed275c1c021/certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c", size = 152900, upload-time = "2026-01-04T02:42:40.15Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "llamafarm"
+version = "0.1.0a1"
+source = { editable = "." }
+dependencies = [
+    { name = "httpx" },
+    { name = "pydantic" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "respx" },
+    { name = "ruff" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest-asyncio" },
+    { name = "respx" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.25.0" },
+    { name = "pydantic", specifier = ">=2.0.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
+    { name = "respx", marker = "extra == 'dev'", specifier = ">=0.21" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
+]
+provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "respx", specifier = ">=0.22.0" },
+    { name = "ruff", specifier = ">=0.15.2" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.12.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.41.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/90/32c9941e728d564b411d574d8ee0cf09b12ec978cb22b294995bae5549a5/pydantic_core-2.41.5-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:77b63866ca88d804225eaa4af3e664c5faf3568cea95360d21f4725ab6e07146", size = 2107298, upload-time = "2025-11-04T13:39:04.116Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/a8/61c96a77fe28993d9a6fb0f4127e05430a267b235a124545d79fea46dd65/pydantic_core-2.41.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:dfa8a0c812ac681395907e71e1274819dec685fec28273a28905df579ef137e2", size = 1901475, upload-time = "2025-11-04T13:39:06.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/b6/338abf60225acc18cdc08b4faef592d0310923d19a87fba1faf05af5346e/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5921a4d3ca3aee735d9fd163808f5e8dd6c6972101e4adbda9a4667908849b97", size = 1918815, upload-time = "2025-11-04T13:39:10.41Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/1c/2ed0433e682983d8e8cba9c8d8ef274d4791ec6a6f24c58935b90e780e0a/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e25c479382d26a2a41b7ebea1043564a937db462816ea07afa8a44c0866d52f9", size = 2065567, upload-time = "2025-11-04T13:39:12.244Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/24/cf84974ee7d6eae06b9e63289b7b8f6549d416b5c199ca2d7ce13bbcf619/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f547144f2966e1e16ae626d8ce72b4cfa0caedc7fa28052001c94fb2fcaa1c52", size = 2230442, upload-time = "2025-11-04T13:39:13.962Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/21/4e287865504b3edc0136c89c9c09431be326168b1eb7841911cbc877a995/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6f52298fbd394f9ed112d56f3d11aabd0d5bd27beb3084cc3d8ad069483b8941", size = 2350956, upload-time = "2025-11-04T13:39:15.889Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/76/7727ef2ffa4b62fcab916686a68a0426b9b790139720e1934e8ba797e238/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:100baa204bb412b74fe285fb0f3a385256dad1d1879f0a5cb1499ed2e83d132a", size = 2068253, upload-time = "2025-11-04T13:39:17.403Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/8c/a4abfc79604bcb4c748e18975c44f94f756f08fb04218d5cb87eb0d3a63e/pydantic_core-2.41.5-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:05a2c8852530ad2812cb7914dc61a1125dc4e06252ee98e5638a12da6cc6fb6c", size = 2177050, upload-time = "2025-11-04T13:39:19.351Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b1/de2e9a9a79b480f9cb0b6e8b6ba4c50b18d4e89852426364c66aa82bb7b3/pydantic_core-2.41.5-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:29452c56df2ed968d18d7e21f4ab0ac55e71dc59524872f6fc57dcf4a3249ed2", size = 2147178, upload-time = "2025-11-04T13:39:21Z" },
+    { url = "https://files.pythonhosted.org/packages/16/c1/dfb33f837a47b20417500efaa0378adc6635b3c79e8369ff7a03c494b4ac/pydantic_core-2.41.5-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:d5160812ea7a8a2ffbe233d8da666880cad0cbaf5d4de74ae15c313213d62556", size = 2341833, upload-time = "2025-11-04T13:39:22.606Z" },
+    { url = "https://files.pythonhosted.org/packages/47/36/00f398642a0f4b815a9a558c4f1dca1b4020a7d49562807d7bc9ff279a6c/pydantic_core-2.41.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:df3959765b553b9440adfd3c795617c352154e497a4eaf3752555cfb5da8fc49", size = 2321156, upload-time = "2025-11-04T13:39:25.843Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/70/cad3acd89fde2010807354d978725ae111ddf6d0ea46d1ea1775b5c1bd0c/pydantic_core-2.41.5-cp310-cp310-win32.whl", hash = "sha256:1f8d33a7f4d5a7889e60dc39856d76d09333d8a6ed0f5f1190635cbec70ec4ba", size = 1989378, upload-time = "2025-11-04T13:39:27.92Z" },
+    { url = "https://files.pythonhosted.org/packages/76/92/d338652464c6c367e5608e4488201702cd1cbb0f33f7b6a85a60fe5f3720/pydantic_core-2.41.5-cp310-cp310-win_amd64.whl", hash = "sha256:62de39db01b8d593e45871af2af9e497295db8d73b085f6bfd0b18c83c70a8f9", size = 2013622, upload-time = "2025-11-04T13:39:29.848Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/72/74a989dd9f2084b3d9530b0915fdda64ac48831c30dbf7c72a41a5232db8/pydantic_core-2.41.5-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a3a52f6156e73e7ccb0f8cced536adccb7042be67cb45f9562e12b319c119da6", size = 2105873, upload-time = "2025-11-04T13:39:31.373Z" },
+    { url = "https://files.pythonhosted.org/packages/12/44/37e403fd9455708b3b942949e1d7febc02167662bf1a7da5b78ee1ea2842/pydantic_core-2.41.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7f3bf998340c6d4b0c9a2f02d6a400e51f123b59565d74dc60d252ce888c260b", size = 1899826, upload-time = "2025-11-04T13:39:32.897Z" },
+    { url = "https://files.pythonhosted.org/packages/33/7f/1d5cab3ccf44c1935a359d51a8a2a9e1a654b744b5e7f80d41b88d501eec/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:378bec5c66998815d224c9ca994f1e14c0c21cb95d2f52b6021cc0b2a58f2a5a", size = 1917869, upload-time = "2025-11-04T13:39:34.469Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6a/30d94a9674a7fe4f4744052ed6c5e083424510be1e93da5bc47569d11810/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e7b576130c69225432866fe2f4a469a85a54ade141d96fd396dffcf607b558f8", size = 2063890, upload-time = "2025-11-04T13:39:36.053Z" },
+    { url = "https://files.pythonhosted.org/packages/50/be/76e5d46203fcb2750e542f32e6c371ffa9b8ad17364cf94bb0818dbfb50c/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6cb58b9c66f7e4179a2d5e0f849c48eff5c1fca560994d6eb6543abf955a149e", size = 2229740, upload-time = "2025-11-04T13:39:37.753Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ee/fed784df0144793489f87db310a6bbf8118d7b630ed07aa180d6067e653a/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:88942d3a3dff3afc8288c21e565e476fc278902ae4d6d134f1eeda118cc830b1", size = 2350021, upload-time = "2025-11-04T13:39:40.94Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/be/8fed28dd0a180dca19e72c233cbf58efa36df055e5b9d90d64fd1740b828/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f31d95a179f8d64d90f6831d71fa93290893a33148d890ba15de25642c5d075b", size = 2066378, upload-time = "2025-11-04T13:39:42.523Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3b/698cf8ae1d536a010e05121b4958b1257f0b5522085e335360e53a6b1c8b/pydantic_core-2.41.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c1df3d34aced70add6f867a8cf413e299177e0c22660cc767218373d0779487b", size = 2175761, upload-time = "2025-11-04T13:39:44.553Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/ba/15d537423939553116dea94ce02f9c31be0fa9d0b806d427e0308ec17145/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:4009935984bd36bd2c774e13f9a09563ce8de4abaa7226f5108262fa3e637284", size = 2146303, upload-time = "2025-11-04T13:39:46.238Z" },
+    { url = "https://files.pythonhosted.org/packages/58/7f/0de669bf37d206723795f9c90c82966726a2ab06c336deba4735b55af431/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:34a64bc3441dc1213096a20fe27e8e128bd3ff89921706e83c0b1ac971276594", size = 2340355, upload-time = "2025-11-04T13:39:48.002Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/de/e7482c435b83d7e3c3ee5ee4451f6e8973cff0eb6007d2872ce6383f6398/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:c9e19dd6e28fdcaa5a1de679aec4141f691023916427ef9bae8584f9c2fb3b0e", size = 2319875, upload-time = "2025-11-04T13:39:49.705Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/e6/8c9e81bb6dd7560e33b9053351c29f30c8194b72f2d6932888581f503482/pydantic_core-2.41.5-cp311-cp311-win32.whl", hash = "sha256:2c010c6ded393148374c0f6f0bf89d206bf3217f201faa0635dcd56bd1520f6b", size = 1987549, upload-time = "2025-11-04T13:39:51.842Z" },
+    { url = "https://files.pythonhosted.org/packages/11/66/f14d1d978ea94d1bc21fc98fcf570f9542fe55bfcc40269d4e1a21c19bf7/pydantic_core-2.41.5-cp311-cp311-win_amd64.whl", hash = "sha256:76ee27c6e9c7f16f47db7a94157112a2f3a00e958bc626e2f4ee8bec5c328fbe", size = 2011305, upload-time = "2025-11-04T13:39:53.485Z" },
+    { url = "https://files.pythonhosted.org/packages/56/d8/0e271434e8efd03186c5386671328154ee349ff0354d83c74f5caaf096ed/pydantic_core-2.41.5-cp311-cp311-win_arm64.whl", hash = "sha256:4bc36bbc0b7584de96561184ad7f012478987882ebf9f9c389b23f432ea3d90f", size = 1972902, upload-time = "2025-11-04T13:39:56.488Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/5d/5f6c63eebb5afee93bcaae4ce9a898f3373ca23df3ccaef086d0233a35a7/pydantic_core-2.41.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f41a7489d32336dbf2199c8c0a215390a751c5b014c2c1c5366e817202e9cdf7", size = 2110990, upload-time = "2025-11-04T13:39:58.079Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/32/9c2e8ccb57c01111e0fd091f236c7b371c1bccea0fa85247ac55b1e2b6b6/pydantic_core-2.41.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:070259a8818988b9a84a449a2a7337c7f430a22acc0859c6b110aa7212a6d9c0", size = 1896003, upload-time = "2025-11-04T13:39:59.956Z" },
+    { url = "https://files.pythonhosted.org/packages/68/b8/a01b53cb0e59139fbc9e4fda3e9724ede8de279097179be4ff31f1abb65a/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e96cea19e34778f8d59fe40775a7a574d95816eb150850a85a7a4c8f4b94ac69", size = 1919200, upload-time = "2025-11-04T13:40:02.241Z" },
+    { url = "https://files.pythonhosted.org/packages/38/de/8c36b5198a29bdaade07b5985e80a233a5ac27137846f3bc2d3b40a47360/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ed2e99c456e3fadd05c991f8f437ef902e00eedf34320ba2b0842bd1c3ca3a75", size = 2052578, upload-time = "2025-11-04T13:40:04.401Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b5/0e8e4b5b081eac6cb3dbb7e60a65907549a1ce035a724368c330112adfdd/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:65840751b72fbfd82c3c640cff9284545342a4f1eb1586ad0636955b261b0b05", size = 2208504, upload-time = "2025-11-04T13:40:06.072Z" },
+    { url = "https://files.pythonhosted.org/packages/77/56/87a61aad59c7c5b9dc8caad5a41a5545cba3810c3e828708b3d7404f6cef/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e536c98a7626a98feb2d3eaf75944ef6f3dbee447e1f841eae16f2f0a72d8ddc", size = 2335816, upload-time = "2025-11-04T13:40:07.835Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/76/941cc9f73529988688a665a5c0ecff1112b3d95ab48f81db5f7606f522d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eceb81a8d74f9267ef4081e246ffd6d129da5d87e37a77c9bde550cb04870c1c", size = 2075366, upload-time = "2025-11-04T13:40:09.804Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/43/ebef01f69baa07a482844faaa0a591bad1ef129253ffd0cdaa9d8a7f72d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d38548150c39b74aeeb0ce8ee1d8e82696f4a4e16ddc6de7b1d8823f7de4b9b5", size = 2171698, upload-time = "2025-11-04T13:40:12.004Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/87/41f3202e4193e3bacfc2c065fab7706ebe81af46a83d3e27605029c1f5a6/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:c23e27686783f60290e36827f9c626e63154b82b116d7fe9adba1fda36da706c", size = 2132603, upload-time = "2025-11-04T13:40:13.868Z" },
+    { url = "https://files.pythonhosted.org/packages/49/7d/4c00df99cb12070b6bccdef4a195255e6020a550d572768d92cc54dba91a/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:482c982f814460eabe1d3bb0adfdc583387bd4691ef00b90575ca0d2b6fe2294", size = 2329591, upload-time = "2025-11-04T13:40:15.672Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6a/ebf4b1d65d458f3cda6a7335d141305dfa19bdc61140a884d165a8a1bbc7/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:bfea2a5f0b4d8d43adf9d7b8bf019fb46fdd10a2e5cde477fbcb9d1fa08c68e1", size = 2319068, upload-time = "2025-11-04T13:40:17.532Z" },
+    { url = "https://files.pythonhosted.org/packages/49/3b/774f2b5cd4192d5ab75870ce4381fd89cf218af999515baf07e7206753f0/pydantic_core-2.41.5-cp312-cp312-win32.whl", hash = "sha256:b74557b16e390ec12dca509bce9264c3bbd128f8a2c376eaa68003d7f327276d", size = 1985908, upload-time = "2025-11-04T13:40:19.309Z" },
+    { url = "https://files.pythonhosted.org/packages/86/45/00173a033c801cacf67c190fef088789394feaf88a98a7035b0e40d53dc9/pydantic_core-2.41.5-cp312-cp312-win_amd64.whl", hash = "sha256:1962293292865bca8e54702b08a4f26da73adc83dd1fcf26fbc875b35d81c815", size = 2020145, upload-time = "2025-11-04T13:40:21.548Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/22/91fbc821fa6d261b376a3f73809f907cec5ca6025642c463d3488aad22fb/pydantic_core-2.41.5-cp312-cp312-win_arm64.whl", hash = "sha256:1746d4a3d9a794cacae06a5eaaccb4b8643a131d45fbc9af23e353dc0a5ba5c3", size = 1976179, upload-time = "2025-11-04T13:40:23.393Z" },
+    { url = "https://files.pythonhosted.org/packages/87/06/8806241ff1f70d9939f9af039c6c35f2360cf16e93c2ca76f184e76b1564/pydantic_core-2.41.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:941103c9be18ac8daf7b7adca8228f8ed6bb7a1849020f643b3a14d15b1924d9", size = 2120403, upload-time = "2025-11-04T13:40:25.248Z" },
+    { url = "https://files.pythonhosted.org/packages/94/02/abfa0e0bda67faa65fef1c84971c7e45928e108fe24333c81f3bfe35d5f5/pydantic_core-2.41.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:112e305c3314f40c93998e567879e887a3160bb8689ef3d2c04b6cc62c33ac34", size = 1896206, upload-time = "2025-11-04T13:40:27.099Z" },
+    { url = "https://files.pythonhosted.org/packages/15/df/a4c740c0943e93e6500f9eb23f4ca7ec9bf71b19e608ae5b579678c8d02f/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cbaad15cb0c90aa221d43c00e77bb33c93e8d36e0bf74760cd00e732d10a6a0", size = 1919307, upload-time = "2025-11-04T13:40:29.806Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e3/6324802931ae1d123528988e0e86587c2072ac2e5394b4bc2bc34b61ff6e/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:03ca43e12fab6023fc79d28ca6b39b05f794ad08ec2feccc59a339b02f2b3d33", size = 2063258, upload-time = "2025-11-04T13:40:33.544Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/d4/2230d7151d4957dd79c3044ea26346c148c98fbf0ee6ebd41056f2d62ab5/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dc799088c08fa04e43144b164feb0c13f9a0bc40503f8df3e9fde58a3c0c101e", size = 2214917, upload-time = "2025-11-04T13:40:35.479Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9f/eaac5df17a3672fef0081b6c1bb0b82b33ee89aa5cec0d7b05f52fd4a1fa/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:97aeba56665b4c3235a0e52b2c2f5ae9cd071b8a8310ad27bddb3f7fb30e9aa2", size = 2332186, upload-time = "2025-11-04T13:40:37.436Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/4e/35a80cae583a37cf15604b44240e45c05e04e86f9cfd766623149297e971/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:406bf18d345822d6c21366031003612b9c77b3e29ffdb0f612367352aab7d586", size = 2073164, upload-time = "2025-11-04T13:40:40.289Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e3/f6e262673c6140dd3305d144d032f7bd5f7497d3871c1428521f19f9efa2/pydantic_core-2.41.5-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b93590ae81f7010dbe380cdeab6f515902ebcbefe0b9327cc4804d74e93ae69d", size = 2179146, upload-time = "2025-11-04T13:40:42.809Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c7/20bd7fc05f0c6ea2056a4565c6f36f8968c0924f19b7d97bbfea55780e73/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:01a3d0ab748ee531f4ea6c3e48ad9dac84ddba4b0d82291f87248f2f9de8d740", size = 2137788, upload-time = "2025-11-04T13:40:44.752Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/8d/34318ef985c45196e004bc46c6eab2eda437e744c124ef0dbe1ff2c9d06b/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:6561e94ba9dacc9c61bce40e2d6bdc3bfaa0259d3ff36ace3b1e6901936d2e3e", size = 2340133, upload-time = "2025-11-04T13:40:46.66Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/59/013626bf8c78a5a5d9350d12e7697d3d4de951a75565496abd40ccd46bee/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:915c3d10f81bec3a74fbd4faebe8391013ba61e5a1a8d48c4455b923bdda7858", size = 2324852, upload-time = "2025-11-04T13:40:48.575Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d9/c248c103856f807ef70c18a4f986693a46a8ffe1602e5d361485da502d20/pydantic_core-2.41.5-cp313-cp313-win32.whl", hash = "sha256:650ae77860b45cfa6e2cdafc42618ceafab3a2d9a3811fcfbd3bbf8ac3c40d36", size = 1994679, upload-time = "2025-11-04T13:40:50.619Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8b/341991b158ddab181cff136acd2552c9f35bd30380422a639c0671e99a91/pydantic_core-2.41.5-cp313-cp313-win_amd64.whl", hash = "sha256:79ec52ec461e99e13791ec6508c722742ad745571f234ea6255bed38c6480f11", size = 2019766, upload-time = "2025-11-04T13:40:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/73/7d/f2f9db34af103bea3e09735bb40b021788a5e834c81eedb541991badf8f5/pydantic_core-2.41.5-cp313-cp313-win_arm64.whl", hash = "sha256:3f84d5c1b4ab906093bdc1ff10484838aca54ef08de4afa9de0f5f14d69639cd", size = 1981005, upload-time = "2025-11-04T13:40:54.734Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/28/46b7c5c9635ae96ea0fbb779e271a38129df2550f763937659ee6c5dbc65/pydantic_core-2.41.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3f37a19d7ebcdd20b96485056ba9e8b304e27d9904d233d7b1015db320e51f0a", size = 2119622, upload-time = "2025-11-04T13:40:56.68Z" },
+    { url = "https://files.pythonhosted.org/packages/74/1a/145646e5687e8d9a1e8d09acb278c8535ebe9e972e1f162ed338a622f193/pydantic_core-2.41.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1d1d9764366c73f996edd17abb6d9d7649a7eb690006ab6adbda117717099b14", size = 1891725, upload-time = "2025-11-04T13:40:58.807Z" },
+    { url = "https://files.pythonhosted.org/packages/23/04/e89c29e267b8060b40dca97bfc64a19b2a3cf99018167ea1677d96368273/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25e1c2af0fce638d5f1988b686f3b3ea8cd7de5f244ca147c777769e798a9cd1", size = 1915040, upload-time = "2025-11-04T13:41:00.853Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a3/15a82ac7bd97992a82257f777b3583d3e84bdb06ba6858f745daa2ec8a85/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:506d766a8727beef16b7adaeb8ee6217c64fc813646b424d0804d67c16eddb66", size = 2063691, upload-time = "2025-11-04T13:41:03.504Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/0046701313c6ef08c0c1cf0e028c67c770a4e1275ca73131563c5f2a310a/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4819fa52133c9aa3c387b3328f25c1facc356491e6135b459f1de698ff64d869", size = 2213897, upload-time = "2025-11-04T13:41:05.804Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/cd/6bac76ecd1b27e75a95ca3a9a559c643b3afcd2dd62086d4b7a32a18b169/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2b761d210c9ea91feda40d25b4efe82a1707da2ef62901466a42492c028553a2", size = 2333302, upload-time = "2025-11-04T13:41:07.809Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/d2/ef2074dc020dd6e109611a8be4449b98cd25e1b9b8a303c2f0fca2f2bcf7/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22f0fb8c1c583a3b6f24df2470833b40207e907b90c928cc8d3594b76f874375", size = 2064877, upload-time = "2025-11-04T13:41:09.827Z" },
+    { url = "https://files.pythonhosted.org/packages/18/66/e9db17a9a763d72f03de903883c057b2592c09509ccfe468187f2a2eef29/pydantic_core-2.41.5-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c870e99878c634505236d81e5443092fba820f0373997ff75f90f68cd553", size = 2180680, upload-time = "2025-11-04T13:41:12.379Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9e/3ce66cebb929f3ced22be85d4c2399b8e85b622db77dad36b73c5387f8f8/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0177272f88ab8312479336e1d777f6b124537d47f2123f89cb37e0accea97f90", size = 2138960, upload-time = "2025-11-04T13:41:14.627Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/62/205a998f4327d2079326b01abee48e502ea739d174f0a89295c481a2272e/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:63510af5e38f8955b8ee5687740d6ebf7c2a0886d15a6d65c32814613681bc07", size = 2339102, upload-time = "2025-11-04T13:41:16.868Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/0d/f05e79471e889d74d3d88f5bd20d0ed189ad94c2423d81ff8d0000aab4ff/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:e56ba91f47764cc14f1daacd723e3e82d1a89d783f0f5afe9c364b8bb491ccdb", size = 2326039, upload-time = "2025-11-04T13:41:18.934Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e1/e08a6208bb100da7e0c4b288eed624a703f4d129bde2da475721a80cab32/pydantic_core-2.41.5-cp314-cp314-win32.whl", hash = "sha256:aec5cf2fd867b4ff45b9959f8b20ea3993fc93e63c7363fe6851424c8a7e7c23", size = 1995126, upload-time = "2025-11-04T13:41:21.418Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5d/56ba7b24e9557f99c9237e29f5c09913c81eeb2f3217e40e922353668092/pydantic_core-2.41.5-cp314-cp314-win_amd64.whl", hash = "sha256:8e7c86f27c585ef37c35e56a96363ab8de4e549a95512445b85c96d3e2f7c1bf", size = 2015489, upload-time = "2025-11-04T13:41:24.076Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/bb/f7a190991ec9e3e0ba22e4993d8755bbc4a32925c0b5b42775c03e8148f9/pydantic_core-2.41.5-cp314-cp314-win_arm64.whl", hash = "sha256:e672ba74fbc2dc8eea59fb6d4aed6845e6905fc2a8afe93175d94a83ba2a01a0", size = 1977288, upload-time = "2025-11-04T13:41:26.33Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ed/77542d0c51538e32e15afe7899d79efce4b81eee631d99850edc2f5e9349/pydantic_core-2.41.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8566def80554c3faa0e65ac30ab0932b9e3a5cd7f8323764303d468e5c37595a", size = 2120255, upload-time = "2025-11-04T13:41:28.569Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/3d/6913dde84d5be21e284439676168b28d8bbba5600d838b9dca99de0fad71/pydantic_core-2.41.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b80aa5095cd3109962a298ce14110ae16b8c1aece8b72f9dafe81cf597ad80b3", size = 1863760, upload-time = "2025-11-04T13:41:31.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f0/e5e6b99d4191da102f2b0eb9687aaa7f5bea5d9964071a84effc3e40f997/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3006c3dd9ba34b0c094c544c6006cc79e87d8612999f1a5d43b769b89181f23c", size = 1878092, upload-time = "2025-11-04T13:41:33.21Z" },
+    { url = "https://files.pythonhosted.org/packages/71/48/36fb760642d568925953bcc8116455513d6e34c4beaa37544118c36aba6d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72f6c8b11857a856bcfa48c86f5368439f74453563f951e473514579d44aa612", size = 2053385, upload-time = "2025-11-04T13:41:35.508Z" },
+    { url = "https://files.pythonhosted.org/packages/20/25/92dc684dd8eb75a234bc1c764b4210cf2646479d54b47bf46061657292a8/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cb1b2f9742240e4bb26b652a5aeb840aa4b417c7748b6f8387927bc6e45e40d", size = 2218832, upload-time = "2025-11-04T13:41:37.732Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/09/f53e0b05023d3e30357d82eb35835d0f6340ca344720a4599cd663dca599/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd3d54f38609ff308209bd43acea66061494157703364ae40c951f83ba99a1a9", size = 2327585, upload-time = "2025-11-04T13:41:40Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4e/2ae1aa85d6af35a39b236b1b1641de73f5a6ac4d5a7509f77b814885760c/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ff4321e56e879ee8d2a879501c8e469414d948f4aba74a2d4593184eb326660", size = 2041078, upload-time = "2025-11-04T13:41:42.323Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/13/2e215f17f0ef326fc72afe94776edb77525142c693767fc347ed6288728d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0d2568a8c11bf8225044aa94409e21da0cb09dcdafe9ecd10250b2baad531a9", size = 2173914, upload-time = "2025-11-04T13:41:45.221Z" },
+    { url = "https://files.pythonhosted.org/packages/02/7a/f999a6dcbcd0e5660bc348a3991c8915ce6599f4f2c6ac22f01d7a10816c/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:a39455728aabd58ceabb03c90e12f71fd30fa69615760a075b9fec596456ccc3", size = 2129560, upload-time = "2025-11-04T13:41:47.474Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/b1/6c990ac65e3b4c079a4fb9f5b05f5b013afa0f4ed6780a3dd236d2cbdc64/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:239edca560d05757817c13dc17c50766136d21f7cd0fac50295499ae24f90fdf", size = 2329244, upload-time = "2025-11-04T13:41:49.992Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/02/3c562f3a51afd4d88fff8dffb1771b30cfdfd79befd9883ee094f5b6c0d8/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:2a5e06546e19f24c6a96a129142a75cee553cc018ffee48a460059b1185f4470", size = 2331955, upload-time = "2025-11-04T13:41:54.079Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/96/5fb7d8c3c17bc8c62fdb031c47d77a1af698f1d7a406b0f79aaa1338f9ad/pydantic_core-2.41.5-cp314-cp314t-win32.whl", hash = "sha256:b4ececa40ac28afa90871c2cc2b9ffd2ff0bf749380fbdf57d165fd23da353aa", size = 1988906, upload-time = "2025-11-04T13:41:56.606Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ed/182129d83032702912c2e2d8bbe33c036f342cc735737064668585dac28f/pydantic_core-2.41.5-cp314-cp314t-win_amd64.whl", hash = "sha256:80aa89cad80b32a912a65332f64a4450ed00966111b6615ca6816153d3585a8c", size = 1981607, upload-time = "2025-11-04T13:41:58.889Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/ed/068e41660b832bb0b1aa5b58011dea2a3fe0ba7861ff38c4d4904c1c1a99/pydantic_core-2.41.5-cp314-cp314t-win_arm64.whl", hash = "sha256:35b44f37a3199f771c3eaa53051bc8a70cd7b54f333531c59e29fd4db5d15008", size = 1974769, upload-time = "2025-11-04T13:42:01.186Z" },
+    { url = "https://files.pythonhosted.org/packages/11/72/90fda5ee3b97e51c494938a4a44c3a35a9c96c19bba12372fb9c634d6f57/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:b96d5f26b05d03cc60f11a7761a5ded1741da411e7fe0909e27a5e6a0cb7b034", size = 2115441, upload-time = "2025-11-04T13:42:39.557Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/53/8942f884fa33f50794f119012dc6a1a02ac43a56407adaac20463df8e98f/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:634e8609e89ceecea15e2d61bc9ac3718caaaa71963717bf3c8f38bfde64242c", size = 1930291, upload-time = "2025-11-04T13:42:42.169Z" },
+    { url = "https://files.pythonhosted.org/packages/79/c8/ecb9ed9cd942bce09fc888ee960b52654fbdbede4ba6c2d6e0d3b1d8b49c/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:93e8740d7503eb008aa2df04d3b9735f845d43ae845e6dcd2be0b55a2da43cd2", size = 1948632, upload-time = "2025-11-04T13:42:44.564Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1b/687711069de7efa6af934e74f601e2a4307365e8fdc404703afc453eab26/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f15489ba13d61f670dcc96772e733aad1a6f9c429cc27574c6cdaed82d0146ad", size = 2138905, upload-time = "2025-11-04T13:42:47.156Z" },
+    { url = "https://files.pythonhosted.org/packages/09/32/59b0c7e63e277fa7911c2fc70ccfb45ce4b98991e7ef37110663437005af/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:7da7087d756b19037bc2c06edc6c170eeef3c3bafcb8f532ff17d64dc427adfd", size = 2110495, upload-time = "2025-11-04T13:42:49.689Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/81/05e400037eaf55ad400bcd318c05bb345b57e708887f07ddb2d20e3f0e98/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:aabf5777b5c8ca26f7824cb4a120a740c9588ed58df9b2d196ce92fba42ff8dc", size = 1915388, upload-time = "2025-11-04T13:42:52.215Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/0d/e3549b2399f71d56476b77dbf3cf8937cec5cd70536bdc0e374a421d0599/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c007fe8a43d43b3969e8469004e9845944f1a80e6acd47c150856bb87f230c56", size = 1942879, upload-time = "2025-11-04T13:42:56.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/07/34573da085946b6a313d7c42f82f16e8920bfd730665de2d11c0c37a74b5/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76d0819de158cd855d1cbb8fcafdf6f5cf1eb8e470abe056d5d161106e38062b", size = 2139017, upload-time = "2025-11-04T13:42:59.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/b0/1a2aa41e3b5a4ba11420aba2d091b2d17959c8d1519ece3627c371951e73/pydantic_core-2.41.5-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:b5819cd790dbf0c5eb9f82c73c16b39a65dd6dd4d1439dcdea7816ec9adddab8", size = 2103351, upload-time = "2025-11-04T13:43:02.058Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/ee/31b1f0020baaf6d091c87900ae05c6aeae101fa4e188e1613c80e4f1ea31/pydantic_core-2.41.5-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:5a4e67afbc95fa5c34cf27d9089bca7fcab4e51e57278d710320a70b956d1b9a", size = 1925363, upload-time = "2025-11-04T13:43:05.159Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/89/ab8e86208467e467a80deaca4e434adac37b10a9d134cd2f99b28a01e483/pydantic_core-2.41.5-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ece5c59f0ce7d001e017643d8d24da587ea1f74f6993467d85ae8a5ef9d4f42b", size = 2135615, upload-time = "2025-11-04T13:43:08.116Z" },
+    { url = "https://files.pythonhosted.org/packages/99/0a/99a53d06dd0348b2008f2f30884b34719c323f16c3be4e6cc1203b74a91d/pydantic_core-2.41.5-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:16f80f7abe3351f8ea6858914ddc8c77e02578544a0ebc15b4c2e1a0e813b0b2", size = 2175369, upload-time = "2025-11-04T13:43:12.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/94/30ca3b73c6d485b9bb0bc66e611cff4a7138ff9736b7e66bcf0852151636/pydantic_core-2.41.5-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:33cb885e759a705b426baada1fe68cbb0a2e68e34c5d0d0289a364cf01709093", size = 2144218, upload-time = "2025-11-04T13:43:15.431Z" },
+    { url = "https://files.pythonhosted.org/packages/87/57/31b4f8e12680b739a91f472b5671294236b82586889ef764b5fbc6669238/pydantic_core-2.41.5-pp310-pypy310_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:c8d8b4eb992936023be7dee581270af5c6e0697a8559895f527f5b7105ecd36a", size = 2329951, upload-time = "2025-11-04T13:43:18.062Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/73/3c2c8edef77b8f7310e6fb012dbc4b8551386ed575b9eb6fb2506e28a7eb/pydantic_core-2.41.5-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:242a206cd0318f95cd21bdacff3fcc3aab23e79bba5cac3db5a841c9ef9c6963", size = 2318428, upload-time = "2025-11-04T13:43:20.679Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/02/8559b1f26ee0d502c74f9cca5c0d2fd97e967e083e006bbbb4e97f3a043a/pydantic_core-2.41.5-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:d3a978c4f57a597908b7e697229d996d77a6d3c94901e9edee593adada95ce1a", size = 2147009, upload-time = "2025-11-04T13:43:23.286Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/9b/1b3f0e9f9305839d7e84912f9e8bfbd191ed1b1ef48083609f0dabde978c/pydantic_core-2.41.5-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:b2379fa7ed44ddecb5bfe4e48577d752db9fc10be00a6b7446e9663ba143de26", size = 2101980, upload-time = "2025-11-04T13:43:25.97Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/ed/d71fefcb4263df0da6a85b5d8a7508360f2f2e9b3bf5814be9c8bccdccc1/pydantic_core-2.41.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:266fb4cbf5e3cbd0b53669a6d1b039c45e3ce651fd5442eff4d07c2cc8d66808", size = 1923865, upload-time = "2025-11-04T13:43:28.763Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/3a/626b38db460d675f873e4444b4bb030453bbe7b4ba55df821d026a0493c4/pydantic_core-2.41.5-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58133647260ea01e4d0500089a8c4f07bd7aa6ce109682b1426394988d8aaacc", size = 2134256, upload-time = "2025-11-04T13:43:31.71Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d9/8412d7f06f616bbc053d30cb4e5f76786af3221462ad5eee1f202021eb4e/pydantic_core-2.41.5-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:287dad91cfb551c363dc62899a80e9e14da1f0e2b6ebde82c806612ca2a13ef1", size = 2174762, upload-time = "2025-11-04T13:43:34.744Z" },
+    { url = "https://files.pythonhosted.org/packages/55/4c/162d906b8e3ba3a99354e20faa1b49a85206c47de97a639510a0e673f5da/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:03b77d184b9eb40240ae9fd676ca364ce1085f203e1b1256f8ab9984dca80a84", size = 2143141, upload-time = "2025-11-04T13:43:37.701Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f2/f11dd73284122713f5f89fc940f370d035fa8e1e078d446b3313955157fe/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:a668ce24de96165bb239160b3d854943128f4334822900534f2fe947930e5770", size = 2330317, upload-time = "2025-11-04T13:43:40.406Z" },
+    { url = "https://files.pythonhosted.org/packages/88/9d/b06ca6acfe4abb296110fb1273a4d848a0bfb2ff65f3ee92127b3244e16b/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f14f8f046c14563f8eb3f45f499cc658ab8d10072961e07225e507adb700e93f", size = 2316992, upload-time = "2025-11-04T13:43:43.602Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c7/cfc8e811f061c841d7990b0201912c3556bfeb99cdcb7ed24adc8d6f8704/pydantic_core-2.41.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:56121965f7a4dc965bff783d70b907ddf3d57f6eba29b6d2e5dabfaf07799c51", size = 2145302, upload-time = "2025-11-04T13:43:46.64Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "respx"
+version = "0.22.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/7c/96bd0bc759cf009675ad1ee1f96535edcb11e9666b985717eb8c87192a95/respx-0.22.0.tar.gz", hash = "sha256:3c8924caa2a50bd71aefc07aa812f2466ff489f1848c96e954a5362d17095d91", size = 28439, upload-time = "2024-12-19T22:33:59.374Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/67/afbb0978d5399bc9ea200f1d4489a23c9a1dad4eee6376242b8182389c79/respx-0.22.0-py2.py3-none-any.whl", hash = "sha256:631128d4c9aba15e56903fb5f66fb1eff412ce28dd387ca3a81339e52dbd3ad0", size = 25127, upload-time = "2024-12-19T22:33:57.837Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/04/eab13a954e763b0606f460443fcbf6bb5a0faf06890ea3754ff16523dce5/ruff-0.15.2.tar.gz", hash = "sha256:14b965afee0969e68bb871eba625343b8673375f457af4abe98553e8bbb98342", size = 4558148, upload-time = "2026-02-19T22:32:20.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/70/3a4dc6d09b13cb3e695f28307e5d889b2e1a66b7af9c5e257e796695b0e6/ruff-0.15.2-py3-none-linux_armv6l.whl", hash = "sha256:120691a6fdae2f16d65435648160f5b81a9625288f75544dc40637436b5d3c0d", size = 10430565, upload-time = "2026-02-19T22:32:41.824Z" },
+    { url = "https://files.pythonhosted.org/packages/71/0b/bb8457b56185ece1305c666dc895832946d24055be90692381c31d57466d/ruff-0.15.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:a89056d831256099658b6bba4037ac6dd06f49d194199215befe2bb10457ea5e", size = 10820354, upload-time = "2026-02-19T22:32:07.366Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/c1/e0532d7f9c9e0b14c46f61b14afd563298b8b83f337b6789ddd987e46121/ruff-0.15.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e36dee3a64be0ebd23c86ffa3aa3fd3ac9a712ff295e192243f814a830b6bd87", size = 10170767, upload-time = "2026-02-19T22:32:13.188Z" },
+    { url = "https://files.pythonhosted.org/packages/47/e8/da1aa341d3af017a21c7a62fb5ec31d4e7ad0a93ab80e3a508316efbcb23/ruff-0.15.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a9fb47b6d9764677f8c0a193c0943ce9a05d6763523f132325af8a858eadc2b9", size = 10529591, upload-time = "2026-02-19T22:32:02.547Z" },
+    { url = "https://files.pythonhosted.org/packages/93/74/184fbf38e9f3510231fbc5e437e808f0b48c42d1df9434b208821efcd8d6/ruff-0.15.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f376990f9d0d6442ea9014b19621d8f2aaf2b8e39fdbfc79220b7f0c596c9b80", size = 10260771, upload-time = "2026-02-19T22:32:36.938Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ac/605c20b8e059a0bc4b42360414baa4892ff278cec1c91fff4be0dceedefd/ruff-0.15.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2dcc987551952d73cbf5c88d9fdee815618d497e4df86cd4c4824cc59d5dd75f", size = 11045791, upload-time = "2026-02-19T22:32:31.642Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/52/db6e419908f45a894924d410ac77d64bdd98ff86901d833364251bd08e22/ruff-0.15.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:42a47fd785cbe8c01b9ff45031af875d101b040ad8f4de7bbb716487c74c9a77", size = 11879271, upload-time = "2026-02-19T22:32:29.305Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d8/7992b18f2008bdc9231d0f10b16df7dda964dbf639e2b8b4c1b4e91b83af/ruff-0.15.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cbe9f49354866e575b4c6943856989f966421870e85cd2ac94dccb0a9dcb2fea", size = 11303707, upload-time = "2026-02-19T22:32:22.492Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/02/849b46184bcfdd4b64cde61752cc9a146c54759ed036edd11857e9b8443b/ruff-0.15.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b7a672c82b5f9887576087d97be5ce439f04bbaf548ee987b92d3a7dede41d3a", size = 11149151, upload-time = "2026-02-19T22:32:44.234Z" },
+    { url = "https://files.pythonhosted.org/packages/70/04/f5284e388bab60d1d3b99614a5a9aeb03e0f333847e2429bebd2aaa1feec/ruff-0.15.2-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:72ecc64f46f7019e2bcc3cdc05d4a7da958b629a5ab7033195e11a438403d956", size = 11091132, upload-time = "2026-02-19T22:32:24.691Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/ae/88d844a21110e14d92cf73d57363fab59b727ebeabe78009b9ccb23500af/ruff-0.15.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:8dcf243b15b561c655c1ef2f2b0050e5d50db37fe90115507f6ff37d865dc8b4", size = 10504717, upload-time = "2026-02-19T22:32:26.75Z" },
+    { url = "https://files.pythonhosted.org/packages/64/27/867076a6ada7f2b9c8292884ab44d08fd2ba71bd2b5364d4136f3cd537e1/ruff-0.15.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dab6941c862c05739774677c6273166d2510d254dac0695c0e3f5efa1b5585de", size = 10263122, upload-time = "2026-02-19T22:32:10.036Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/ef/faf9321d550f8ebf0c6373696e70d1758e20ccdc3951ad7af00c0956be7c/ruff-0.15.2-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1b9164f57fc36058e9a6806eb92af185b0697c9fe4c7c52caa431c6554521e5c", size = 10735295, upload-time = "2026-02-19T22:32:39.227Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/55/e8089fec62e050ba84d71b70e7834b97709ca9b7aba10c1a0b196e493f97/ruff-0.15.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:80d24fcae24d42659db7e335b9e1531697a7102c19185b8dc4a028b952865fd8", size = 11241641, upload-time = "2026-02-19T22:32:34.617Z" },
+    { url = "https://files.pythonhosted.org/packages/23/01/1c30526460f4d23222d0fabd5888868262fd0e2b71a00570ca26483cd993/ruff-0.15.2-py3-none-win32.whl", hash = "sha256:fd5ff9e5f519a7e1bd99cbe8daa324010a74f5e2ebc97c6242c08f26f3714f6f", size = 10507885, upload-time = "2026-02-19T22:32:15.635Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/10/3d18e3bbdf8fc50bbb4ac3cc45970aa5a9753c5cb51bf9ed9a3cd8b79fa3/ruff-0.15.2-py3-none-win_amd64.whl", hash = "sha256:d20014e3dfa400f3ff84830dfb5755ece2de45ab62ecea4af6b7262d0fb4f7c5", size = 11623725, upload-time = "2026-02-19T22:32:04.947Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/78/097c0798b1dab9f8affe73da9642bb4500e098cb27fd8dc9724816ac747b/ruff-0.15.2-py3-none-win_arm64.whl", hash = "sha256:cabddc5822acdc8f7b5527b36ceac55cc51eec7b1946e60181de8fe83ca8876e", size = 10941649, upload-time = "2026-02-19T22:32:18.108Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/30/31573e9457673ab10aa432461bee537ce6cef177667deca369efb79df071/tomli-2.4.0.tar.gz", hash = "sha256:aa89c3f6c277dd275d8e243ad24f3b5e701491a860d5121f2cdd399fbb31fc9c", size = 17477, upload-time = "2026-01-11T11:22:38.165Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/d9/3dc2289e1f3b32eb19b9785b6a006b28ee99acb37d1d47f78d4c10e28bf8/tomli-2.4.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b5ef256a3fd497d4973c11bf142e9ed78b150d36f5773f1ca6088c230ffc5867", size = 153663, upload-time = "2026-01-11T11:21:45.27Z" },
+    { url = "https://files.pythonhosted.org/packages/51/32/ef9f6845e6b9ca392cd3f64f9ec185cc6f09f0a2df3db08cbe8809d1d435/tomli-2.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5572e41282d5268eb09a697c89a7bee84fae66511f87533a6f88bd2f7b652da9", size = 148469, upload-time = "2026-01-11T11:21:46.873Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/c2/506e44cce89a8b1b1e047d64bd495c22c9f71f21e05f380f1a950dd9c217/tomli-2.4.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:551e321c6ba03b55676970b47cb1b73f14a0a4dce6a3e1a9458fd6d921d72e95", size = 236039, upload-time = "2026-01-11T11:21:48.503Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/40/e1b65986dbc861b7e986e8ec394598187fa8aee85b1650b01dd925ca0be8/tomli-2.4.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e3f639a7a8f10069d0e15408c0b96a2a828cfdec6fca05296ebcdcc28ca7c76", size = 243007, upload-time = "2026-01-11T11:21:49.456Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/6f/6e39ce66b58a5b7ae572a0f4352ff40c71e8573633deda43f6a379d56b3e/tomli-2.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1b168f2731796b045128c45982d3a4874057626da0e2ef1fdd722848b741361d", size = 240875, upload-time = "2026-01-11T11:21:50.755Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ad/cb089cb190487caa80204d503c7fd0f4d443f90b95cf4ef5cf5aa0f439b0/tomli-2.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:133e93646ec4300d651839d382d63edff11d8978be23da4cc106f5a18b7d0576", size = 246271, upload-time = "2026-01-11T11:21:51.81Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/63/69125220e47fd7a3a27fd0de0c6398c89432fec41bc739823bcc66506af6/tomli-2.4.0-cp311-cp311-win32.whl", hash = "sha256:b6c78bdf37764092d369722d9946cb65b8767bfa4110f902a1b2542d8d173c8a", size = 96770, upload-time = "2026-01-11T11:21:52.647Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/0d/a22bb6c83f83386b0008425a6cd1fa1c14b5f3dd4bad05e98cf3dbbf4a64/tomli-2.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:d3d1654e11d724760cdb37a3d7691f0be9db5fbdaef59c9f532aabf87006dbaa", size = 107626, upload-time = "2026-01-11T11:21:53.459Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/6d/77be674a3485e75cacbf2ddba2b146911477bd887dda9d8c9dfb2f15e871/tomli-2.4.0-cp311-cp311-win_arm64.whl", hash = "sha256:cae9c19ed12d4e8f3ebf46d1a75090e4c0dc16271c5bce1c833ac168f08fb614", size = 94842, upload-time = "2026-01-11T11:21:54.831Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/43/7389a1869f2f26dba52404e1ef13b4784b6b37dac93bac53457e3ff24ca3/tomli-2.4.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:920b1de295e72887bafa3ad9f7a792f811847d57ea6b1215154030cf131f16b1", size = 154894, upload-time = "2026-01-11T11:21:56.07Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/05/2f9bf110b5294132b2edf13fe6ca6ae456204f3d749f623307cbb7a946f2/tomli-2.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7d6d9a4aee98fac3eab4952ad1d73aee87359452d1c086b5ceb43ed02ddb16b8", size = 149053, upload-time = "2026-01-11T11:21:57.467Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/41/1eda3ca1abc6f6154a8db4d714a4d35c4ad90adc0bcf700657291593fbf3/tomli-2.4.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:36b9d05b51e65b254ea6c2585b59d2c4cb91c8a3d91d0ed0f17591a29aaea54a", size = 243481, upload-time = "2026-01-11T11:21:58.661Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/6d/02ff5ab6c8868b41e7d4b987ce2b5f6a51d3335a70aa144edd999e055a01/tomli-2.4.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1c8a885b370751837c029ef9bc014f27d80840e48bac415f3412e6593bbc18c1", size = 251720, upload-time = "2026-01-11T11:22:00.178Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/57/0405c59a909c45d5b6f146107c6d997825aa87568b042042f7a9c0afed34/tomli-2.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8768715ffc41f0008abe25d808c20c3d990f42b6e2e58305d5da280ae7d1fa3b", size = 247014, upload-time = "2026-01-11T11:22:01.238Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/0e/2e37568edd944b4165735687cbaf2fe3648129e440c26d02223672ee0630/tomli-2.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7b438885858efd5be02a9a133caf5812b8776ee0c969fea02c45e8e3f296ba51", size = 251820, upload-time = "2026-01-11T11:22:02.727Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/1c/ee3b707fdac82aeeb92d1a113f803cf6d0f37bdca0849cb489553e1f417a/tomli-2.4.0-cp312-cp312-win32.whl", hash = "sha256:0408e3de5ec77cc7f81960c362543cbbd91ef883e3138e81b729fc3eea5b9729", size = 97712, upload-time = "2026-01-11T11:22:03.777Z" },
+    { url = "https://files.pythonhosted.org/packages/69/13/c07a9177d0b3bab7913299b9278845fc6eaaca14a02667c6be0b0a2270c8/tomli-2.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:685306e2cc7da35be4ee914fd34ab801a6acacb061b6a7abca922aaf9ad368da", size = 108296, upload-time = "2026-01-11T11:22:04.86Z" },
+    { url = "https://files.pythonhosted.org/packages/18/27/e267a60bbeeee343bcc279bb9e8fbed0cbe224bc7b2a3dc2975f22809a09/tomli-2.4.0-cp312-cp312-win_arm64.whl", hash = "sha256:5aa48d7c2356055feef06a43611fc401a07337d5b006be13a30f6c58f869e3c3", size = 94553, upload-time = "2026-01-11T11:22:05.854Z" },
+    { url = "https://files.pythonhosted.org/packages/34/91/7f65f9809f2936e1f4ce6268ae1903074563603b2a2bd969ebbda802744f/tomli-2.4.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:84d081fbc252d1b6a982e1870660e7330fb8f90f676f6e78b052ad4e64714bf0", size = 154915, upload-time = "2026-01-11T11:22:06.703Z" },
+    { url = "https://files.pythonhosted.org/packages/20/aa/64dd73a5a849c2e8f216b755599c511badde80e91e9bc2271baa7b2cdbb1/tomli-2.4.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:9a08144fa4cba33db5255f9b74f0b89888622109bd2776148f2597447f92a94e", size = 149038, upload-time = "2026-01-11T11:22:07.56Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8a/6d38870bd3d52c8d1505ce054469a73f73a0fe62c0eaf5dddf61447e32fa/tomli-2.4.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c73add4bb52a206fd0c0723432db123c0c75c280cbd67174dd9d2db228ebb1b4", size = 242245, upload-time = "2026-01-11T11:22:08.344Z" },
+    { url = "https://files.pythonhosted.org/packages/59/bb/8002fadefb64ab2669e5b977df3f5e444febea60e717e755b38bb7c41029/tomli-2.4.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fb2945cbe303b1419e2706e711b7113da57b7db31ee378d08712d678a34e51e", size = 250335, upload-time = "2026-01-11T11:22:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/3d/4cdb6f791682b2ea916af2de96121b3cb1284d7c203d97d92d6003e91c8d/tomli-2.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bbb1b10aa643d973366dc2cb1ad94f99c1726a02343d43cbc011edbfac579e7c", size = 245962, upload-time = "2026-01-11T11:22:11.27Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/4a/5f25789f9a460bd858ba9756ff52d0830d825b458e13f754952dd15fb7bb/tomli-2.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4cbcb367d44a1f0c2be408758b43e1ffb5308abe0ea222897d6bfc8e8281ef2f", size = 250396, upload-time = "2026-01-11T11:22:12.325Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/2f/b73a36fea58dfa08e8b3a268750e6853a6aac2a349241a905ebd86f3047a/tomli-2.4.0-cp313-cp313-win32.whl", hash = "sha256:7d49c66a7d5e56ac959cb6fc583aff0651094ec071ba9ad43df785abc2320d86", size = 97530, upload-time = "2026-01-11T11:22:13.865Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/af/ca18c134b5d75de7e8dc551c5234eaba2e8e951f6b30139599b53de9c187/tomli-2.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:3cf226acb51d8f1c394c1b310e0e0e61fecdd7adcb78d01e294ac297dd2e7f87", size = 108227, upload-time = "2026-01-11T11:22:15.224Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c3/b386b832f209fee8073c8138ec50f27b4460db2fdae9ffe022df89a57f9b/tomli-2.4.0-cp313-cp313-win_arm64.whl", hash = "sha256:d20b797a5c1ad80c516e41bc1fb0443ddb5006e9aaa7bda2d71978346aeb9132", size = 94748, upload-time = "2026-01-11T11:22:16.009Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c4/84047a97eb1004418bc10bdbcfebda209fca6338002eba2dc27cc6d13563/tomli-2.4.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:26ab906a1eb794cd4e103691daa23d95c6919cc2fa9160000ac02370cc9dd3f6", size = 154725, upload-time = "2026-01-11T11:22:17.269Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/5d/d39038e646060b9d76274078cddf146ced86dc2b9e8bbf737ad5983609a0/tomli-2.4.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:20cedb4ee43278bc4f2fee6cb50daec836959aadaf948db5172e776dd3d993fc", size = 148901, upload-time = "2026-01-11T11:22:18.287Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e5/383be1724cb30f4ce44983d249645684a48c435e1cd4f8b5cded8a816d3c/tomli-2.4.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:39b0b5d1b6dd03684b3fb276407ebed7090bbec989fa55838c98560c01113b66", size = 243375, upload-time = "2026-01-11T11:22:19.154Z" },
+    { url = "https://files.pythonhosted.org/packages/31/f0/bea80c17971c8d16d3cc109dc3585b0f2ce1036b5f4a8a183789023574f2/tomli-2.4.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a26d7ff68dfdb9f87a016ecfd1e1c2bacbe3108f4e0f8bcd2228ef9a766c787d", size = 250639, upload-time = "2026-01-11T11:22:20.168Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/8f/2853c36abbb7608e3f945d8a74e32ed3a74ee3a1f468f1ffc7d1cb3abba6/tomli-2.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:20ffd184fb1df76a66e34bd1b36b4a4641bd2b82954befa32fe8163e79f1a702", size = 246897, upload-time = "2026-01-11T11:22:21.544Z" },
+    { url = "https://files.pythonhosted.org/packages/49/f0/6c05e3196ed5337b9fe7ea003e95fd3819a840b7a0f2bf5a408ef1dad8ed/tomli-2.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:75c2f8bbddf170e8effc98f5e9084a8751f8174ea6ccf4fca5398436e0320bc8", size = 254697, upload-time = "2026-01-11T11:22:23.058Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/f5/2922ef29c9f2951883525def7429967fc4d8208494e5ab524234f06b688b/tomli-2.4.0-cp314-cp314-win32.whl", hash = "sha256:31d556d079d72db7c584c0627ff3a24c5d3fb4f730221d3444f3efb1b2514776", size = 98567, upload-time = "2026-01-11T11:22:24.033Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/31/22b52e2e06dd2a5fdbc3ee73226d763b184ff21fc24e20316a44ccc4d96b/tomli-2.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:43e685b9b2341681907759cf3a04e14d7104b3580f808cfde1dfdb60ada85475", size = 108556, upload-time = "2026-01-11T11:22:25.378Z" },
+    { url = "https://files.pythonhosted.org/packages/48/3d/5058dff3255a3d01b705413f64f4306a141a8fd7a251e5a495e3f192a998/tomli-2.4.0-cp314-cp314-win_arm64.whl", hash = "sha256:3d895d56bd3f82ddd6faaff993c275efc2ff38e52322ea264122d72729dca2b2", size = 96014, upload-time = "2026-01-11T11:22:26.138Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/4e/75dab8586e268424202d3a1997ef6014919c941b50642a1682df43204c22/tomli-2.4.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:5b5807f3999fb66776dbce568cc9a828544244a8eb84b84b9bafc080c99597b9", size = 163339, upload-time = "2026-01-11T11:22:27.143Z" },
+    { url = "https://files.pythonhosted.org/packages/06/e3/b904d9ab1016829a776d97f163f183a48be6a4deb87304d1e0116a349519/tomli-2.4.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c084ad935abe686bd9c898e62a02a19abfc9760b5a79bc29644463eaf2840cb0", size = 159490, upload-time = "2026-01-11T11:22:28.399Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/5a/fc3622c8b1ad823e8ea98a35e3c632ee316d48f66f80f9708ceb4f2a0322/tomli-2.4.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f2e3955efea4d1cfbcb87bc321e00dc08d2bcb737fd1d5e398af111d86db5df", size = 269398, upload-time = "2026-01-11T11:22:29.345Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/33/62bd6152c8bdd4c305ad9faca48f51d3acb2df1f8791b1477d46ff86e7f8/tomli-2.4.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0e0fe8a0b8312acf3a88077a0802565cb09ee34107813bba1c7cd591fa6cfc8d", size = 276515, upload-time = "2026-01-11T11:22:30.327Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/ff/ae53619499f5235ee4211e62a8d7982ba9e439a0fb4f2f351a93d67c1dd2/tomli-2.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:413540dce94673591859c4c6f794dfeaa845e98bf35d72ed59636f869ef9f86f", size = 273806, upload-time = "2026-01-11T11:22:32.56Z" },
+    { url = "https://files.pythonhosted.org/packages/47/71/cbca7787fa68d4d0a9f7072821980b39fbb1b6faeb5f5cf02f4a5559fa28/tomli-2.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0dc56fef0e2c1c470aeac5b6ca8cc7b640bb93e92d9803ddaf9ea03e198f5b0b", size = 281340, upload-time = "2026-01-11T11:22:33.505Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/00/d595c120963ad42474cf6ee7771ad0d0e8a49d0f01e29576ee9195d9ecdf/tomli-2.4.0-cp314-cp314t-win32.whl", hash = "sha256:d878f2a6707cc9d53a1be1414bbb419e629c3d6e67f69230217bb663e76b5087", size = 108106, upload-time = "2026-01-11T11:22:34.451Z" },
+    { url = "https://files.pythonhosted.org/packages/de/69/9aa0c6a505c2f80e519b43764f8b4ba93b5a0bbd2d9a9de6e2b24271b9a5/tomli-2.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2add28aacc7425117ff6364fe9e06a183bb0251b03f986df0e78e974047571fd", size = 120504, upload-time = "2026-01-11T11:22:35.764Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/9f/f1668c281c58cfae01482f7114a4b88d345e4c140386241a1a24dcc9e7bc/tomli-2.4.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2b1e3b80e1d5e52e40e9b924ec43d81570f0e7d09d11081b797bc4692765a3d4", size = 99561, upload-time = "2026-01-11T11:22:36.624Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d1/136eb2cb77520a31e1f64cbae9d33ec6df0d78bdf4160398e86eec8a8754/tomli-2.4.0-py3-none-any.whl", hash = "sha256:1f776e7d669ebceb01dee46484485f43a4048746235e683bcdffacdf1fb4785a", size = 14477, upload-time = "2026-01-11T11:22:37.446Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]


### PR DESCRIPTION
## Summary
Thin client SDKs for the full LlamaFarm API — Python (pip) and TypeScript (npm).

### Python SDK (`packages/llamafarm-sdk/`)
- `pip install llamafarm` — httpx + pydantic, zero heavy deps
- Full API coverage: projects, chat, vision, fine-tune, KV cache, RAG, datasets, ML sub-APIs (anomaly, classifiers, NLP, embeddings, time series, ADTK, CatBoost, drift, explainability, Polars)
- Auto-discovery (env → config → localhost probe), sync + async, SSE streaming
- `build_project_config()` helper for zero-edit YAML generation
- OpenAI drop-in compatibility via `openai_base_url`
- 31/31 tests

### TypeScript SDK (`packages/llamafarm-sdk-ts/`)
- `npm install llamafarm` — zero runtime deps (native fetch)
- Dual ESM + CJS build, 15.9KB tarball
- All ML sub-APIs mirrored from Python
- 44/44 tests

### Testing
- Unit tests: Python 31/31, TypeScript 44/44
- Live tested against running LlamaFarm (ports 14345 + 11540)
