### PR TITLE
Fix #802: Add a description to improve Dispatch discoverability

### DIFF
--- a/.claude/skills/react-skills/SKILL.md
+++ b/.claude/skills/react-skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: react-skills
-description: React 18 patterns for LlamaFarm Designer. Covers components, hooks, TanStack Query, and testing.
+description: React 18 patterns for LlamaFarm Designer. Covers components, hooks, TanStack Query, and testing. Use when writing or reviewing Designer UI code involving React components, custom hooks, state management, or Vitest/RTL tests.
 allowed-tools: Read, Grep, Glob
 user-invocable: false
 ---


### PR DESCRIPTION
Closes #802

## Motivation

Dispatch (a Claude Code skill recommendation runtime) flagged that `react-skills` had a description that didn't include activation guidance, limiting how effectively automated tooling — and contributors — can determine when to invoke the skill.

## Changes

**`.claude/skills/react-skills/SKILL.md`**, `description` field (line 3):

Appended a trigger clause to the existing description: _"Use when writing or reviewing Designer UI code involving React components, custom hooks, state management, or Vitest/RTL tests."_ The name, allowed-tools, and user-invocable settings are unchanged.

## Testing

Manually verified the updated SKILL.md is valid frontmatter (no YAML parse errors). Confirmed the description surfaces correctly when listing skills via the Claude Code runtime. No behavioral changes to the skill's prompts or tooling — metadata-only edit.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*