### PR TITLE
fix(edge): resolve model format from local dir before HF API

### DIFF
--- a/runtimes/edge/server.py
+++ b/runtimes/edge/server.py
@@ -279,11 +279,13 @@ async def load_language(
                         f"for LLAMAFARM_MODEL_DIR lookup"
                     )
 
-                # Check LLAMAFARM_MODEL_DIR first — avoids HuggingFace
-                # API calls that fail for alias-style model IDs in
-                # offline mode.
+                # For alias-style model IDs (no org/ namespace), check
+                # LLAMAFARM_MODEL_DIR first — avoids HuggingFace API
+                # calls that fail in offline mode.  Namespaced IDs like
+                # "org/model" always go through detect_model_format so a
+                # local alias can't silently override a specific repo.
                 model_format: str | None = None
-                if alias:
+                if alias and "/" not in model_id:
                     from llamafarm_common.model_dir import resolve_from_model_dir
                     if resolve_from_model_dir(alias) is not None:
                         model_format = "gguf"

--- a/runtimes/edge/server.py
+++ b/runtimes/edge/server.py
@@ -270,13 +270,7 @@ async def load_language(
             if cache_key not in _models:
                 logger.info(f"Loading causal LM: {model_id}")
                 device = get_device()
-                model_format = detect_model_format(model_id, trusted=trusted)
-                logger.info(f"Detected format: {model_format}")
 
-                # Derive an alias for LLAMAFARM_MODEL_DIR lookup. If the
-                # model_id can't be turned into a safe alias (absolute
-                # path, unusual chars), `alias` stays None and the
-                # constructor falls back to legacy HF-cache resolution.
                 from utils.alias import derive_alias_from_model_id
                 alias = derive_alias_from_model_id(model_id)
                 if alias:
@@ -284,6 +278,18 @@ async def load_language(
                         f"Derived alias {alias!r} from model_id {model_id!r} "
                         f"for LLAMAFARM_MODEL_DIR lookup"
                     )
+
+                # Check LLAMAFARM_MODEL_DIR first — avoids HuggingFace
+                # API calls that fail for alias-style model IDs in
+                # offline mode.
+                model_format: str | None = None
+                if alias:
+                    from llamafarm_common.model_dir import resolve_from_model_dir
+                    if resolve_from_model_dir(alias) is not None:
+                        model_format = "gguf"
+                if model_format is None:
+                    model_format = detect_model_format(model_id, trusted=trusted)
+                logger.info(f"Detected format: {model_format}")
 
                 model: BaseModel
                 if model_format == "gguf":


### PR DESCRIPTION
## Summary
- When `load_language()` receives an alias-style model ID (e.g. `mission-router-v1` from `NAVLINK_AGENT_MODEL`), `detect_model_format()` can't resolve it via HuggingFace in offline mode and crashes.
- Moves alias derivation before format detection and checks `LLAMAFARM_MODEL_DIR` first. If the alias resolves to a local GGUF file, the HF API call is skipped entirely.
- Fixes the navlink → edge-runtime flow on the Pi where `LLAMAFARM_OFFLINE=1`.

## Test plan
- [ ] Verify `mission-router-v1` alias resolves via `LLAMAFARM_MODEL_DIR` without HF API calls
- [ ] Verify full HF-style model IDs (e.g. `org/repo:quant`) still work via `detect_model_format` fallback
- [ ] Verify existing alias + model_format tests pass (`pytest runtimes/edge/tests/ common/tests/test_model_utils_offline.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)