### PR TITLE
fix(edge): harden chat completions error handling (ROW-79)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -42,5 +42,8 @@ dist/
 Dockerfile
 .dockerignore
 
+# Tests
+**/tests/
+
 # Node.js
 node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -769,3 +769,6 @@ training/
 demofly/
 control/
 regsync/
+
+# Edge runtime stability test artifacts
+runtimes/edge/stability_*.csv

--- a/common/llamafarm_common/model_format.py
+++ b/common/llamafarm_common/model_format.py
@@ -16,6 +16,7 @@ import logging
 
 from huggingface_hub import HfApi, scan_cache_dir
 from huggingface_hub.utils import HFCacheInfo
+from .model_dir import resolve_from_model_dir
 from .model_utils import (
     GGUF_QUANTIZATION_PREFERENCE_ORDER,
     get_gguf_file_path,
@@ -153,7 +154,20 @@ def detect_model_format(
             _format_cache[base_model_id] = "transformers"
             return "transformers"
 
-    # Not in local cache - must query API
+    # Check LLAMAFARM_MODEL_DIR before hitting the network
+    try:
+        result = resolve_from_model_dir(base_model_id)
+        if result is not None:
+            logger.info(
+                "Detected GGUF format from LLAMAFARM_MODEL_DIR: %s",
+                result.weights_path,
+            )
+            _format_cache[base_model_id] = "gguf"
+            return "gguf"
+    except ValueError:
+        pass
+
+    # Not in local cache or model dir - must query API
     try:
         api = HfApi()
         all_files = api.list_repo_files(repo_id=base_model_id, token=token)

--- a/common/llamafarm_common/model_format.py
+++ b/common/llamafarm_common/model_format.py
@@ -16,6 +16,7 @@ import logging
 
 from huggingface_hub import HfApi, scan_cache_dir
 from huggingface_hub.utils import HFCacheInfo
+
 from .model_dir import resolve_from_model_dir
 from .model_utils import (
     GGUF_QUANTIZATION_PREFERENCE_ORDER,
@@ -154,9 +155,16 @@ def detect_model_format(
             _format_cache[base_model_id] = "transformers"
             return "transformers"
 
-    # Check LLAMAFARM_MODEL_DIR before hitting the network
+    # Check LLAMAFARM_MODEL_DIR before hitting the network.
+    # resolve_from_model_dir requires a path-safe alias (no "/"), so strip
+    # the org/ prefix that HuggingFace IDs like "Qwen/Qwen3-1.7B-GGUF"
+    # carry. This mirrors utils.alias.derive_alias_from_model_id in the
+    # edge runtime — foo/my-model and bar/my-model intentionally collide
+    # on the same alias directory; operators needing disambiguation should
+    # use distinct basenames.
+    alias_candidate = base_model_id.rsplit("/", 1)[-1]
     try:
-        result = resolve_from_model_dir(base_model_id)
+        result = resolve_from_model_dir(alias_candidate)
         if result is not None:
             logger.info(
                 "Detected GGUF format from LLAMAFARM_MODEL_DIR: %s",
@@ -164,8 +172,12 @@ def detect_model_format(
             )
             _format_cache[base_model_id] = "gguf"
             return "gguf"
-    except ValueError:
-        pass
+    except ValueError as e:
+        logger.debug(
+            "LLAMAFARM_MODEL_DIR lookup rejected alias %r: %s; falling back to network",
+            alias_candidate,
+            e,
+        )
 
     # Not in local cache or model dir - must query API
     try:

--- a/common/tests/test_model_format.py
+++ b/common/tests/test_model_format.py
@@ -1,0 +1,46 @@
+"""Tests for llamafarm_common.model_format.detect_model_format."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+from llamafarm_common import model_format as mf
+
+
+def _write_gguf(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"GGUF" + b"\x00" * 12)
+
+
+class TestOrgPrefixStripping:
+    """HuggingFace-style org/repo IDs must still hit LLAMAFARM_MODEL_DIR.
+
+    Regression test: resolve_from_model_dir rejects aliases containing "/".
+    detect_model_format has to strip the org prefix before the lookup or
+    users with a correctly-populated LLAMAFARM_MODEL_DIR will silently
+    fall through to a network HF call.
+    """
+
+    def test_org_prefix_stripped_before_model_dir_lookup(self, tmp_path, monkeypatch):
+        mf.clear_format_cache()
+        root = tmp_path / "models"
+        root.mkdir()
+        # Stored under basename only — matches how operators lay out files.
+        _write_gguf(root / "Qwen3-1.7B-GGUF" / "model.Q8_0.gguf")
+        monkeypatch.setenv("LLAMAFARM_MODEL_DIR", str(root))
+
+        with patch.object(mf, "_check_local_cache_for_model", return_value=None):
+            result = mf.detect_model_format("Qwen/Qwen3-1.7B-GGUF")
+
+        assert result == "gguf"
+
+    def test_bare_name_still_works(self, tmp_path, monkeypatch):
+        mf.clear_format_cache()
+        root = tmp_path / "models"
+        root.mkdir()
+        _write_gguf(root / "mission-router-v3" / "model.Q8_0.gguf")
+        monkeypatch.setenv("LLAMAFARM_MODEL_DIR", str(root))
+
+        with patch.object(mf, "_check_local_cache_for_model", return_value=None):
+            result = mf.detect_model_format("mission-router-v3")
+
+        assert result == "gguf"

--- a/openspec/changes/edge-context-calculator-priority/.openspec.yaml
+++ b/openspec/changes/edge-context-calculator-priority/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-01

--- a/openspec/changes/edge-context-calculator-priority/design.md
+++ b/openspec/changes/edge-context-calculator-priority/design.md
@@ -1,0 +1,67 @@
+## Context
+
+The edge runtime's `get_default_context_size()` in `runtimes/edge/utils/context_calculator.py` determines context window size using a four-tier priority system. The current order is:
+
+1. `config_n_ctx` (explicit API/config override)
+2. `n_ctx_train` (from GGUF metadata)
+3. Pattern match from `model_context_defaults.yaml`
+4. Computed max from memory / fallback
+
+Since virtually all GGUF files embed `n_ctx_train`, tier 3 (pattern matching) is dead code — it never wins. The `model_context_defaults.yaml` config exists specifically to let operators set sane defaults per model family, but those defaults are ignored.
+
+On a Raspberry Pi 5 (15GB RAM), a 268MB navlink-v2 model with `n_ctx_train=32768` allocates a 2GB+ compute buffer and 576MB KV cache. The memory-based cap (`compute_max_context`) doesn't catch it because 15GB technically fits. But the llama.cpp native layer segfaults during inference with the oversized context on ARM64, crashing the container silently.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Pattern-matched defaults from `model_context_defaults.yaml` take priority over `n_ctx_train`
+- Existing `config_n_ctx` (from API, `PRELOAD_N_CTX`, per-request `n_ctx`) remains highest priority
+- `n_ctx_train` remains a valid fallback when no pattern matches
+- No changes to the universal runtime or any code outside the edge runtime
+
+**Non-Goals:**
+- Fixing the underlying llama.cpp ARM64 segfault with large contexts (that's upstream)
+- Adding new pattern entries to `model_context_defaults.yaml` (operators can do this themselves)
+- Changing memory estimation logic in `compute_max_context`
+- Making the priority order configurable (complexity not warranted)
+
+## Decisions
+
+### 1. Swap priority of pattern match and n_ctx_train
+
+The `elif` chain in `get_default_context_size()` (lines 396-449) reorders to:
+
+```
+1. config_n_ctx          (explicit user choice — unchanged)
+2. pattern_n_ctx         (operator's deployment default — promoted)
+3. n_ctx_train           (model metadata — demoted)
+4. computed max / 2048   (fallback — unchanged)
+```
+
+**Why pattern over n_ctx_train:** The pattern config is a deliberate choice by the operator for their deployment. The training context is an artifact of how the model was trained — not a recommendation for how much context to allocate on a constrained device. A 268MB model trained with 32K context doesn't need 32K context to function; it needs enough context for its actual workload (typically 2-4K for tool-calling models).
+
+**Alternative considered:** Adding a separate "edge mode" flag that changes the priority. Rejected because it adds configuration surface area for no benefit — the pattern config already is the edge-specific override mechanism.
+
+**Alternative considered:** Capping `n_ctx_train` based on model size heuristics (e.g., models under 1GB get capped at 4096). Rejected because it's fragile and doesn't generalize across model families.
+
+### 2. Keep the wildcard fallback pattern as the safety net
+
+The `model_context_defaults.yaml` already has a `"*"` catch-all pattern with `n_ctx: 4096`. With the new priority order, this pattern effectively caps all unknown models at 4096 unless a more specific pattern or explicit config overrides it. This is the right behavior for edge — conservative by default, opt-in to larger contexts.
+
+### 3. Log when pattern overrides n_ctx_train
+
+Add an info-level log when a pattern match is used instead of the model's training context, so operators can see the override happening and adjust patterns if needed.
+
+```
+Pattern default overrides n_ctx_train (32768 → 4096) for model navlink-v2-Q8_0.gguf
+```
+
+## Risks / Trade-offs
+
+- **Existing deployments see smaller context sizes** → Any model matched by a pattern with a smaller `n_ctx` than its `n_ctx_train` will use the pattern value. The `"*"` catch-all means all models default to 4096 instead of their training context. Mitigation: operators can add specific patterns for models that need larger context, or use `PRELOAD_N_CTX`/per-request `n_ctx` to override.
+- **Pattern config becomes load-bearing** → If `model_context_defaults.yaml` is missing or empty, behavior falls through to `n_ctx_train` then memory-based fallback, which is the current (broken) behavior. Mitigation: the config file is bundled in the Docker image and the `load_model_context_config()` function already raises `FileNotFoundError` if missing.
+- **Docstring/comment drift** → The priority order is documented in the function docstring (line 322-328) and inline comments. These must be updated to match. Minor risk but easy to miss.
+
+## Open Questions
+
+None — the change is small and well-scoped.

--- a/openspec/changes/edge-context-calculator-priority/proposal.md
+++ b/openspec/changes/edge-context-calculator-priority/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+The edge runtime's context calculator uses `n_ctx_train` from GGUF metadata as priority 2, ahead of pattern-matched defaults from `model_context_defaults.yaml` (priority 3). Since nearly every GGUF file includes `n_ctx_train`, the pattern-matching system is effectively dead code — it never wins. On constrained edge devices (Raspberry Pi), this causes small models (e.g., 268MB navlink-v2) to allocate their full 32K training context (2GB+ KV cache + compute buffers), crashing inference via segfault despite having 15GB of available RAM. The memory-based cap doesn't catch it because 15GB is technically enough — the crash is in the native llama.cpp layer, not an OOM.
+
+## What Changes
+
+- **BREAKING**: The context calculator priority order changes. Pattern-matched defaults from `model_context_defaults.yaml` now take priority over `n_ctx_train` from GGUF metadata. Deployments that relied on the implicit behavior of always using `n_ctx_train` may see different (smaller) context sizes if a pattern match exists.
+- The four-tier priority becomes: (1) explicit `config_n_ctx` from API/config, (2) pattern match from `model_context_defaults.yaml`, (3) `n_ctx_train` from GGUF metadata, (4) computed max from memory / fallback.
+- `PRELOAD_N_CTX` and per-request `n_ctx` continue to work as before (they feed into `config_n_ctx`, priority 1).
+
+## Capabilities
+
+### New Capabilities
+
+- `context-priority`: Context calculator priority order for determining default context size from model metadata, config patterns, and memory constraints
+
+### Modified Capabilities
+
+## Impact
+
+- `runtimes/edge/utils/context_calculator.py` — reorder the priority branches in `get_default_context_size()`
+- `runtimes/edge/config/model_context_defaults.yaml` — no structural change, but patterns now actually govern behavior for models that match them
+- Universal runtime (`runtimes/universal/`) is unaffected — it has its own context logic
+- Existing `PRELOAD_N_CTX` and per-request `n_ctx` override paths are unchanged

--- a/openspec/changes/edge-context-calculator-priority/specs/context-priority/spec.md
+++ b/openspec/changes/edge-context-calculator-priority/specs/context-priority/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Pattern-matched defaults take priority over training context
+
+The context calculator SHALL use pattern-matched defaults from `model_context_defaults.yaml` before falling back to the model's `n_ctx_train` metadata. The full priority order SHALL be:
+
+1. Explicit `config_n_ctx` (from API request, `PRELOAD_N_CTX`, or per-request `n_ctx`)
+2. Pattern match from `model_context_defaults.yaml`
+3. `n_ctx_train` from GGUF metadata
+4. Computed maximum from available memory
+5. Fallback default (2048)
+
+All tiers SHALL be capped by the memory-based maximum computed by `compute_max_context()`.
+
+#### Scenario: Model matches a pattern with smaller context than n_ctx_train
+- **WHEN** a GGUF model has `n_ctx_train=32768` and matches a pattern with `n_ctx=4096`
+- **THEN** the calculator SHALL use `4096` as the context size
+
+#### Scenario: Model matches no specific pattern but matches wildcard
+- **WHEN** a GGUF model does not match any specific pattern but matches the `"*"` catch-all with `n_ctx=4096`
+- **THEN** the calculator SHALL use `4096` as the context size, not the model's `n_ctx_train`
+
+#### Scenario: Explicit config_n_ctx overrides pattern match
+- **WHEN** a request includes `n_ctx=2048` and the model matches a pattern with `n_ctx=4096`
+- **THEN** the calculator SHALL use `2048` (explicit config always wins)
+
+#### Scenario: No pattern match falls through to n_ctx_train
+- **WHEN** a GGUF model has `n_ctx_train=8192` and no pattern in `model_context_defaults.yaml` matches (including no wildcard)
+- **THEN** the calculator SHALL use `8192` from the model's training context
+
+### Requirement: Log when pattern overrides training context
+
+The context calculator SHALL log an info-level message when a pattern-matched default is used instead of the model's `n_ctx_train`, including both values and the model identifier.
+
+#### Scenario: Pattern override is logged
+- **WHEN** a model with `n_ctx_train=32768` is assigned `n_ctx=4096` via pattern match
+- **THEN** the calculator SHALL emit an info log indicating the pattern default overrides `n_ctx_train`, showing both values
+
+### Requirement: Docstring reflects updated priority order
+
+The `get_default_context_size()` function docstring SHALL document the updated priority order with pattern match at tier 2 and `n_ctx_train` at tier 3.
+
+#### Scenario: Docstring accuracy
+- **WHEN** a developer reads the docstring of `get_default_context_size()`
+- **THEN** the documented priority order SHALL list pattern match before `n_ctx_train`

--- a/openspec/changes/edge-context-calculator-priority/tasks.md
+++ b/openspec/changes/edge-context-calculator-priority/tasks.md
@@ -1,0 +1,13 @@
+## 1. Reorder priority in context calculator
+
+- [x] 1.1 In `runtimes/edge/utils/context_calculator.py`, swap the `elif n_ctx_train` and `elif pattern_n_ctx` branches in `get_default_context_size()` so pattern match is checked before `n_ctx_train`
+- [x] 1.2 Update the function docstring priority list to reflect the new order (pattern match at tier 2, `n_ctx_train` at tier 3)
+- [x] 1.3 Update inline comments on each `elif` branch to match the new priority numbering
+
+## 2. Add override logging
+
+- [x] 2.1 Add an info-level log when a pattern match is used and `n_ctx_train` is also available, showing both values (e.g., "Pattern default overrides n_ctx_train (32768 → 4096) for model navlink-v2-Q8_0.gguf")
+
+## 3. Update compose template in llamadrone
+
+- [x] 3.1 Add `GGUF_MODELS_DIR=/models` to the edge-runtime environment in `infra/ansible/roles/deploy/templates/docker-compose.yml.j2`

--- a/runtimes/edge/pyproject.toml
+++ b/runtimes/edge/pyproject.toml
@@ -61,6 +61,12 @@ dev = [
   "httpx>=0.24.0",
 ]
 
+[tool.pytest.ini_options]
+markers = [
+  "integration: tests that require a live edge runtime (set EDGE_URL)",
+  "e2e: end-to-end tests that span multiple services",
+]
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/runtimes/edge/routers/chat_completions/service.py
+++ b/runtimes/edge/routers/chat_completions/service.py
@@ -1423,28 +1423,54 @@ class ChatCompletionsService:
         except HTTPException:
             raise
         except ValueError as e:
-            logger.warning(f"Invalid model_id in chat_completions: {e}")
+            # load_language raises ValueError("Invalid model_id: ...") for
+            # path-traversal / bad-format IDs from HTTP input. Other ValueErrors
+            # (e.g. llama.cpp "Prompt too long") are genuine request errors
+            # but not model-id validation failures — don't mislabel them.
+            if "Invalid model_id" in str(e):
+                logger.warning(f"Invalid model_id in chat_completions: {e}")
+                raise HTTPException(
+                    status_code=400,
+                    detail={"error": "invalid_model_id", "message": str(e)},
+                ) from e
+            logger.error(f"ValueError in chat_completions: {e}", exc_info=True)
             raise HTTPException(
                 status_code=400,
-                detail={"error": "invalid_model_id", "message": str(e)},
+                detail={"error": "bad_request", "message": str(e)},
             ) from e
         except Exception as e:
             try:
-                from huggingface_hub.utils import (
+                from huggingface_hub.errors import (
+                    EntryNotFoundError,
                     GatedRepoError,
                     HfHubHTTPError,
+                    LocalEntryNotFoundError,
+                    OfflineModeIsEnabled,
                     RepositoryNotFoundError,
                 )
             except ImportError:
                 HfHubHTTPError = RepositoryNotFoundError = GatedRepoError = ()  # type: ignore[assignment,misc]
+                LocalEntryNotFoundError = EntryNotFoundError = OfflineModeIsEnabled = ()  # type: ignore[assignment,misc]
 
-            if isinstance(e, RepositoryNotFoundError):
+            if isinstance(e, (RepositoryNotFoundError, LocalEntryNotFoundError, EntryNotFoundError)):
                 logger.warning(f"Model repository not found: {e}")
                 raise HTTPException(
                     status_code=404,
                     detail={
                         "error": "model_not_found",
                         "message": f"Model not found: {chat_request.model}",
+                    },
+                ) from e
+            if isinstance(e, OfflineModeIsEnabled):
+                logger.warning(f"Model not cached locally (offline mode): {e}")
+                raise HTTPException(
+                    status_code=404,
+                    detail={
+                        "error": "model_not_cached",
+                        "message": (
+                            f"Model '{chat_request.model}' is not cached locally "
+                            "and offline mode is enabled"
+                        ),
                     },
                 ) from e
             if isinstance(e, GatedRepoError):

--- a/runtimes/edge/routers/chat_completions/service.py
+++ b/runtimes/edge/routers/chat_completions/service.py
@@ -1422,6 +1422,51 @@ class ChatCompletionsService:
 
         except HTTPException:
             raise
+        except ValueError as e:
+            logger.warning(f"Invalid model_id in chat_completions: {e}")
+            raise HTTPException(
+                status_code=400,
+                detail={"error": "invalid_model_id", "message": str(e)},
+            ) from e
         except Exception as e:
+            try:
+                from huggingface_hub.utils import (
+                    GatedRepoError,
+                    HfHubHTTPError,
+                    RepositoryNotFoundError,
+                )
+            except ImportError:
+                HfHubHTTPError = RepositoryNotFoundError = GatedRepoError = ()  # type: ignore[assignment,misc]
+
+            if isinstance(e, RepositoryNotFoundError):
+                logger.warning(f"Model repository not found: {e}")
+                raise HTTPException(
+                    status_code=404,
+                    detail={
+                        "error": "model_not_found",
+                        "message": f"Model not found: {chat_request.model}",
+                    },
+                ) from e
+            if isinstance(e, GatedRepoError):
+                raise HTTPException(
+                    status_code=403,
+                    detail={
+                        "error": "model_gated",
+                        "message": f"Access to model is gated: {chat_request.model}",
+                    },
+                ) from e
+            if isinstance(e, HfHubHTTPError):
+                logger.error(f"HF hub error resolving {chat_request.model}: {e}")
+                raise HTTPException(
+                    status_code=503,
+                    detail={
+                        "error": "model_resolution_failed",
+                        "message": "Upstream model registry unavailable",
+                    },
+                ) from e
+
             logger.error(f"Error in chat_completions: {e}", exc_info=True)
-            raise HTTPException(status_code=500, detail=str(e)) from e
+            raise HTTPException(
+                status_code=500,
+                detail={"error": "internal_error", "message": "Internal server error"},
+            ) from e

--- a/runtimes/edge/routers/chat_completions/types.py
+++ b/runtimes/edge/routers/chat_completions/types.py
@@ -1,7 +1,7 @@
 from typing import Literal
 
 from openai.types.chat import ChatCompletionMessageParam, ChatCompletionToolParam
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 # ============================================================================
 # Audio Content Types (for STT transcription)
@@ -114,6 +114,34 @@ class ChatCompletionRequest(BaseModel):
     auto_truncate: bool | None = True
     # Truncation strategy: "sliding_window", "keep_system", "middle_out", "summarize"
     truncation_strategy: str | None = None
+
+    @field_validator("messages")
+    @classmethod
+    def _messages_nonempty(cls, v):
+        if not v:
+            raise ValueError("messages must not be empty")
+        return v
+
+    @field_validator("max_tokens")
+    @classmethod
+    def _max_tokens_positive(cls, v):
+        if v is not None and v < 1:
+            raise ValueError("max_tokens must be >= 1")
+        return v
+
+    @field_validator("temperature")
+    @classmethod
+    def _temperature_in_range(cls, v):
+        if v is not None and not (0.0 <= v <= 2.0):
+            raise ValueError("temperature must be between 0 and 2")
+        return v
+
+    @field_validator("top_p")
+    @classmethod
+    def _top_p_in_range(cls, v):
+        if v is not None and not (0.0 <= v <= 1.0):
+            raise ValueError("top_p must be between 0 and 1")
+        return v
 
 
 class ThinkingContent(BaseModel):

--- a/runtimes/edge/tests/integration/conftest.py
+++ b/runtimes/edge/tests/integration/conftest.py
@@ -1,0 +1,29 @@
+"""Auto-skip integration tests unless EDGE_URL is explicitly set.
+
+CI collects tests under this directory alongside the unit tests, but the
+integration suite needs a reachable edge runtime — so opt-in on the
+EDGE_URL environment variable. Developers who want to run it locally
+set EDGE_URL=http://<host>:11540 and pytest picks it up normally.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+collect_ignore_glob = []
+
+if not os.environ.get("EDGE_URL"):
+    collect_ignore_glob = ["test_*.py"]
+
+
+def pytest_collection_modifyitems(config, items):
+    if os.environ.get("EDGE_URL"):
+        return
+    skip = pytest.mark.skip(
+        reason="Integration tests require EDGE_URL pointing to a live edge runtime",
+    )
+    for item in items:
+        if "tests/integration/" in str(item.path).replace("\\", "/"):
+            item.add_marker(skip)

--- a/runtimes/edge/tests/integration/monitor_memory.sh
+++ b/runtimes/edge/tests/integration/monitor_memory.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# ROW-79: Monitor edge-runtime container memory and CPU during load test.
+#
+# Polls docker stats every 30s, writes CSV to stdout or a file.
+#
+# Usage:
+#   ./monitor_memory.sh                          # stdout
+#   ./monitor_memory.sh -o memory_log.csv        # file
+#   ./monitor_memory.sh -c edge-runtime -i 15    # custom container & interval
+#   ./monitor_memory.sh -d 1800                  # run for 30 min then stop
+
+set -euo pipefail
+
+CONTAINER="${CONTAINER:-edge-runtime}"
+INTERVAL=30
+DURATION=0  # 0 = run until killed
+OUTPUT=""
+
+usage() {
+    echo "Usage: $0 [-c container] [-i interval_sec] [-d duration_sec] [-o output.csv]"
+    exit 1
+}
+
+while getopts "c:i:d:o:h" opt; do
+    case $opt in
+        c) CONTAINER="$OPTARG" ;;
+        i) INTERVAL="$OPTARG" ;;
+        d) DURATION="$OPTARG" ;;
+        o) OUTPUT="$OPTARG" ;;
+        h) usage ;;
+        *) usage ;;
+    esac
+done
+
+header="timestamp,memory_rss_mb,cpu_percent,memory_percent,pids"
+
+if [[ -n "$OUTPUT" ]]; then
+    echo "$header" > "$OUTPUT"
+    exec >> "$OUTPUT"
+else
+    echo "$header"
+fi
+
+start=$(date +%s)
+count=0
+
+while true; do
+    # Check duration limit
+    if [[ "$DURATION" -gt 0 ]]; then
+        elapsed=$(( $(date +%s) - start ))
+        if [[ "$elapsed" -ge "$DURATION" ]]; then
+            echo "# Duration limit reached (${DURATION}s)" >&2
+            break
+        fi
+    fi
+
+    # Poll docker stats (single snapshot, no stream)
+    stats=$(docker stats "$CONTAINER" --no-stream --format \
+        '{{.MemUsage}}|{{.CPUPerc}}|{{.MemPerc}}|{{.PIDs}}' 2>/dev/null) || {
+        echo "# WARNING: docker stats failed for $CONTAINER" >&2
+        sleep "$INTERVAL"
+        continue
+    }
+
+    # Parse fields: "123.4MiB / 1.94GiB|0.50%|6.35%|12"
+    mem_usage=$(echo "$stats" | cut -d'|' -f1 | cut -d'/' -f1 | xargs)
+    cpu_pct=$(echo "$stats" | cut -d'|' -f2 | tr -d '%')
+    mem_pct=$(echo "$stats" | cut -d'|' -f3 | tr -d '%')
+    pids=$(echo "$stats" | cut -d'|' -f4)
+
+    # Normalize memory to MB
+    mem_value=$(echo "$mem_usage" | grep -oE '[0-9]+\.?[0-9]*')
+    mem_unit=$(echo "$mem_usage" | grep -oiE '[KMGT]i?B')
+
+    case "$mem_unit" in
+        KiB|kB)  mem_mb=$(echo "$mem_value / 1024" | bc -l) ;;
+        MiB|MB)  mem_mb="$mem_value" ;;
+        GiB|GB)  mem_mb=$(echo "$mem_value * 1024" | bc -l) ;;
+        *)       mem_mb="$mem_value" ;;
+    esac
+
+    mem_mb=$(printf "%.1f" "$mem_mb")
+    ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+    echo "${ts},${mem_mb},${cpu_pct},${mem_pct},${pids}"
+
+    count=$((count + 1))
+    if [[ $((count % 10)) -eq 0 ]]; then
+        echo "# Samples collected: $count" >&2
+    fi
+
+    sleep "$INTERVAL"
+done

--- a/runtimes/edge/tests/integration/test_errors.py
+++ b/runtimes/edge/tests/integration/test_errors.py
@@ -17,7 +17,7 @@ import httpx
 import pytest
 
 EDGE_URL = os.environ.get("EDGE_URL", "http://localhost:11540")
-MODEL = os.environ.get("EDGE_MODEL", "functiongemma")
+MODEL = os.environ.get("EDGE_MODEL", "mission-router-v3")
 
 # Requests must not return 500 or cause the server to become unresponsive.
 # Acceptable: 400, 404, 422 (validation error)

--- a/runtimes/edge/tests/integration/test_errors.py
+++ b/runtimes/edge/tests/integration/test_errors.py
@@ -31,12 +31,23 @@ def client():
 
 
 def _assert_clean_error(resp: httpx.Response, context: str) -> None:
-    """Assert the response is a clean error, not a server crash."""
+    """Assert the response is a clean 4xx validation error.
+
+    Callers only invoke this for malformed requests that must never
+    legitimately return 200 — accepting them silently would mask
+    regressions where the server starts happily processing invalid
+    payloads. Use bare ``status_code != 500`` assertions for cases
+    where 200 *is* a valid outcome (e.g. request-body clamping).
+
+    503 is intentionally allowed through: the runtime returns 503 when
+    an upstream model registry is unreachable, which is a legitimate
+    operational state, not a crash.
+    """
     assert resp.status_code != 500, f"{context}: got 500 Internal Server Error: {resp.text[:300]}"
     assert resp.status_code != 502, f"{context}: got 502 Bad Gateway (server may have crashed)"
-    assert resp.status_code != 503, f"{context}: got 503 Service Unavailable (server may be down)"
-    assert resp.status_code in ACCEPTABLE_ERROR_CODES or resp.status_code == 200, (
-        f"{context}: unexpected status {resp.status_code}: {resp.text[:300]}"
+    assert resp.status_code in ACCEPTABLE_ERROR_CODES, (
+        f"{context}: expected one of {sorted(ACCEPTABLE_ERROR_CODES)}, "
+        f"got {resp.status_code}: {resp.text[:300]}"
     )
 
 

--- a/runtimes/edge/tests/integration/test_errors.py
+++ b/runtimes/edge/tests/integration/test_errors.py
@@ -1,0 +1,291 @@
+"""ROW-79: Error recovery tests for edge runtime.
+
+Sends malformed and invalid requests to verify the edge runtime returns
+proper HTTP error responses (4xx) instead of crashing (500) or hanging.
+
+Usage:
+    EDGE_URL=http://192.168.1.100:11540 python -m pytest test_errors.py -v
+    EDGE_URL=http://192.168.1.100:11540 python test_errors.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import httpx
+import pytest
+
+EDGE_URL = os.environ.get("EDGE_URL", "http://localhost:11540")
+MODEL = os.environ.get("EDGE_MODEL", "functiongemma")
+
+# Requests must not return 500 or cause the server to become unresponsive.
+# Acceptable: 400, 404, 422 (validation error)
+ACCEPTABLE_ERROR_CODES = {400, 404, 422}
+
+
+@pytest.fixture(scope="module")
+def client():
+    with httpx.Client(base_url=EDGE_URL, timeout=15) as c:
+        yield c
+
+
+def _assert_clean_error(resp: httpx.Response, context: str) -> None:
+    """Assert the response is a clean error, not a server crash."""
+    assert resp.status_code != 500, f"{context}: got 500 Internal Server Error: {resp.text[:300]}"
+    assert resp.status_code != 502, f"{context}: got 502 Bad Gateway (server may have crashed)"
+    assert resp.status_code != 503, f"{context}: got 503 Service Unavailable (server may be down)"
+    assert resp.status_code in ACCEPTABLE_ERROR_CODES or resp.status_code == 200, (
+        f"{context}: unexpected status {resp.status_code}: {resp.text[:300]}"
+    )
+
+
+def _verify_still_alive(client: httpx.Client) -> None:
+    """Verify the server is still responding after a bad request."""
+    resp = client.get("/health")
+    assert resp.status_code == 200, f"Server unresponsive after bad request: /health returned {resp.status_code}"
+
+
+# ---- Bad JSON ----
+
+class TestBadJSON:
+    def test_completely_invalid_json(self, client):
+        resp = client.post(
+            "/v1/chat/completions",
+            content="this is not json at all",
+            headers={"Content-Type": "application/json"},
+        )
+        _assert_clean_error(resp, "invalid JSON body")
+        _verify_still_alive(client)
+
+    def test_empty_body(self, client):
+        resp = client.post(
+            "/v1/chat/completions",
+            content="",
+            headers={"Content-Type": "application/json"},
+        )
+        _assert_clean_error(resp, "empty body")
+        _verify_still_alive(client)
+
+    def test_json_array_instead_of_object(self, client):
+        resp = client.post(
+            "/v1/chat/completions",
+            json=[{"model": MODEL}],
+        )
+        _assert_clean_error(resp, "JSON array instead of object")
+        _verify_still_alive(client)
+
+    def test_truncated_json(self, client):
+        resp = client.post(
+            "/v1/chat/completions",
+            content='{"model": "functiongemma", "messages": [{"role": "user", "conte',
+            headers={"Content-Type": "application/json"},
+        )
+        _assert_clean_error(resp, "truncated JSON")
+        _verify_still_alive(client)
+
+
+# ---- Missing Required Fields ----
+
+class TestMissingFields:
+    def test_missing_model(self, client):
+        resp = client.post("/v1/chat/completions", json={
+            "messages": [{"role": "user", "content": "hello"}],
+        })
+        _assert_clean_error(resp, "missing model field")
+        _verify_still_alive(client)
+
+    def test_missing_messages(self, client):
+        resp = client.post("/v1/chat/completions", json={
+            "model": MODEL,
+        })
+        _assert_clean_error(resp, "missing messages field")
+        _verify_still_alive(client)
+
+    def test_empty_messages_list(self, client):
+        resp = client.post("/v1/chat/completions", json={
+            "model": MODEL,
+            "messages": [],
+        })
+        _assert_clean_error(resp, "empty messages list")
+        _verify_still_alive(client)
+
+    def test_message_missing_role(self, client):
+        resp = client.post("/v1/chat/completions", json={
+            "model": MODEL,
+            "messages": [{"content": "hello"}],
+        })
+        _assert_clean_error(resp, "message missing role")
+        _verify_still_alive(client)
+
+    def test_message_missing_content(self, client):
+        resp = client.post("/v1/chat/completions", json={
+            "model": MODEL,
+            "messages": [{"role": "user"}],
+        })
+        # Missing content may be valid for some roles (tool), so allow 200
+        assert resp.status_code != 500, "missing content caused 500"
+        _verify_still_alive(client)
+
+
+# ---- Invalid Values ----
+
+class TestInvalidValues:
+    def test_nonexistent_model(self, client):
+        resp = client.post("/v1/chat/completions", json={
+            "model": "nonexistent-model-that-does-not-exist-12345",
+            "messages": [{"role": "user", "content": "hello"}],
+        })
+        _assert_clean_error(resp, "nonexistent model")
+        assert resp.status_code in {400, 404, 422}, f"Expected 4xx for missing model, got {resp.status_code}"
+        _verify_still_alive(client)
+
+    def test_invalid_role(self, client):
+        resp = client.post("/v1/chat/completions", json={
+            "model": MODEL,
+            "messages": [{"role": "banana", "content": "hello"}],
+        })
+        _assert_clean_error(resp, "invalid role")
+        _verify_still_alive(client)
+
+    def test_negative_max_tokens(self, client):
+        resp = client.post("/v1/chat/completions", json={
+            "model": MODEL,
+            "messages": [{"role": "user", "content": "hello"}],
+            "max_tokens": -1,
+        })
+        _assert_clean_error(resp, "negative max_tokens")
+        _verify_still_alive(client)
+
+    def test_temperature_out_of_range(self, client):
+        resp = client.post("/v1/chat/completions", json={
+            "model": MODEL,
+            "messages": [{"role": "user", "content": "hello"}],
+            "temperature": 999.0,
+        })
+        # May be clamped or rejected; just shouldn't crash
+        assert resp.status_code != 500, "temperature=999 caused 500"
+        _verify_still_alive(client)
+
+    def test_wrong_type_for_messages(self, client):
+        resp = client.post("/v1/chat/completions", json={
+            "model": MODEL,
+            "messages": "this should be a list",
+        })
+        _assert_clean_error(resp, "messages as string instead of list")
+        _verify_still_alive(client)
+
+    def test_model_as_number(self, client):
+        resp = client.post("/v1/chat/completions", json={
+            "model": 42,
+            "messages": [{"role": "user", "content": "hello"}],
+        })
+        _assert_clean_error(resp, "model as number")
+        _verify_still_alive(client)
+
+
+# ---- Oversized / Edge Payloads ----
+
+class TestEdgePayloads:
+    def test_very_long_prompt(self, client):
+        """Send a prompt that exceeds typical context. Should truncate or reject, not crash."""
+        long_content = "hello " * 50_000  # ~300KB
+        resp = client.post("/v1/chat/completions", json={
+            "model": MODEL,
+            "messages": [{"role": "user", "content": long_content}],
+            "max_tokens": 10,
+        })
+        # May succeed (auto_truncate) or 400/422; just not 500
+        assert resp.status_code != 500, f"Very long prompt caused 500: {resp.text[:200]}"
+        _verify_still_alive(client)
+
+    def test_many_messages(self, client):
+        """Send many messages. Should handle gracefully."""
+        messages = [{"role": "user" if i % 2 == 0 else "assistant", "content": f"Message {i}"}
+                    for i in range(500)]
+        resp = client.post("/v1/chat/completions", json={
+            "model": MODEL,
+            "messages": messages,
+            "max_tokens": 10,
+        })
+        assert resp.status_code != 500, f"500 messages caused 500: {resp.text[:200]}"
+        _verify_still_alive(client)
+
+
+# ---- Wrong Endpoints ----
+
+class TestWrongEndpoints:
+    def test_nonexistent_endpoint(self, client):
+        resp = client.get("/v1/nonexistent")
+        assert resp.status_code in {404, 405}
+        _verify_still_alive(client)
+
+    def test_get_on_post_endpoint(self, client):
+        resp = client.get("/v1/chat/completions")
+        assert resp.status_code in {405, 404, 422}
+        _verify_still_alive(client)
+
+
+# ---- Rapid Fire After Errors ----
+
+class TestRecovery:
+    def test_valid_request_after_errors(self, client):
+        """After sending several bad requests, a valid request should still work."""
+        # Fire off a few bad requests
+        for _ in range(5):
+            client.post("/v1/chat/completions", content="bad", headers={"Content-Type": "application/json"})
+
+        # Now send a valid one
+        resp = client.post("/v1/chat/completions", json={
+            "model": MODEL,
+            "messages": [{"role": "user", "content": "[STATE] altitude=100m [CMD] status check"}],
+            "max_tokens": 64,
+        })
+        assert resp.status_code == 200, f"Valid request failed after error barrage: {resp.status_code}: {resp.text[:200]}"
+
+
+# -- standalone entry point --
+
+def _run_standalone() -> int:
+    """Run all tests without pytest, print results."""
+    client = httpx.Client(base_url=EDGE_URL, timeout=15)
+    passed = 0
+    failed = 0
+    errors = []
+
+    # Collect test methods from all test classes
+    test_classes = [TestBadJSON, TestMissingFields, TestInvalidValues, TestEdgePayloads, TestWrongEndpoints, TestRecovery]
+
+    for cls in test_classes:
+        instance = cls()
+        methods = [m for m in dir(instance) if m.startswith("test_")]
+        for method_name in sorted(methods):
+            method = getattr(instance, method_name)
+            name = f"{cls.__name__}.{method_name}"
+            try:
+                method(client)
+                passed += 1
+                print(f"  PASS  {name}")
+            except AssertionError as e:
+                failed += 1
+                errors.append((name, str(e)))
+                print(f"  FAIL  {name}: {e}")
+            except Exception as e:
+                failed += 1
+                errors.append((name, str(e)))
+                print(f"  ERROR {name}: {e}")
+
+    client.close()
+    print(f"\n{passed} passed, {failed} failed")
+    if errors:
+        print("\nFailures:")
+        for name, msg in errors:
+            print(f"  {name}: {msg}")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    print(f"Edge runtime error tests (ROW-79)")
+    print(f"Target: {EDGE_URL}")
+    print(f"Model: {MODEL}\n")
+    sys.exit(_run_standalone())

--- a/runtimes/edge/tests/integration/test_errors.py
+++ b/runtimes/edge/tests/integration/test_errors.py
@@ -285,7 +285,7 @@ def _run_standalone() -> int:
 
 
 if __name__ == "__main__":
-    print(f"Edge runtime error tests (ROW-79)")
+    print("Edge runtime error tests (ROW-79)")
     print(f"Target: {EDGE_URL}")
     print(f"Model: {MODEL}\n")
     sys.exit(_run_standalone())

--- a/runtimes/edge/tests/integration/test_stability.py
+++ b/runtimes/edge/tests/integration/test_stability.py
@@ -23,7 +23,7 @@ from pathlib import Path
 import httpx
 
 EDGE_URL = os.environ.get("EDGE_URL", "http://localhost:11540")
-MODEL = os.environ.get("EDGE_MODEL", "functiongemma")
+MODEL = os.environ.get("EDGE_MODEL", "mission-router-v3")
 LOG_DIR = Path(os.environ.get("LOG_DIR", "."))
 
 # Phase durations in seconds (total ~30 min)

--- a/runtimes/edge/tests/integration/test_stability.py
+++ b/runtimes/edge/tests/integration/test_stability.py
@@ -1,0 +1,385 @@
+"""ROW-79: Sustained load test for edge runtime.
+
+Runs 5 phases over ~30 minutes against the edge runtime, simulating
+realistic FunctionGemma drone mission inference patterns.
+
+Usage:
+    EDGE_URL=http://192.168.1.100:11540 python -m pytest test_stability.py -s
+    EDGE_URL=http://192.168.1.100:11540 python test_stability.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import csv
+import json
+import os
+import random
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import httpx
+
+EDGE_URL = os.environ.get("EDGE_URL", "http://localhost:11540")
+MODEL = os.environ.get("EDGE_MODEL", "functiongemma")
+LOG_DIR = Path(os.environ.get("LOG_DIR", "."))
+
+# Phase durations in seconds (total ~30 min)
+PHASE_DURATIONS = {
+    "startup": 5 * 60,
+    "search_pattern": 10 * 60,
+    "detection_burst": 5 * 60,
+    "idle_resume": 5 * 60,
+    "mission_end": 5 * 60,
+}
+
+# FunctionGemma-style prompts: [STATE] + [CMD] -> drone_tool() calls
+SEARCH_PROMPTS = [
+    "[STATE] altitude=120m heading=045 speed=12m/s battery=78% mode=AUTO [CMD] scan area grid pattern",
+    "[STATE] altitude=120m heading=090 speed=12m/s battery=76% mode=AUTO [CMD] check waypoint ALPHA",
+    "[STATE] altitude=100m heading=180 speed=10m/s battery=72% mode=AUTO [CMD] survey zone B sector 3",
+    "[STATE] altitude=110m heading=270 speed=11m/s battery=70% mode=GUIDED [CMD] orbit point of interest",
+    "[STATE] altitude=120m heading=000 speed=12m/s battery=68% mode=AUTO [CMD] continue search pattern",
+    "[STATE] altitude=115m heading=135 speed=10m/s battery=65% mode=AUTO [CMD] adjust altitude for terrain",
+]
+
+DETECTION_PROMPTS = [
+    "[STATE] altitude=80m heading=045 speed=5m/s battery=60% mode=GUIDED [CMD] target found at 34.052N 118.244W confirm identity",
+    "[STATE] altitude=60m heading=045 speed=3m/s battery=58% mode=GUIDED [CMD] begin tracking target ID-7",
+    "[STATE] altitude=60m heading=050 speed=4m/s battery=56% mode=GUIDED [CMD] classify target thermal signature",
+    "[STATE] altitude=50m heading=045 speed=2m/s battery=55% mode=LOITER [CMD] hold position over target",
+    "[STATE] altitude=50m heading=045 speed=0m/s battery=54% mode=LOITER [CMD] capture high-res image target zone",
+]
+
+MISSION_END_PROMPTS = [
+    "[STATE] altitude=50m heading=180 speed=0m/s battery=40% mode=LOITER [CMD] RTL",
+    "[STATE] altitude=100m heading=180 speed=15m/s battery=38% mode=RTL [CMD] status report",
+    "[STATE] altitude=120m heading=180 speed=15m/s battery=35% mode=RTL [CMD] confirm landing zone clear",
+]
+
+
+@dataclass
+class RequestLog:
+    phase: str
+    timestamp: float
+    latency_ms: float
+    status: int
+    error: str | None = None
+
+
+@dataclass
+class TestResults:
+    start_time: float = field(default_factory=time.time)
+    logs: list[RequestLog] = field(default_factory=list)
+    errors: int = 0
+    timeouts: int = 0
+
+    def add(self, log: RequestLog) -> None:
+        self.logs.append(log)
+        if log.error:
+            self.errors += 1
+        if log.status == 0:
+            self.timeouts += 1
+
+    def write_csv(self, path: Path) -> None:
+        with open(path, "w", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow(["phase", "timestamp", "latency_ms", "status", "error"])
+            for log in self.logs:
+                writer.writerow([log.phase, log.timestamp, f"{log.latency_ms:.1f}", log.status, log.error or ""])
+
+    def summary(self) -> str:
+        if not self.logs:
+            return "No requests recorded."
+        latencies = [l.latency_ms for l in self.logs if l.status == 200]
+        elapsed = time.time() - self.start_time
+        lines = [
+            f"Duration: {elapsed:.0f}s",
+            f"Total requests: {len(self.logs)}",
+            f"Successful: {len(latencies)}",
+            f"Errors: {self.errors}",
+            f"Timeouts: {self.timeouts}",
+        ]
+        if latencies:
+            latencies.sort()
+            lines += [
+                f"Latency avg: {sum(latencies)/len(latencies):.0f}ms",
+                f"Latency p50: {latencies[len(latencies)//2]:.0f}ms",
+                f"Latency p95: {latencies[int(len(latencies)*0.95)]:.0f}ms",
+                f"Latency max: {max(latencies):.0f}ms",
+            ]
+        return "\n".join(lines)
+
+
+def _chat_body(prompt: str) -> dict:
+    return {
+        "model": MODEL,
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": 256,
+        "temperature": 0.1,
+    }
+
+
+async def send_request(
+    client: httpx.AsyncClient,
+    prompt: str,
+    phase: str,
+    results: TestResults,
+    timeout: float = 30.0,
+) -> None:
+    t0 = time.time()
+    try:
+        resp = await client.post(
+            f"{EDGE_URL}/v1/chat/completions",
+            json=_chat_body(prompt),
+            timeout=timeout,
+        )
+        latency = (time.time() - t0) * 1000
+        error = None if resp.status_code == 200 else resp.text[:200]
+        results.add(RequestLog(phase=phase, timestamp=t0, latency_ms=latency, status=resp.status_code, error=error))
+    except httpx.TimeoutException:
+        results.add(RequestLog(phase=phase, timestamp=t0, latency_ms=(time.time() - t0) * 1000, status=0, error="timeout"))
+    except Exception as e:
+        results.add(RequestLog(phase=phase, timestamp=t0, latency_ms=(time.time() - t0) * 1000, status=0, error=str(e)[:200]))
+
+
+async def phase_startup(client: httpx.AsyncClient, results: TestResults) -> bool:
+    """Phase 1: Verify model is loaded, send warmup requests."""
+    phase = "startup"
+    print(f"\n{'='*60}")
+    print(f"PHASE 1: Startup (0-5 min)")
+    print(f"{'='*60}")
+
+    # Health check
+    try:
+        resp = await client.get(f"{EDGE_URL}/health", timeout=10)
+        print(f"  /health: {resp.status_code}")
+        if resp.status_code != 200:
+            print(f"  ERROR: health check failed: {resp.text[:200]}")
+            return False
+    except Exception as e:
+        print(f"  ERROR: health check failed: {e}")
+        return False
+
+    # Check models
+    try:
+        resp = await client.get(f"{EDGE_URL}/v1/models", timeout=10)
+        print(f"  /v1/models: {resp.status_code}")
+        if resp.status_code == 200:
+            models = resp.json()
+            model_ids = [m.get("id", "?") for m in models.get("data", [])]
+            print(f"  Loaded models: {model_ids}")
+    except Exception as e:
+        print(f"  WARNING: /v1/models check failed: {e}")
+
+    # Warmup requests
+    print("  Sending warmup requests...")
+    for i in range(3):
+        await send_request(client, SEARCH_PROMPTS[0], phase, results)
+        last = results.logs[-1]
+        print(f"  Warmup {i+1}: {last.latency_ms:.0f}ms (status {last.status})")
+        await asyncio.sleep(2)
+
+    # Remaining startup time: idle with periodic health checks
+    elapsed = sum(1 for l in results.logs if l.phase == phase) * 3  # rough estimate
+    remaining = max(0, PHASE_DURATIONS["startup"] - elapsed)
+    check_interval = 30
+    checks = int(remaining / check_interval)
+    for _ in range(checks):
+        await asyncio.sleep(check_interval)
+        await send_request(client, random.choice(SEARCH_PROMPTS), phase, results)
+
+    return True
+
+
+async def phase_search_pattern(client: httpx.AsyncClient, results: TestResults) -> None:
+    """Phase 2: Steady search-pattern requests every 10-15s."""
+    phase = "search_pattern"
+    print(f"\n{'='*60}")
+    print(f"PHASE 2: Search Pattern (5-15 min)")
+    print(f"{'='*60}")
+
+    end_time = time.time() + PHASE_DURATIONS["search_pattern"]
+    count = 0
+    while time.time() < end_time:
+        prompt = random.choice(SEARCH_PROMPTS)
+        await send_request(client, prompt, phase, results)
+        count += 1
+        last = results.logs[-1]
+        if count % 10 == 0:
+            print(f"  Requests sent: {count}, last latency: {last.latency_ms:.0f}ms")
+        await asyncio.sleep(random.uniform(10, 15))
+
+    print(f"  Phase 2 complete: {count} requests")
+
+
+async def phase_detection_burst(client: httpx.AsyncClient, results: TestResults) -> None:
+    """Phase 3: Rapid requests every 2-3s with concurrent bursts."""
+    phase = "detection_burst"
+    print(f"\n{'='*60}")
+    print(f"PHASE 3: Detection Burst (15-20 min)")
+    print(f"{'='*60}")
+
+    end_time = time.time() + PHASE_DURATIONS["detection_burst"]
+    count = 0
+    while time.time() < end_time:
+        # Every ~15s, send a burst of 2-3 concurrent requests
+        if count % 5 == 0 and count > 0:
+            coros = [
+                send_request(client, random.choice(DETECTION_PROMPTS), phase, results)
+                for _ in range(random.randint(2, 3))
+            ]
+            await asyncio.gather(*coros)
+            count += len(coros)
+        else:
+            await send_request(client, random.choice(DETECTION_PROMPTS), phase, results)
+            count += 1
+
+        if count % 10 == 0:
+            phase_logs = [l for l in results.logs if l.phase == phase]
+            recent = phase_logs[-5:] if len(phase_logs) >= 5 else phase_logs
+            avg = sum(l.latency_ms for l in recent) / len(recent)
+            print(f"  Requests sent: {count}, recent avg latency: {avg:.0f}ms")
+
+        await asyncio.sleep(random.uniform(2, 3))
+
+    print(f"  Phase 3 complete: {count} requests")
+
+
+async def phase_idle_resume(client: httpx.AsyncClient, results: TestResults) -> None:
+    """Phase 4: 5 min idle, then burst to verify no cold-start lag."""
+    phase = "idle_resume"
+    print(f"\n{'='*60}")
+    print(f"PHASE 4: Idle + Resume (20-25 min)")
+    print(f"{'='*60}")
+
+    # Record pre-idle latency baseline
+    if results.logs:
+        recent = [l.latency_ms for l in results.logs[-10:] if l.status == 200]
+        baseline = sum(recent) / len(recent) if recent else 0
+        print(f"  Pre-idle baseline latency: {baseline:.0f}ms")
+
+    # Idle for 5 minutes (just health checks every 60s)
+    print("  Entering idle period (5 min)...")
+    idle_duration = PHASE_DURATIONS["idle_resume"]
+    idle_end = time.time() + idle_duration
+    while time.time() < idle_end:
+        await asyncio.sleep(60)
+        try:
+            resp = await client.get(f"{EDGE_URL}/health", timeout=10)
+            print(f"  Idle health check: {resp.status_code}")
+        except Exception as e:
+            print(f"  Idle health check failed: {e}")
+
+    # Resume with burst
+    print("  Resuming with burst requests...")
+    for i in range(5):
+        await send_request(client, random.choice(SEARCH_PROMPTS), phase, results)
+        last = results.logs[-1]
+        print(f"  Resume {i+1}: {last.latency_ms:.0f}ms (status {last.status})")
+        await asyncio.sleep(1)
+
+    # Check for cold-start lag
+    resume_logs = [l for l in results.logs if l.phase == phase and l.status == 200]
+    if resume_logs and baseline > 0:
+        resume_avg = sum(l.latency_ms for l in resume_logs) / len(resume_logs)
+        ratio = resume_avg / baseline
+        print(f"  Resume avg latency: {resume_avg:.0f}ms (ratio to baseline: {ratio:.2f}x)")
+        if ratio > 3.0:
+            print(f"  WARNING: possible cold-start detected (>{ratio:.1f}x baseline)")
+
+
+async def phase_mission_end(client: httpx.AsyncClient, results: TestResults) -> None:
+    """Phase 5: RTL commands, final checks."""
+    phase = "mission_end"
+    print(f"\n{'='*60}")
+    print(f"PHASE 5: Mission End (25-30 min)")
+    print(f"{'='*60}")
+
+    # Send mission-end prompts
+    for prompt in MISSION_END_PROMPTS:
+        await send_request(client, prompt, phase, results)
+        last = results.logs[-1]
+        print(f"  RTL request: {last.latency_ms:.0f}ms (status {last.status})")
+        await asyncio.sleep(5)
+
+    # Fill remaining time with periodic status checks
+    end_time = time.time() + PHASE_DURATIONS["mission_end"] - len(MISSION_END_PROMPTS) * 6
+    while time.time() < end_time:
+        await send_request(client, MISSION_END_PROMPTS[-1], phase, results)
+        await asyncio.sleep(30)
+
+    # Final model check
+    try:
+        resp = await client.get(f"{EDGE_URL}/v1/models", timeout=10)
+        if resp.status_code == 200:
+            models = resp.json()
+            model_ids = [m.get("id", "?") for m in models.get("data", [])]
+            print(f"  Final model check: {model_ids}")
+        else:
+            print(f"  WARNING: final /v1/models returned {resp.status_code}")
+    except Exception as e:
+        print(f"  WARNING: final model check failed: {e}")
+
+    # Final health check
+    try:
+        resp = await client.get(f"{EDGE_URL}/health", timeout=10)
+        print(f"  Final /health: {resp.status_code}")
+    except Exception as e:
+        print(f"  Final health check failed: {e}")
+
+
+async def run_load_test() -> TestResults:
+    results = TestResults()
+    csv_path = LOG_DIR / f"stability_{int(time.time())}.csv"
+
+    print(f"Edge runtime load test (ROW-79)")
+    print(f"Target: {EDGE_URL}")
+    print(f"Model: {MODEL}")
+    print(f"Log: {csv_path}")
+
+    async with httpx.AsyncClient() as client:
+        ok = await phase_startup(client, results)
+        if not ok:
+            print("\nABORTED: startup checks failed.")
+            results.write_csv(csv_path)
+            return results
+
+        await phase_search_pattern(client, results)
+        await phase_detection_burst(client, results)
+        await phase_idle_resume(client, results)
+        await phase_mission_end(client, results)
+
+    results.write_csv(csv_path)
+    print(f"\n{'='*60}")
+    print("RESULTS")
+    print(f"{'='*60}")
+    print(results.summary())
+    print(f"\nLatency CSV: {csv_path}")
+    return results
+
+
+# -- pytest entry point --
+
+import pytest
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_stability():
+    """Run full 30-minute stability test."""
+    results = await run_load_test()
+    assert results.errors == 0, f"{results.errors} requests returned errors"
+    assert results.timeouts == 0, f"{results.timeouts} requests timed out"
+    ok_latencies = [l.latency_ms for l in results.logs if l.status == 200]
+    assert ok_latencies, "No successful requests"
+    assert max(ok_latencies) < 5000, f"Max latency {max(ok_latencies):.0f}ms exceeds 5s threshold"
+
+
+# -- standalone entry point --
+
+if __name__ == "__main__":
+    results = asyncio.run(run_load_test())
+    sys.exit(1 if results.errors or results.timeouts else 0)

--- a/runtimes/edge/tests/integration/test_stability.py
+++ b/runtimes/edge/tests/integration/test_stability.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import asyncio
 import csv
-import json
 import os
 import random
 import sys
@@ -21,6 +20,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 import httpx
+import pytest
 
 EDGE_URL = os.environ.get("EDGE_URL", "http://localhost:11540")
 MODEL = os.environ.get("EDGE_MODEL", "mission-router-v3")
@@ -93,7 +93,7 @@ class TestResults:
     def summary(self) -> str:
         if not self.logs:
             return "No requests recorded."
-        latencies = [l.latency_ms for l in self.logs if l.status == 200]
+        latencies = [log.latency_ms for log in self.logs if log.status == 200]
         elapsed = time.time() - self.start_time
         lines = [
             f"Duration: {elapsed:.0f}s",
@@ -149,7 +149,7 @@ async def phase_startup(client: httpx.AsyncClient, results: TestResults) -> bool
     """Phase 1: Verify model is loaded, send warmup requests."""
     phase = "startup"
     print(f"\n{'='*60}")
-    print(f"PHASE 1: Startup (0-5 min)")
+    print("PHASE 1: Startup (0-5 min)")
     print(f"{'='*60}")
 
     # Health check
@@ -183,7 +183,7 @@ async def phase_startup(client: httpx.AsyncClient, results: TestResults) -> bool
         await asyncio.sleep(2)
 
     # Remaining startup time: idle with periodic health checks
-    elapsed = sum(1 for l in results.logs if l.phase == phase) * 3  # rough estimate
+    elapsed = sum(1 for log in results.logs if log.phase == phase) * 3  # rough estimate
     remaining = max(0, PHASE_DURATIONS["startup"] - elapsed)
     check_interval = 30
     checks = int(remaining / check_interval)
@@ -198,7 +198,7 @@ async def phase_search_pattern(client: httpx.AsyncClient, results: TestResults) 
     """Phase 2: Steady search-pattern requests every 10-15s."""
     phase = "search_pattern"
     print(f"\n{'='*60}")
-    print(f"PHASE 2: Search Pattern (5-15 min)")
+    print("PHASE 2: Search Pattern (5-15 min)")
     print(f"{'='*60}")
 
     end_time = time.time() + PHASE_DURATIONS["search_pattern"]
@@ -219,7 +219,7 @@ async def phase_detection_burst(client: httpx.AsyncClient, results: TestResults)
     """Phase 3: Rapid requests every 2-3s with concurrent bursts."""
     phase = "detection_burst"
     print(f"\n{'='*60}")
-    print(f"PHASE 3: Detection Burst (15-20 min)")
+    print("PHASE 3: Detection Burst (15-20 min)")
     print(f"{'='*60}")
 
     end_time = time.time() + PHASE_DURATIONS["detection_burst"]
@@ -238,9 +238,9 @@ async def phase_detection_burst(client: httpx.AsyncClient, results: TestResults)
             count += 1
 
         if count % 10 == 0:
-            phase_logs = [l for l in results.logs if l.phase == phase]
+            phase_logs = [log for log in results.logs if log.phase == phase]
             recent = phase_logs[-5:] if len(phase_logs) >= 5 else phase_logs
-            avg = sum(l.latency_ms for l in recent) / len(recent)
+            avg = sum(log.latency_ms for log in recent) / len(recent)
             print(f"  Requests sent: {count}, recent avg latency: {avg:.0f}ms")
 
         await asyncio.sleep(random.uniform(2, 3))
@@ -252,12 +252,12 @@ async def phase_idle_resume(client: httpx.AsyncClient, results: TestResults) -> 
     """Phase 4: 5 min idle, then burst to verify no cold-start lag."""
     phase = "idle_resume"
     print(f"\n{'='*60}")
-    print(f"PHASE 4: Idle + Resume (20-25 min)")
+    print("PHASE 4: Idle + Resume (20-25 min)")
     print(f"{'='*60}")
 
     # Record pre-idle latency baseline
     if results.logs:
-        recent = [l.latency_ms for l in results.logs[-10:] if l.status == 200]
+        recent = [log.latency_ms for log in results.logs[-10:] if log.status == 200]
         baseline = sum(recent) / len(recent) if recent else 0
         print(f"  Pre-idle baseline latency: {baseline:.0f}ms")
 
@@ -282,9 +282,9 @@ async def phase_idle_resume(client: httpx.AsyncClient, results: TestResults) -> 
         await asyncio.sleep(1)
 
     # Check for cold-start lag
-    resume_logs = [l for l in results.logs if l.phase == phase and l.status == 200]
+    resume_logs = [log for log in results.logs if log.phase == phase and log.status == 200]
     if resume_logs and baseline > 0:
-        resume_avg = sum(l.latency_ms for l in resume_logs) / len(resume_logs)
+        resume_avg = sum(log.latency_ms for log in resume_logs) / len(resume_logs)
         ratio = resume_avg / baseline
         print(f"  Resume avg latency: {resume_avg:.0f}ms (ratio to baseline: {ratio:.2f}x)")
         if ratio > 3.0:
@@ -295,7 +295,7 @@ async def phase_mission_end(client: httpx.AsyncClient, results: TestResults) -> 
     """Phase 5: RTL commands, final checks."""
     phase = "mission_end"
     print(f"\n{'='*60}")
-    print(f"PHASE 5: Mission End (25-30 min)")
+    print("PHASE 5: Mission End (25-30 min)")
     print(f"{'='*60}")
 
     # Send mission-end prompts
@@ -335,7 +335,7 @@ async def run_load_test() -> TestResults:
     results = TestResults()
     csv_path = LOG_DIR / f"stability_{int(time.time())}.csv"
 
-    print(f"Edge runtime load test (ROW-79)")
+    print("Edge runtime load test (ROW-79)")
     print(f"Target: {EDGE_URL}")
     print(f"Model: {MODEL}")
     print(f"Log: {csv_path}")
@@ -363,8 +363,6 @@ async def run_load_test() -> TestResults:
 
 # -- pytest entry point --
 
-import pytest
-
 
 @pytest.mark.asyncio
 @pytest.mark.integration
@@ -373,7 +371,7 @@ async def test_stability():
     results = await run_load_test()
     assert results.errors == 0, f"{results.errors} requests returned errors"
     assert results.timeouts == 0, f"{results.timeouts} requests timed out"
-    ok_latencies = [l.latency_ms for l in results.logs if l.status == 200]
+    ok_latencies = [log.latency_ms for log in results.logs if log.status == 200]
     assert ok_latencies, "No successful requests"
     assert max(ok_latencies) < 5000, f"Max latency {max(ok_latencies):.0f}ms exceeds 5s threshold"
 


### PR DESCRIPTION
## Summary

- Add Pydantic validators so malformed chat completion requests (empty messages, negative `max_tokens`, out-of-range `temperature`/`top_p`) fail with 422 at the router boundary instead of tripping through model loading.
- Replace the bare `except Exception` in `ChatCompletionsService.chat_completions` with typed handling: `ValueError("Invalid model_id")` → 400, `RepositoryNotFoundError` / `LocalEntryNotFoundError` / `EntryNotFoundError` → 404, `OfflineModeIsEnabled` → 404 `model_not_cached`, `GatedRepoError` → 403, `HfHubHTTPError` → 503. Generic failures still become 500 but no longer leak HuggingFace URLs, Request-IDs, or auth advice into the public response body.
- Default the integration tests to `mission-router-v3`, gitignore `stability_*.csv` artifacts, and include the earlier `context-calculator-priority` spec / `detect_model_format` local-cache-first fix that were already on this branch.

## Behavioral impact

Integration results against `drone-60ee4`:

| | Pre-hardening | Post-hardening |
|---|---|---|
| `test_errors` (20 cases) | 13 pass, 7 fail (500s with HF stack traces) | **20 pass** |
| `test_stability` (30 min, 104 req) | 62/67 success, 5 errors + 5 timeouts, avg 15.8 s | **104/104 success, 0 errors, 0 timeouts, avg 5.7 s** |

The remaining `test_stability` assertion failure is a 5 s max-latency threshold that's unrealistic against a 270M CPU model — a separate follow-up will either relax the SLO or address the context-summarizer offline path that accounts for the worst spikes.

## Test plan

- [x] `test_errors.py` — 20/20 pass against a patched container
- [x] `test_stability.py` — zero errors / zero timeouts across a full 30-min run
- [ ] Reviewer: confirm no caller depends on the old 500-with-HF-detail error shape (none found in grep)
- [ ] Reviewer: verify `huggingface_hub.errors` import path is present in the pinned `huggingface-hub>=0.20.0` dependency