### PR TITLE
fix(runtime): harden context summarizer and truncation in offline mode

### DIFF
--- a/runtimes/edge/routers/chat_completions/service.py
+++ b/runtimes/edge/routers/chat_completions/service.py
@@ -23,6 +23,7 @@ from models import GGUFLanguageModel
 from utils.context_manager import (
     ContextBudget,
     ContextManager,
+    ContextTruncationFailed,
     ContextUsage,
     TruncationStrategy,
 )
@@ -30,9 +31,12 @@ from utils.context_manager import (
 # Edge runtime: heavy management-plane utilities are optional.
 # These are not needed for basic chat completion on edge devices.
 try:
-    from utils.context_summarizer import ContextSummarizer
+    from utils.context_summarizer import ContextSummarizer, SummarizerUnavailable
 except ImportError:
     ContextSummarizer = None  # type: ignore[assignment,misc]
+
+    class SummarizerUnavailable(RuntimeError):  # type: ignore[no-redef]
+        """Fallback when the summarizer module is not installed on edge."""
 
 try:
     from utils.history_compressor import HistoryCompressor
@@ -568,12 +572,26 @@ class ChatCompletionsService:
                                         f"Still over budget after summarization "
                                         f"({usage.prompt_tokens} tokens), applying fallback truncation"
                                     )
-                                    messages_for_context, usage = (
-                                        context_manager.truncate_if_needed(
-                                            messages_for_context,
-                                            TruncationStrategy.KEEP_SYSTEM_SLIDING,
+                                    try:
+                                        messages_for_context, usage = (
+                                            context_manager.truncate_if_needed(
+                                                messages_for_context,
+                                                TruncationStrategy.KEEP_SYSTEM_SLIDING,
+                                            )
                                         )
-                                    )
+                                    except ContextTruncationFailed as exc:
+                                        raise HTTPException(
+                                            status_code=400,
+                                            detail={
+                                                "error": "context_truncation_failed",
+                                                "message": str(exc),
+                                                "context_usage": {
+                                                    "total_context": context_manager.budget.total_context,
+                                                    "prompt_tokens": usage.prompt_tokens,
+                                                    "available_for_completion": usage.available_for_completion,
+                                                },
+                                            },
+                                        ) from exc
                                     usage = type(usage)(
                                         total_context=usage.total_context,
                                         prompt_tokens=usage.prompt_tokens,
@@ -594,21 +612,78 @@ class ChatCompletionsService:
                                 logger.info(
                                     f"Context summarized: {usage.prompt_tokens} tokens after summarization"
                                 )
+                            except SummarizerUnavailable as e:
+                                logger.info(
+                                    f"Summarizer unavailable ({e}); "
+                                    f"using keep_system_sliding truncation"
+                                )
+                                try:
+                                    messages_for_context, usage = (
+                                        context_manager.truncate_if_needed(
+                                            messages_for_context,
+                                            TruncationStrategy.KEEP_SYSTEM_SLIDING,
+                                        )
+                                    )
+                                except ContextTruncationFailed as exc:
+                                    raise HTTPException(
+                                        status_code=400,
+                                        detail={
+                                            "error": "context_truncation_failed",
+                                            "message": str(exc),
+                                            "context_usage": {
+                                                "total_context": context_manager.budget.total_context,
+                                                "prompt_tokens": usage.prompt_tokens,
+                                                "available_for_completion": usage.available_for_completion,
+                                            },
+                                        },
+                                    ) from exc
+                            except HTTPException:
+                                raise
+                            except ContextTruncationFailed:
+                                raise
                             except Exception as e:
                                 logger.warning(
                                     f"Summarization failed: {e}, falling back to keep_system"
                                 )
-                                messages_for_context, usage = (
-                                    context_manager.truncate_if_needed(
-                                        messages_for_context,
-                                        TruncationStrategy.KEEP_SYSTEM_SLIDING,
+                                try:
+                                    messages_for_context, usage = (
+                                        context_manager.truncate_if_needed(
+                                            messages_for_context,
+                                            TruncationStrategy.KEEP_SYSTEM_SLIDING,
+                                        )
                                     )
-                                )
+                                except ContextTruncationFailed as exc:
+                                    raise HTTPException(
+                                        status_code=400,
+                                        detail={
+                                            "error": "context_truncation_failed",
+                                            "message": str(exc),
+                                            "context_usage": {
+                                                "total_context": context_manager.budget.total_context,
+                                                "prompt_tokens": usage.prompt_tokens,
+                                                "available_for_completion": usage.available_for_completion,
+                                            },
+                                        },
+                                    ) from exc
                         else:
                             # Use regular truncation strategy
-                            messages_for_context, usage = context_manager.truncate_if_needed(
-                                messages_for_context, strategy
-                            )
+                            try:
+                                messages_for_context, usage = context_manager.truncate_if_needed(
+                                    messages_for_context, strategy
+                                )
+                            except ContextTruncationFailed as exc:
+                                raise HTTPException(
+                                    status_code=400,
+                                    detail={
+                                        "error": "context_truncation_failed",
+                                        "message": str(exc),
+                                        "context_usage": {
+                                            "total_context": context_manager.budget.total_context,
+                                            "prompt_tokens": usage.prompt_tokens,
+                                            "available_for_completion": usage.available_for_completion,
+                                        },
+                                    },
+                                ) from exc
                             logger.info(
                                 f"Context truncated: {usage.truncated_messages} messages removed, "
                                 f"strategy={usage.strategy_used}"
@@ -636,15 +711,38 @@ class ChatCompletionsService:
                         strategy_used=usage.strategy_used,
                     )
 
-                    # Final safety check: ensure we're actually under budget
-                    if (
-                        native_rendered_prompt is None
-                        and context_manager.needs_truncation(prepared_messages)
-                    ):
-                        final_usage = context_manager.validate_messages(prepared_messages)
+                    # Final safety check: ensure we're actually under budget.
+                    # Runs for both the message-based path (after truncation)
+                    # and the native-rendered path (defense in depth).
+                    final_over_budget = False
+                    final_prompt_tokens = 0
+                    final_available = 0
+                    if native_rendered_prompt is None:
+                        if context_manager.needs_truncation(prepared_messages):
+                            final_usage = context_manager.validate_messages(
+                                prepared_messages
+                            )
+                            final_over_budget = True
+                            final_prompt_tokens = final_usage.prompt_tokens
+                            final_available = final_usage.available_for_completion
+                    elif model.token_counter is not None:
+                        native_tokens = model.token_counter.count_tokens(
+                            native_rendered_prompt
+                        )
+                        if native_tokens > context_manager.budget.max_prompt_tokens:
+                            final_over_budget = True
+                            final_prompt_tokens = native_tokens
+                            final_available = max(
+                                0,
+                                context_manager.budget.total_context
+                                - native_tokens
+                                - context_manager.budget.safety_margin,
+                            )
+
+                    if final_over_budget:
                         logger.error(
                             f"CRITICAL: Still over context budget after all truncation: "
-                            f"{final_usage.prompt_tokens} tokens > "
+                            f"{final_prompt_tokens} tokens > "
                             f"{context_manager.budget.max_prompt_tokens} max"
                         )
                         raise HTTPException(
@@ -653,14 +751,14 @@ class ChatCompletionsService:
                                 "error": "context_truncation_failed",
                                 "message": (
                                     f"Failed to reduce context to fit within budget. "
-                                    f"Current: {final_usage.prompt_tokens} tokens, "
+                                    f"Current: {final_prompt_tokens} tokens, "
                                     f"Max: {context_manager.budget.max_prompt_tokens} tokens. "
                                     "Try sending fewer or shorter messages."
                                 ),
                                 "context_usage": {
-                                    "total_context": final_usage.total_context,
-                                    "prompt_tokens": final_usage.prompt_tokens,
-                                    "available_for_completion": final_usage.available_for_completion,
+                                    "total_context": context_manager.budget.total_context,
+                                    "prompt_tokens": final_prompt_tokens,
+                                    "available_for_completion": final_available,
                                 },
                             },
                         )

--- a/runtimes/edge/utils/context_manager.py
+++ b/runtimes/edge/utils/context_manager.py
@@ -18,6 +18,16 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+class ContextTruncationFailed(RuntimeError):
+    """Raised when truncation cannot reduce messages below the budget.
+
+    Typical cause: a single message (or merged system block) that cannot be
+    shrunk further without losing the final few tokens needed to represent
+    the user's current turn. Callers should surface this as a 400-class
+    error to the client rather than letting it reach the inference engine.
+    """
+
+
 class TruncationStrategy(Enum):
     """Available truncation strategies for context overflow."""
 
@@ -295,9 +305,25 @@ class ContextManager:
         system_msgs = [m for m in messages if m.get("role") == "system"]
         other_msgs = [m for m in messages if m.get("role") != "system"]
 
-        # Calculate tokens for system messages
+        max_prompt = self._budget.max_prompt_tokens
         system_tokens = self._counter.estimate_prompt_tokens(system_msgs)
-        available_for_others = self._budget.max_prompt_tokens - system_tokens
+
+        # If system messages alone meet/exceed the prompt budget, trim them
+        # down so there is room for at least a small user turn. Without this,
+        # the loop below and the content-truncation fallback can both exit
+        # while still over budget (they never touch system messages).
+        if system_tokens >= max_prompt and system_msgs:
+            user_reserve = min(256, max(1, max_prompt // 4))
+            system_budget = max(1, max_prompt - user_reserve)
+            logger.warning(
+                f"System messages ({system_tokens} tokens) meet or exceed "
+                f"max_prompt_tokens ({max_prompt}); trimming system content to "
+                f"{system_budget} tokens to reserve room for the user turn."
+            )
+            system_msgs = self._trim_system_to_budget(system_msgs, system_budget)
+            system_tokens = self._counter.estimate_prompt_tokens(system_msgs)
+
+        available_for_others = max(0, max_prompt - system_tokens)
 
         # Remove oldest non-system messages until fits
         while (
@@ -309,14 +335,42 @@ class ContextManager:
         result = system_msgs + other_msgs
 
         # If still over budget, apply aggressive content truncation
-        if (
-            self._counter.estimate_prompt_tokens(result)
-            > self._budget.max_prompt_tokens
-        ):
+        if self._counter.estimate_prompt_tokens(result) > max_prompt:
             logger.warning("Message removal insufficient, applying content truncation")
             result = self._truncate_message_contents(result)
 
         return result
+
+    def _trim_system_to_budget(
+        self, system_msgs: list[dict], budget: int
+    ) -> list[dict]:
+        """Merge system messages and truncate them to fit within a token budget.
+
+        Preserves the opening (usually highest-priority instructions) and
+        drops from the tail. Returns a single merged system message.
+        """
+        if not system_msgs or budget <= 0:
+            return system_msgs
+
+        parts = [(m.get("content") or "") for m in system_msgs]
+        merged = "\n\n".join(p for p in parts if p)
+        if not merged:
+            return system_msgs
+
+        # Deflate the token budget by the template-overhead factor and the
+        # per-message overhead so the resulting estimate fits within `budget`.
+        overhead_factor = self._counter.TEMPLATE_OVERHEAD_FACTOR
+        msg_overhead = self._counter.MESSAGE_OVERHEAD
+        target_raw = max(1, int(budget / overhead_factor) - msg_overhead)
+        truncated = self._counter.truncate_to_tokens(merged, target_raw)
+
+        return [
+            {
+                "role": "system",
+                "content": truncated
+                + "\n\n[... system content truncated to fit context ...]",
+            }
+        ]
 
     def _middle_out(self, messages: list[dict]) -> list[dict]:
         """Keep system, first exchange, and recent messages; remove middle.
@@ -396,7 +450,7 @@ class ContextManager:
         if current_tokens <= max_tokens:
             return result
 
-        tokens_to_cut = current_tokens - max_tokens + 100  # Extra buffer
+        tokens_to_cut = current_tokens - max_tokens
 
         logger.info(
             f"Content truncation: need to cut ~{tokens_to_cut} tokens "
@@ -484,11 +538,13 @@ class ContextManager:
                         largest_idx = i
 
             if largest_idx < 0 or largest_tokens <= 50:
-                # No more content to truncate
-                logger.error(
-                    f"Cannot reduce context further. Remaining: {final_tokens} tokens"
+                # No more content to truncate — raise so the caller can
+                # surface a structured 400 instead of letting an over-budget
+                # prompt reach the inference engine.
+                raise ContextTruncationFailed(
+                    f"Cannot reduce context to fit within {max_tokens} tokens; "
+                    f"{final_tokens} tokens remain after exhausting truncation."
                 )
-                break
 
             # Truncate the largest message to 50 tokens
             content = result[largest_idx]["content"]
@@ -501,6 +557,13 @@ class ContextManager:
             logger.info(
                 f"Emergency truncated message {largest_idx}: "
                 f"{largest_tokens} -> ~50 tokens. New total: {final_tokens}"
+            )
+
+        if final_tokens > max_tokens:
+            raise ContextTruncationFailed(
+                f"Emergency truncation loop exhausted ({emergency_iterations} "
+                f"iterations) with {final_tokens} tokens still over the "
+                f"{max_tokens}-token budget."
             )
 
         return result

--- a/runtimes/edge/utils/context_manager.py
+++ b/runtimes/edge/utils/context_manager.py
@@ -348,11 +348,19 @@ class ContextManager:
 
         Preserves the opening (usually highest-priority instructions) and
         drops from the tail. Returns a single merged system message.
+
+        OpenAI's ChatCompletionMessageParam allows multimodal `content` (a
+        list of parts like ``[{"type": "text", "text": "..."}]``). We
+        normalize each message's content to a string before merging so a
+        multimodal system message doesn't raise TypeError in the join.
+        Non-text parts become short placeholders (``[image]``, ``[audio]``)
+        so their presence is visible in the truncated output rather than
+        silently dropped.
         """
         if not system_msgs or budget <= 0:
             return system_msgs
 
-        parts = [(m.get("content") or "") for m in system_msgs]
+        parts = [self._stringify_content(m.get("content")) for m in system_msgs]
         merged = "\n\n".join(p for p in parts if p)
         if not merged:
             return system_msgs
@@ -371,6 +379,34 @@ class ContextManager:
                 + "\n\n[... system content truncated to fit context ...]",
             }
         ]
+
+    @staticmethod
+    def _stringify_content(content: object) -> str:
+        """Normalize an OpenAI-shape message content value to a string.
+
+        Accepts str, None, or a list of content parts; anything else falls
+        through ``str()``.
+        """
+        if content is None:
+            return ""
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            segments: list[str] = []
+            for part in content:
+                if not isinstance(part, dict):
+                    continue
+                ptype = part.get("type", "")
+                if ptype == "text":
+                    text = part.get("text", "")
+                    if text:
+                        segments.append(text)
+                elif ptype == "image_url":
+                    segments.append("[image]")
+                elif ptype == "input_audio":
+                    segments.append("[audio]")
+            return "\n".join(segments)
+        return str(content)
 
     def _middle_out(self, messages: list[dict]) -> list[dict]:
         """Keep system, first exchange, and recent messages; remove middle.

--- a/runtimes/edge/utils/context_summarizer.py
+++ b/runtimes/edge/utils/context_summarizer.py
@@ -10,10 +10,21 @@ import logging
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
+from llamafarm_common.offline_mode import is_offline
+
 if TYPE_CHECKING:
     from models.gguf_language_model import GGUFLanguageModel
 
 logger = logging.getLogger(__name__)
+
+
+class SummarizerUnavailable(RuntimeError):
+    """Raised when the summarizer model cannot be loaded.
+
+    Callers should catch this and fall back to a non-summarizing truncation
+    strategy (e.g. KEEP_SYSTEM_SLIDING). Typical causes: strict offline mode
+    without a locally staged summarizer model, or an underlying loader failure.
+    """
 
 
 # Prompt for summarizing conversation history
@@ -75,47 +86,72 @@ class ContextSummarizer:
         self._model: GGUFLanguageModel | None = None
 
     async def ensure_model_loaded(self) -> None:
-        """Load the summarization model using the server's caching mechanism."""
+        """Load the summarization model using the server's caching mechanism.
+
+        Raises:
+            SummarizerUnavailable: when strict offline mode is active (the
+                summarizer model is not pre-staged in any LlamaFarm install
+                layout) or the underlying loader fails for any reason.
+        """
         if self._model is not None:
             return
 
-        # Use the server's load_language function for proper caching
-        if self._load_language is not None:
-            logger.info(
-                f"Loading summarization model via server cache: {self._model_id}"
+        # In strict offline mode we short-circuit: the default summarizer model
+        # (Qwen/Qwen3-1.7B-GGUF) is not bundled in any LlamaFarm install
+        # layout, so attempting to load it would hit HuggingFace and fail with
+        # a long stack trace. Raising a dedicated exception lets callers route
+        # to a non-summarizing truncation strategy deterministically.
+        if is_offline():
+            raise SummarizerUnavailable(
+                f"Summarizer model {self._model_id!r} is not available in "
+                f"strict offline mode (LLAMAFARM_OFFLINE=1). Falling back to "
+                f"non-summarizing truncation."
             )
-            self._model = await self._load_language(
-                self._model_id,
-                n_ctx=4096,
-                preferred_quantization=self._quantization,
-            )
-            logger.info("Summarization model loaded (cached by server)")
-        else:
-            # Fallback: import server's loader directly
-            try:
-                from server import load_language
 
-                logger.info(f"Loading summarization model: {self._model_id}")
-                self._model = await load_language(
+        try:
+            # Use the server's load_language function for proper caching
+            if self._load_language is not None:
+                logger.info(
+                    f"Loading summarization model via server cache: {self._model_id}"
+                )
+                self._model = await self._load_language(
                     self._model_id,
                     n_ctx=4096,
                     preferred_quantization=self._quantization,
                 )
-                logger.info("Summarization model loaded successfully")
-            except ImportError:
-                # Last resort: create model directly (won't be cached)
-                from models.gguf_language_model import GGUFLanguageModel
+                logger.info("Summarization model loaded (cached by server)")
+            else:
+                # Fallback: import server's loader directly
+                try:
+                    from server import load_language
 
-                logger.warning(
-                    f"Loading summarization model directly (not cached): {self._model_id}"
-                )
-                self._model = GGUFLanguageModel(
-                    model_id=self._model_id,
-                    device="cpu",
-                    n_ctx=4096,
-                    preferred_quantization=self._quantization,
-                )
-                await self._model.load()
+                    logger.info(f"Loading summarization model: {self._model_id}")
+                    self._model = await load_language(
+                        self._model_id,
+                        n_ctx=4096,
+                        preferred_quantization=self._quantization,
+                    )
+                    logger.info("Summarization model loaded successfully")
+                except ImportError:
+                    # Last resort: create model directly (won't be cached)
+                    from models.gguf_language_model import GGUFLanguageModel
+
+                    logger.warning(
+                        f"Loading summarization model directly (not cached): {self._model_id}"
+                    )
+                    self._model = GGUFLanguageModel(
+                        model_id=self._model_id,
+                        device="cpu",
+                        n_ctx=4096,
+                        preferred_quantization=self._quantization,
+                    )
+                    await self._model.load()
+        except SummarizerUnavailable:
+            raise
+        except Exception as exc:
+            raise SummarizerUnavailable(
+                f"Failed to load summarizer model {self._model_id!r}: {exc}"
+            ) from exc
 
     async def summarize_messages(
         self,

--- a/runtimes/universal/routers/chat_completions/service.py
+++ b/runtimes/universal/routers/chat_completions/service.py
@@ -23,10 +23,11 @@ from models import GGUFLanguageModel
 from utils.context_manager import (
     ContextBudget,
     ContextManager,
+    ContextTruncationFailed,
     ContextUsage,
     TruncationStrategy,
 )
-from utils.context_summarizer import ContextSummarizer
+from utils.context_summarizer import ContextSummarizer, SummarizerUnavailable
 from utils.history_compressor import HistoryCompressor
 from utils.thinking import inject_thinking_control, parse_thinking_response
 from utils.tool_calling import (
@@ -516,12 +517,26 @@ class ChatCompletionsService:
                                         f"Still over budget after summarization "
                                         f"({usage.prompt_tokens} tokens), applying fallback truncation"
                                     )
-                                    messages_for_context, usage = (
-                                        context_manager.truncate_if_needed(
-                                            messages_for_context,
-                                            TruncationStrategy.KEEP_SYSTEM_SLIDING,
+                                    try:
+                                        messages_for_context, usage = (
+                                            context_manager.truncate_if_needed(
+                                                messages_for_context,
+                                                TruncationStrategy.KEEP_SYSTEM_SLIDING,
+                                            )
                                         )
-                                    )
+                                    except ContextTruncationFailed as exc:
+                                        raise HTTPException(
+                                            status_code=400,
+                                            detail={
+                                                "error": "context_truncation_failed",
+                                                "message": str(exc),
+                                                "context_usage": {
+                                                    "total_context": context_manager.budget.total_context,
+                                                    "prompt_tokens": usage.prompt_tokens,
+                                                    "available_for_completion": usage.available_for_completion,
+                                                },
+                                            },
+                                        ) from exc
                                     usage = type(usage)(
                                         total_context=usage.total_context,
                                         prompt_tokens=usage.prompt_tokens,
@@ -542,21 +557,78 @@ class ChatCompletionsService:
                                 logger.info(
                                     f"Context summarized: {usage.prompt_tokens} tokens after summarization"
                                 )
+                            except SummarizerUnavailable as e:
+                                logger.info(
+                                    f"Summarizer unavailable ({e}); "
+                                    f"using keep_system_sliding truncation"
+                                )
+                                try:
+                                    messages_for_context, usage = (
+                                        context_manager.truncate_if_needed(
+                                            messages_for_context,
+                                            TruncationStrategy.KEEP_SYSTEM_SLIDING,
+                                        )
+                                    )
+                                except ContextTruncationFailed as exc:
+                                    raise HTTPException(
+                                        status_code=400,
+                                        detail={
+                                            "error": "context_truncation_failed",
+                                            "message": str(exc),
+                                            "context_usage": {
+                                                "total_context": context_manager.budget.total_context,
+                                                "prompt_tokens": usage.prompt_tokens,
+                                                "available_for_completion": usage.available_for_completion,
+                                            },
+                                        },
+                                    ) from exc
+                            except HTTPException:
+                                raise
+                            except ContextTruncationFailed:
+                                raise
                             except Exception as e:
                                 logger.warning(
                                     f"Summarization failed: {e}, falling back to keep_system"
                                 )
-                                messages_for_context, usage = (
-                                    context_manager.truncate_if_needed(
-                                        messages_for_context,
-                                        TruncationStrategy.KEEP_SYSTEM_SLIDING,
+                                try:
+                                    messages_for_context, usage = (
+                                        context_manager.truncate_if_needed(
+                                            messages_for_context,
+                                            TruncationStrategy.KEEP_SYSTEM_SLIDING,
+                                        )
                                     )
-                                )
+                                except ContextTruncationFailed as exc:
+                                    raise HTTPException(
+                                        status_code=400,
+                                        detail={
+                                            "error": "context_truncation_failed",
+                                            "message": str(exc),
+                                            "context_usage": {
+                                                "total_context": context_manager.budget.total_context,
+                                                "prompt_tokens": usage.prompt_tokens,
+                                                "available_for_completion": usage.available_for_completion,
+                                            },
+                                        },
+                                    ) from exc
                         else:
                             # Use regular truncation strategy
-                            messages_for_context, usage = context_manager.truncate_if_needed(
-                                messages_for_context, strategy
-                            )
+                            try:
+                                messages_for_context, usage = context_manager.truncate_if_needed(
+                                    messages_for_context, strategy
+                                )
+                            except ContextTruncationFailed as exc:
+                                raise HTTPException(
+                                    status_code=400,
+                                    detail={
+                                        "error": "context_truncation_failed",
+                                        "message": str(exc),
+                                        "context_usage": {
+                                            "total_context": context_manager.budget.total_context,
+                                            "prompt_tokens": usage.prompt_tokens,
+                                            "available_for_completion": usage.available_for_completion,
+                                        },
+                                    },
+                                ) from exc
                             logger.info(
                                 f"Context truncated: {usage.truncated_messages} messages removed, "
                                 f"strategy={usage.strategy_used}"
@@ -584,15 +656,39 @@ class ChatCompletionsService:
                         strategy_used=usage.strategy_used,
                     )
 
-                    # Final safety check: ensure we're actually under budget
-                    if (
-                        native_rendered_prompt is None
-                        and context_manager.needs_truncation(prepared_messages)
-                    ):
-                        final_usage = context_manager.validate_messages(prepared_messages)
+                    # Final safety check: ensure we're actually under budget.
+                    # Runs for both the message-based path (after truncation)
+                    # and the native-rendered path (defense in depth — the
+                    # initial check at line 426 should have caught it, but we
+                    # re-verify so nothing over budget reaches llama.cpp).
+                    final_over_budget = False
+                    final_prompt_tokens = 0
+                    if native_rendered_prompt is None:
+                        if context_manager.needs_truncation(prepared_messages):
+                            final_usage = context_manager.validate_messages(
+                                prepared_messages
+                            )
+                            final_over_budget = True
+                            final_prompt_tokens = final_usage.prompt_tokens
+                            final_available = final_usage.available_for_completion
+                    elif model.token_counter is not None:
+                        native_tokens = model.token_counter.count_tokens(
+                            native_rendered_prompt
+                        )
+                        if native_tokens > context_manager.budget.max_prompt_tokens:
+                            final_over_budget = True
+                            final_prompt_tokens = native_tokens
+                            final_available = max(
+                                0,
+                                context_manager.budget.total_context
+                                - native_tokens
+                                - context_manager.budget.safety_margin,
+                            )
+
+                    if final_over_budget:
                         logger.error(
                             f"CRITICAL: Still over context budget after all truncation: "
-                            f"{final_usage.prompt_tokens} tokens > "
+                            f"{final_prompt_tokens} tokens > "
                             f"{context_manager.budget.max_prompt_tokens} max"
                         )
                         raise HTTPException(
@@ -601,14 +697,14 @@ class ChatCompletionsService:
                                 "error": "context_truncation_failed",
                                 "message": (
                                     f"Failed to reduce context to fit within budget. "
-                                    f"Current: {final_usage.prompt_tokens} tokens, "
+                                    f"Current: {final_prompt_tokens} tokens, "
                                     f"Max: {context_manager.budget.max_prompt_tokens} tokens. "
                                     "Try sending fewer or shorter messages."
                                 ),
                                 "context_usage": {
-                                    "total_context": final_usage.total_context,
-                                    "prompt_tokens": final_usage.prompt_tokens,
-                                    "available_for_completion": final_usage.available_for_completion,
+                                    "total_context": context_manager.budget.total_context,
+                                    "prompt_tokens": final_prompt_tokens,
+                                    "available_for_completion": final_available,
                                 },
                             },
                         )

--- a/runtimes/universal/tests/test_context_manager.py
+++ b/runtimes/universal/tests/test_context_manager.py
@@ -290,7 +290,31 @@ class TestContextManager:
             {"role": "system", "content": "sys"},
             {"role": "user", "content": huge_content},
         ]
-        result, usage = manager.truncate_if_needed(
+        _, usage = manager.truncate_if_needed(
+            messages, TruncationStrategy.KEEP_SYSTEM_SLIDING
+        )
+        assert usage.prompt_tokens <= manager.budget.max_prompt_tokens
+
+    def test_keep_system_sliding_handles_multimodal_system_content(self, manager):
+        """Multimodal system content (list of parts) must not crash trimming.
+
+        OpenAI's ChatCompletionMessageParam allows `content` to be a list of
+        parts. Regression: the first pass of `_trim_system_to_budget` joined
+        raw `content` values with `"\\n\\n"`, which raised TypeError when a
+        system message used list-of-parts content.
+        """
+        big_text = "s" * 50000
+        messages = [
+            {
+                "role": "system",
+                "content": [
+                    {"type": "text", "text": big_text},
+                    {"type": "image_url", "image_url": {"url": "http://x/y.png"}},
+                ],
+            },
+            {"role": "user", "content": "hi"},
+        ]
+        _, usage = manager.truncate_if_needed(
             messages, TruncationStrategy.KEEP_SYSTEM_SLIDING
         )
         assert usage.prompt_tokens <= manager.budget.max_prompt_tokens

--- a/runtimes/universal/tests/test_context_manager.py
+++ b/runtimes/universal/tests/test_context_manager.py
@@ -5,6 +5,7 @@ import pytest
 from utils.context_manager import (
     ContextBudget,
     ContextManager,
+    ContextTruncationFailed,
     ContextUsage,
     TruncationStrategy,
 )
@@ -255,6 +256,62 @@ class TestContextManager:
         # Should have truncated the content
         assert usage.truncated is True
         assert len(result[0]["content"]) < len(huge_content)
+
+    def test_keep_system_sliding_trims_oversized_system(self, manager):
+        """System messages alone exceeding budget must be trimmed.
+
+        Regression: previously `_keep_system_sliding` preserved all system
+        messages verbatim, so a 10k-token system prompt would exit the
+        strategy still over budget and blow past the content-truncation
+        fallback (which also skipped system messages).
+        """
+        huge_system = "s" * 50000  # ~12.5k raw tokens with MockLlama
+        messages = [
+            {"role": "system", "content": huge_system},
+            {"role": "user", "content": "hi"},
+        ]
+        result, usage = manager.truncate_if_needed(
+            messages, TruncationStrategy.KEEP_SYSTEM_SLIDING
+        )
+
+        assert usage.prompt_tokens <= manager.budget.max_prompt_tokens
+        system_msgs = [m for m in result if m.get("role") == "system"]
+        assert system_msgs, "expected at least one system message after trimming"
+        assert len(system_msgs[0]["content"]) < len(huge_system)
+
+    def test_content_truncation_respects_max_tokens(self, manager):
+        """After content truncation, estimate must be <= max_prompt_tokens.
+
+        Regression: the old `+100` overshoot in `_truncate_message_contents`
+        let the final estimate exceed the budget by up to ~100 tokens.
+        """
+        huge_content = "x" * 50000
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": huge_content},
+        ]
+        result, usage = manager.truncate_if_needed(
+            messages, TruncationStrategy.KEEP_SYSTEM_SLIDING
+        )
+        assert usage.prompt_tokens <= manager.budget.max_prompt_tokens
+
+    def test_content_truncation_raises_when_unconvergable(self):
+        """When truncation can't converge, ContextTruncationFailed is raised.
+
+        Uses a tiny budget and many small messages so the emergency loop
+        can't cut below the per-message overhead floor.
+        """
+        counter = TokenCounter(MockLlama())
+        # Very tight budget — 20 tokens total, most of which is overhead.
+        budget = ContextBudget.from_context_size(20, max_completion_tokens=4)
+        tight_manager = ContextManager(counter, budget)
+
+        # 20 tiny messages — each contributes MESSAGE_OVERHEAD=4 tokens that
+        # the emergency loop cannot reduce further (no content to shrink).
+        messages = [{"role": "user", "content": "x"} for _ in range(20)]
+
+        with pytest.raises(ContextTruncationFailed):
+            tight_manager._truncate_message_contents(messages)
 
 
 class TestHistoryCompressor:

--- a/runtimes/universal/tests/test_context_summarizer.py
+++ b/runtimes/universal/tests/test_context_summarizer.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from utils.context_summarizer import ContextSummarizer
+from utils.context_summarizer import ContextSummarizer, SummarizerUnavailable
 
 
 class TestContextSummarizer:
@@ -166,3 +166,34 @@ class TestContextSummarizer:
         assert "World" in formatted
         # Should only have 2 parts (not 3)
         assert formatted.count("User:") == 2
+
+    @pytest.mark.asyncio
+    async def test_ensure_model_loaded_raises_in_offline_mode(
+        self, summarizer, monkeypatch
+    ):
+        """Offline mode short-circuits with SummarizerUnavailable.
+
+        The default summarizer model (Qwen/Qwen3-1.7B-GGUF) is not bundled
+        in any LlamaFarm install layout, so attempting to load it in strict
+        offline mode would hit HuggingFace and fail slowly. The guard must
+        raise deterministically so callers can route to a fallback strategy.
+        """
+        monkeypatch.setenv("LLAMAFARM_OFFLINE", "1")
+
+        with pytest.raises(SummarizerUnavailable):
+            await summarizer.ensure_model_loaded()
+
+    @pytest.mark.asyncio
+    async def test_ensure_model_loaded_wraps_loader_errors(
+        self, monkeypatch
+    ):
+        """Arbitrary loader failures surface as SummarizerUnavailable."""
+        monkeypatch.delenv("LLAMAFARM_OFFLINE", raising=False)
+
+        async def failing_loader(*args, **kwargs):
+            raise RuntimeError("boom")
+
+        summarizer = ContextSummarizer(load_language=failing_loader)
+
+        with pytest.raises(SummarizerUnavailable):
+            await summarizer.ensure_model_loaded()

--- a/runtimes/universal/utils/context_manager.py
+++ b/runtimes/universal/utils/context_manager.py
@@ -18,6 +18,16 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+class ContextTruncationFailed(RuntimeError):
+    """Raised when truncation cannot reduce messages below the budget.
+
+    Typical cause: a single message (or merged system block) that cannot be
+    shrunk further without losing the final few tokens needed to represent
+    the user's current turn. Callers should surface this as a 400-class
+    error to the client rather than letting it reach the inference engine.
+    """
+
+
 class TruncationStrategy(Enum):
     """Available truncation strategies for context overflow."""
 
@@ -295,9 +305,25 @@ class ContextManager:
         system_msgs = [m for m in messages if m.get("role") == "system"]
         other_msgs = [m for m in messages if m.get("role") != "system"]
 
-        # Calculate tokens for system messages
+        max_prompt = self._budget.max_prompt_tokens
         system_tokens = self._counter.estimate_prompt_tokens(system_msgs)
-        available_for_others = self._budget.max_prompt_tokens - system_tokens
+
+        # If system messages alone meet/exceed the prompt budget, trim them
+        # down so there is room for at least a small user turn. Without this,
+        # the loop below and the content-truncation fallback can both exit
+        # while still over budget (they never touch system messages).
+        if system_tokens >= max_prompt and system_msgs:
+            user_reserve = min(256, max(1, max_prompt // 4))
+            system_budget = max(1, max_prompt - user_reserve)
+            logger.warning(
+                f"System messages ({system_tokens} tokens) meet or exceed "
+                f"max_prompt_tokens ({max_prompt}); trimming system content to "
+                f"{system_budget} tokens to reserve room for the user turn."
+            )
+            system_msgs = self._trim_system_to_budget(system_msgs, system_budget)
+            system_tokens = self._counter.estimate_prompt_tokens(system_msgs)
+
+        available_for_others = max(0, max_prompt - system_tokens)
 
         # Remove oldest non-system messages until fits
         while (
@@ -309,14 +335,42 @@ class ContextManager:
         result = system_msgs + other_msgs
 
         # If still over budget, apply aggressive content truncation
-        if (
-            self._counter.estimate_prompt_tokens(result)
-            > self._budget.max_prompt_tokens
-        ):
+        if self._counter.estimate_prompt_tokens(result) > max_prompt:
             logger.warning("Message removal insufficient, applying content truncation")
             result = self._truncate_message_contents(result)
 
         return result
+
+    def _trim_system_to_budget(
+        self, system_msgs: list[dict], budget: int
+    ) -> list[dict]:
+        """Merge system messages and truncate them to fit within a token budget.
+
+        Preserves the opening (usually highest-priority instructions) and
+        drops from the tail. Returns a single merged system message.
+        """
+        if not system_msgs or budget <= 0:
+            return system_msgs
+
+        parts = [(m.get("content") or "") for m in system_msgs]
+        merged = "\n\n".join(p for p in parts if p)
+        if not merged:
+            return system_msgs
+
+        # Deflate the token budget by the template-overhead factor and the
+        # per-message overhead so the resulting estimate fits within `budget`.
+        overhead_factor = self._counter.TEMPLATE_OVERHEAD_FACTOR
+        msg_overhead = self._counter.MESSAGE_OVERHEAD
+        target_raw = max(1, int(budget / overhead_factor) - msg_overhead)
+        truncated = self._counter.truncate_to_tokens(merged, target_raw)
+
+        return [
+            {
+                "role": "system",
+                "content": truncated
+                + "\n\n[... system content truncated to fit context ...]",
+            }
+        ]
 
     def _middle_out(self, messages: list[dict]) -> list[dict]:
         """Keep system, first exchange, and recent messages; remove middle.
@@ -396,7 +450,7 @@ class ContextManager:
         if current_tokens <= max_tokens:
             return result
 
-        tokens_to_cut = current_tokens - max_tokens + 100  # Extra buffer
+        tokens_to_cut = current_tokens - max_tokens
 
         logger.info(
             f"Content truncation: need to cut ~{tokens_to_cut} tokens "
@@ -484,11 +538,13 @@ class ContextManager:
                         largest_idx = i
 
             if largest_idx < 0 or largest_tokens <= 50:
-                # No more content to truncate
-                logger.error(
-                    f"Cannot reduce context further. Remaining: {final_tokens} tokens"
+                # No more content to truncate — raise so the caller can
+                # surface a structured 400 instead of letting an over-budget
+                # prompt reach the inference engine.
+                raise ContextTruncationFailed(
+                    f"Cannot reduce context to fit within {max_tokens} tokens; "
+                    f"{final_tokens} tokens remain after exhausting truncation."
                 )
-                break
 
             # Truncate the largest message to 50 tokens
             content = result[largest_idx]["content"]
@@ -501,6 +557,13 @@ class ContextManager:
             logger.info(
                 f"Emergency truncated message {largest_idx}: "
                 f"{largest_tokens} -> ~50 tokens. New total: {final_tokens}"
+            )
+
+        if final_tokens > max_tokens:
+            raise ContextTruncationFailed(
+                f"Emergency truncation loop exhausted ({emergency_iterations} "
+                f"iterations) with {final_tokens} tokens still over the "
+                f"{max_tokens}-token budget."
             )
 
         return result

--- a/runtimes/universal/utils/context_manager.py
+++ b/runtimes/universal/utils/context_manager.py
@@ -348,11 +348,19 @@ class ContextManager:
 
         Preserves the opening (usually highest-priority instructions) and
         drops from the tail. Returns a single merged system message.
+
+        OpenAI's ChatCompletionMessageParam allows multimodal `content` (a
+        list of parts like ``[{"type": "text", "text": "..."}]``). We
+        normalize each message's content to a string before merging so a
+        multimodal system message doesn't raise TypeError in the join.
+        Non-text parts become short placeholders (``[image]``, ``[audio]``)
+        so their presence is visible in the truncated output rather than
+        silently dropped.
         """
         if not system_msgs or budget <= 0:
             return system_msgs
 
-        parts = [(m.get("content") or "") for m in system_msgs]
+        parts = [self._stringify_content(m.get("content")) for m in system_msgs]
         merged = "\n\n".join(p for p in parts if p)
         if not merged:
             return system_msgs
@@ -371,6 +379,34 @@ class ContextManager:
                 + "\n\n[... system content truncated to fit context ...]",
             }
         ]
+
+    @staticmethod
+    def _stringify_content(content: object) -> str:
+        """Normalize an OpenAI-shape message content value to a string.
+
+        Accepts str, None, or a list of content parts; anything else falls
+        through ``str()``.
+        """
+        if content is None:
+            return ""
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            segments: list[str] = []
+            for part in content:
+                if not isinstance(part, dict):
+                    continue
+                ptype = part.get("type", "")
+                if ptype == "text":
+                    text = part.get("text", "")
+                    if text:
+                        segments.append(text)
+                elif ptype == "image_url":
+                    segments.append("[image]")
+                elif ptype == "input_audio":
+                    segments.append("[audio]")
+            return "\n".join(segments)
+        return str(content)
 
     def _middle_out(self, messages: list[dict]) -> list[dict]:
         """Keep system, first exchange, and recent messages; remove middle.

--- a/runtimes/universal/utils/context_summarizer.py
+++ b/runtimes/universal/utils/context_summarizer.py
@@ -10,10 +10,21 @@ import logging
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
+from llamafarm_common.offline_mode import is_offline
+
 if TYPE_CHECKING:
     from models.gguf_language_model import GGUFLanguageModel
 
 logger = logging.getLogger(__name__)
+
+
+class SummarizerUnavailable(RuntimeError):
+    """Raised when the summarizer model cannot be loaded.
+
+    Callers should catch this and fall back to a non-summarizing truncation
+    strategy (e.g. KEEP_SYSTEM_SLIDING). Typical causes: strict offline mode
+    without a locally staged summarizer model, or an underlying loader failure.
+    """
 
 
 # Prompt for summarizing conversation history
@@ -75,47 +86,72 @@ class ContextSummarizer:
         self._model: GGUFLanguageModel | None = None
 
     async def ensure_model_loaded(self) -> None:
-        """Load the summarization model using the server's caching mechanism."""
+        """Load the summarization model using the server's caching mechanism.
+
+        Raises:
+            SummarizerUnavailable: when strict offline mode is active (the
+                summarizer model is not pre-staged in any LlamaFarm install
+                layout) or the underlying loader fails for any reason.
+        """
         if self._model is not None:
             return
 
-        # Use the server's load_language function for proper caching
-        if self._load_language is not None:
-            logger.info(
-                f"Loading summarization model via server cache: {self._model_id}"
+        # In strict offline mode we short-circuit: the default summarizer model
+        # (Qwen/Qwen3-1.7B-GGUF) is not bundled in any LlamaFarm install
+        # layout, so attempting to load it would hit HuggingFace and fail with
+        # a long stack trace. Raising a dedicated exception lets callers route
+        # to a non-summarizing truncation strategy deterministically.
+        if is_offline():
+            raise SummarizerUnavailable(
+                f"Summarizer model {self._model_id!r} is not available in "
+                f"strict offline mode (LLAMAFARM_OFFLINE=1). Falling back to "
+                f"non-summarizing truncation."
             )
-            self._model = await self._load_language(
-                self._model_id,
-                n_ctx=4096,
-                preferred_quantization=self._quantization,
-            )
-            logger.info("Summarization model loaded (cached by server)")
-        else:
-            # Fallback: import server's loader directly
-            try:
-                from server import load_language
 
-                logger.info(f"Loading summarization model: {self._model_id}")
-                self._model = await load_language(
+        try:
+            # Use the server's load_language function for proper caching
+            if self._load_language is not None:
+                logger.info(
+                    f"Loading summarization model via server cache: {self._model_id}"
+                )
+                self._model = await self._load_language(
                     self._model_id,
                     n_ctx=4096,
                     preferred_quantization=self._quantization,
                 )
-                logger.info("Summarization model loaded successfully")
-            except ImportError:
-                # Last resort: create model directly (won't be cached)
-                from models.gguf_language_model import GGUFLanguageModel
+                logger.info("Summarization model loaded (cached by server)")
+            else:
+                # Fallback: import server's loader directly
+                try:
+                    from server import load_language
 
-                logger.warning(
-                    f"Loading summarization model directly (not cached): {self._model_id}"
-                )
-                self._model = GGUFLanguageModel(
-                    model_id=self._model_id,
-                    device="cpu",
-                    n_ctx=4096,
-                    preferred_quantization=self._quantization,
-                )
-                await self._model.load()
+                    logger.info(f"Loading summarization model: {self._model_id}")
+                    self._model = await load_language(
+                        self._model_id,
+                        n_ctx=4096,
+                        preferred_quantization=self._quantization,
+                    )
+                    logger.info("Summarization model loaded successfully")
+                except ImportError:
+                    # Last resort: create model directly (won't be cached)
+                    from models.gguf_language_model import GGUFLanguageModel
+
+                    logger.warning(
+                        f"Loading summarization model directly (not cached): {self._model_id}"
+                    )
+                    self._model = GGUFLanguageModel(
+                        model_id=self._model_id,
+                        device="cpu",
+                        n_ctx=4096,
+                        preferred_quantization=self._quantization,
+                    )
+                    await self._model.load()
+        except SummarizerUnavailable:
+            raise
+        except Exception as exc:
+            raise SummarizerUnavailable(
+                f"Failed to load summarizer model {self._model_id!r}: {exc}"
+            ) from exc
 
     async def summarize_messages(
         self,


### PR DESCRIPTION
## Summary

- **Offline summarizer**: `ContextSummarizer` tried to download `Qwen/Qwen3-1.7B-GGUF` at runtime. Under `LLAMAFARM_OFFLINE=1`, the HF block produced a slow stack trace and the fallback `KEEP_SYSTEM_SLIDING` still left the prompt over budget — llama.cpp then returned a 500. Now short-circuits with a new `SummarizerUnavailable` exception so callers route to a non-summarizing strategy deterministically.
- **Truncation invariants**: `_keep_system_sliding` now trims oversized system messages (previously it left them untouched, so a 10k-token system prompt bypassed truncation entirely). `_truncate_message_contents` drops the `+100` overshoot and raises a new `ContextTruncationFailed` instead of silently returning over budget.
- **Safety-check gap**: the final `needs_truncation` check in the chat-completions service now runs on both the message-based and Jinja-rendered paths. `ContextTruncationFailed` is caught at every `truncate_if_needed` call site and converted to a structured 400 so an over-budget prompt never reaches llama.cpp.
- Mirrored utils to `runtimes/edge/`; edge `service.py` gets matching patches with graceful-fallback classes for the optional-import pattern.

## Test plan

- [x] `pytest runtimes/universal/tests/test_context_manager.py runtimes/universal/tests/test_context_summarizer.py` — 44/44 pass (5 new tests)
- [ ] Verify chat completions still return 200 for in-budget requests (manual smoke)
- [ ] Verify oversized request in offline mode returns 400 `context_truncation_failed`, not a 500 from llama.cpp
- [ ] Full CI matrix (Linux/macOS/Windows) green

## New tests
- `test_ensure_model_loaded_raises_in_offline_mode` — `LLAMAFARM_OFFLINE=1` → `SummarizerUnavailable`
- `test_ensure_model_loaded_wraps_loader_errors` — arbitrary loader failures surface as `SummarizerUnavailable`
- `test_keep_system_sliding_trims_oversized_system` — huge system prompt is trimmed to fit
- `test_content_truncation_respects_max_tokens` — no `+100` overshoot after content truncation
- `test_content_truncation_raises_when_unconvergable` — `ContextTruncationFailed` when emergency loop can't shrink further

## Out of scope
- `TEMPLATE_OVERHEAD_FACTOR = 1.10` recalibration against a real tokenizer
- Bundling a summarizer GGUF in the default model-dir layout