### PR TITLE
fix(llamafarm-llama): prepend BOS in create_chat_completion

### DIFF
--- a/packages/llamafarm-llama/src/llamafarm_llama/llama.py
+++ b/packages/llamafarm-llama/src/llamafarm_llama/llama.py
@@ -1319,8 +1319,15 @@ class Llama:
         # Apply chat template
         prompt = self._apply_chat_template(messages, add_generation_prompt=True)
 
-        # Tokenize
-        tokens = self.tokenize(prompt, add_special=False, parse_special=True)
+        # Tokenize. add_special=True so the model's BOS is prepended for
+        # decoder-only models (Gemma/Llama/Mistral) that degenerate without
+        # it — the parallel bug on the raw-completion path was fixed in
+        # PR #820; this mirror is the chat-path fix. parse_special=True so
+        # that any literal delimiter tokens the template renders
+        # (`<bos>`, `<start_of_turn>`, `<end_of_turn>`) tokenize as their
+        # special IDs. llama.cpp's tokenizer deduplicates BOS if the
+        # template string already begins with one.
+        tokens = self.tokenize(prompt, add_special=True, parse_special=True)
         t_tokenize = time.perf_counter()
 
         if len(tokens) > self._n_ctx:

--- a/packages/llamafarm-llama/tests/test_llama.py
+++ b/packages/llamafarm-llama/tests/test_llama.py
@@ -267,6 +267,24 @@ class TestCreateCompletionBOS:
         assert "add_special=True" in source
 
 
+class TestCreateChatCompletionBOS:
+    """Regression: create_chat_completion must tokenize with add_special=True.
+
+    PR #820 fixed BOS handling on the raw-completion path but left the chat
+    path tokenizing with add_special=False, which stripped BOS for
+    decoder-only models (Gemma 3, Llama, Mistral) and produced garbage chat
+    output. The chat path must apply the same BOS-always policy."""
+
+    def test_tokenize_called_with_add_special_true(self):
+        import inspect
+
+        from llamafarm_llama.llama import Llama
+
+        source = inspect.getsource(Llama.create_chat_completion)
+        assert "add_special=True" in source
+        assert "add_special=False" not in source
+
+
 
 class TestSamplerChain:
     """Verify the sampler chain matches the requested sampling mode."""

--- a/packages/llamafarm-llama/tests/test_llama.py
+++ b/packages/llamafarm-llama/tests/test_llama.py
@@ -255,16 +255,37 @@ class TestChatTemplateUsesModelTemplate:
         assert apply_call[0][0] == sentinel
 
 
+def _assert_tokenize_uses_add_special_true(method):
+    """Parse method source via AST and verify every self.tokenize() call
+    passes add_special=True.  Immune to comment changes and whitespace."""
+    import ast
+    import inspect
+    import textwrap
+
+    source = textwrap.dedent(inspect.getsource(method))
+    tree = ast.parse(source)
+    tokenize_calls = [
+        node for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "tokenize"
+    ]
+    assert tokenize_calls, "no self.tokenize() call found"
+    for call in tokenize_calls:
+        kw = {k.arg: k.value for k in call.keywords}
+        assert "add_special" in kw, "tokenize() missing add_special kwarg"
+        assert isinstance(kw["add_special"], ast.Constant)
+        assert kw["add_special"].value is True, (
+            "tokenize() must use add_special=True for BOS"
+        )
+
+
 class TestCreateCompletionBOS:
     """Regression: create_completion must tokenize with add_special=True."""
 
     def test_tokenize_called_with_add_special_true(self):
-        import inspect
-
         from llamafarm_llama.llama import Llama
-
-        source = inspect.getsource(Llama.create_completion)
-        assert "add_special=True" in source
+        _assert_tokenize_uses_add_special_true(Llama.create_completion)
 
 
 class TestCreateChatCompletionBOS:
@@ -276,13 +297,8 @@ class TestCreateChatCompletionBOS:
     output. The chat path must apply the same BOS-always policy."""
 
     def test_tokenize_called_with_add_special_true(self):
-        import inspect
-
         from llamafarm_llama.llama import Llama
-
-        source = inspect.getsource(Llama.create_chat_completion)
-        assert "add_special=True" in source
-        assert "add_special=False" not in source
+        _assert_tokenize_uses_add_special_true(Llama.create_chat_completion)
 
 
 


### PR DESCRIPTION
## Summary

Mirror of the `create_completion` BOS fix from #820 to the `create_chat_completion` path. PR #820 set `add_special=True` on the raw-completion tokenize call — so decoder-only models like Gemma 3 get their required BOS token and don't degenerate into random-logit multilingual garbage — but left `create_chat_completion` tokenizing with `add_special=False`. So `/v1/chat/completions` was still producing garbage on Gemma 3 270M fine-tunes (and by extension Llama, Mistral, …), just on a different code path.

This is an incomplete-fix follow-up, not a new bug class.

## Repro

Raspberry Pi 5 / Cortex-A76, llama.cpp **b8816**, `llama-farm/llamadrone-mission-router-v3` Q8_0 GGUF (Gemma 3 270M fine-tune), `temperature=0` through `/v1/chat/completions`:

| Prompt | Before | After |
|---|---|---|
| `takeoff` | `<div>\n您 лица` | `{"role":"takingoff","altitude":10}` |
| `land now` | `</u>\n</u>\n</u>\n...` | `{"role":"land","action":"hold"}` |
| `Say hello in three words.` (generic chat) | `<h2>Emphasis on precision</h2>\n<h3>Seasonal Seasonal Seasonal</h3>...` | coherent |

`/v1/completions` with the same model was already fine after #820; this PR brings `/v1/chat/completions` to parity.

## Fix

One-line change at `packages/llamafarm-llama/src/llamafarm_llama/llama.py:1323` — `add_special=False` → `add_special=True`. Same dedup reasoning as #820: if the rendered chat template already begins with `<bos>`, llama.cpp's tokenizer deduplicates it, so the change is safe for both paths.

## Test plan

- Added `TestCreateChatCompletionBOS` regression test mirroring the existing `TestCreateCompletionBOS` from #820 — asserts `add_special=True` is present in `create_chat_completion` source and `add_special=False` is not.
- All 25 existing tests pass.
- Hot-patched into the edge-runtime container on a Pi 5 and verified the "after" outputs above against both `mission-router-v2` and `mission-router-v3`.

## Related

- #820 — the original BOS fix (completion path only), where I missed this parallel call site.