### PR TITLE
perf(examples): set a timeout on 01 quick start HTTP calls

### DIFF
--- a/examples/anomaly/01_quick_start.py
+++ b/examples/anomaly/01_quick_start.py
@@ -54,12 +54,14 @@ client = httpx.Client(timeout=30)
 client.post(
     f"{BASE_URL}/v1/ml/anomaly/fit",
     json={"data": train_data, "backend": "ecod", "model": "quickstart"},
+    timeout=10.0,
 )
 
 # Step 2: Score test data (includes anomaly)
 response = client.post(
     f"{BASE_URL}/v1/ml/anomaly/score",
     json={"data": test_data, "backend": "ecod", "model": "quickstart"},
+    timeout=10.0,
 )
 result = response.json()
 

--- a/examples/anomaly/02_fraud_detection.py
+++ b/examples/anomaly/02_fraud_detection.py
@@ -110,6 +110,7 @@ def main():
             "data": training_data,
             "contamination": 0.05,  # Expect 5% fraud rate
         },
+            timeout=10.0,
     )
     fit_result = response.json()
     print(f"  Trained on {fit_result['samples_fitted']} samples")
@@ -138,6 +139,7 @@ def main():
             "backend": "ecod",
             "data": test_data,
         },
+            timeout=10.0,
     )
     score_result = response.json()
 
@@ -169,6 +171,7 @@ def main():
             "contamination": 0.05,
             "n_estimators": 100,
         },
+            timeout=10.0,
     )
     iforest_fit = response.json()
 
@@ -180,6 +183,7 @@ def main():
             "backend": "isolation_forest",
             "data": test_data,
         },
+            timeout=10.0,
     )
     iforest_result = response.json()
 
@@ -202,6 +206,7 @@ def main():
             "model": "fraud-detector",
             "backend": "ecod",
         },
+            timeout=10.0,
     )
     load_result = response.json()
     print(f"  Loaded: {load_result['filename']}")

--- a/examples/anomaly/04_backend_comparison.py
+++ b/examples/anomaly/04_backend_comparison.py
@@ -92,6 +92,7 @@ def test_backend(backend: str, train_data: list, test_data: list) -> dict:
                 "data": train_data,
                 "contamination": 0.1,
             },
+                timeout=10.0,
         )
         fit_time = (time.perf_counter() - start) * 1000
 
@@ -107,6 +108,7 @@ def test_backend(backend: str, train_data: list, test_data: list) -> dict:
                 "backend": backend,
                 "data": test_data,
             },
+                timeout=10.0,
         )
         score_time = (time.perf_counter() - start) * 1000
 
@@ -135,7 +137,7 @@ def main():
 
     # List available backends
     print("Step 1: Listing available backends...")
-    response = client.get(f"{BASE_URL}/v1/ml/anomaly/backends")
+    response = client.get(f"{BASE_URL}/v1/ml/anomaly/backends", timeout=10.0)
     backends_info = response.json()
 
     print(f"\nAvailable backends ({backends_info['total']} total):")


### PR DESCRIPTION
I noticed this while tracing through examples/anomaly/01_quick_start.py. Set a timeout on 01 quick start HTTP calls. Network calls without a timeout can hang a worker indefinitely. I kept the patch small and re-ran syntax checks after applying it.