### PR TITLE
feat(cli/server): show runtime status in models list (#798)

### DIFF
--- a/cli/cmd/models.go
+++ b/cli/cmd/models.go
@@ -89,6 +89,15 @@ Examples:
 				fmt.Printf("    %s\n", m.Description)
 			}
 			fmt.Printf("    Provider: %s | Model: %s\n", m.Provider, m.Model)
+			if runtimeSummary := formatModelRuntimeSummary(m); runtimeSummary != "" {
+				fmt.Printf("    Status: %s\n", runtimeSummary)
+			}
+			if runtimeMessage := formatModelRuntimeMessage(m); runtimeMessage != "" {
+				fmt.Printf("    Runtime: %s\n", runtimeMessage)
+			}
+			if m.RuntimeHost != "" {
+				fmt.Printf("    Host: %s\n", m.RuntimeHost)
+			}
 			fmt.Println()
 		}
 	},
@@ -136,4 +145,32 @@ func init() {
 	modelsCmd.AddCommand(modelsListCmd)
 	modelsCmd.AddCommand(modelsCachedCmd)
 	rootCmd.AddCommand(modelsCmd)
+}
+
+func formatModelRuntimeSummary(model ModelInfo) string {
+	if model.RuntimeStatus == "" {
+		return ""
+	}
+
+	parts := []string{model.RuntimeStatus}
+	if model.MemoryUsageHuman != "" {
+		parts = append(parts, "Memory: "+model.MemoryUsageHuman)
+	}
+	if model.GPUAllocation != "" {
+		parts = append(parts, "GPU: "+model.GPUAllocation)
+	}
+	if model.UptimeHuman != "" {
+		parts = append(parts, "Uptime: "+model.UptimeHuman)
+	}
+
+	return strings.Join(parts, " | ")
+}
+
+func formatModelRuntimeMessage(model ModelInfo) string {
+	switch model.RuntimeStatus {
+	case "missing", "remote", "reachable", "unreachable", "unknown":
+		return model.RuntimeMessage
+	default:
+		return ""
+	}
 }

--- a/cli/cmd/models_shared.go
+++ b/cli/cmd/models_shared.go
@@ -13,11 +13,22 @@ import (
 
 // ModelInfo represents a model configuration
 type ModelInfo struct {
-	Name        string `json:"name"`
-	Description string `json:"description"`
-	Provider    string `json:"provider"`
-	Model       string `json:"model"`
-	IsDefault   bool   `json:"default"`
+	Name             string                 `json:"name"`
+	Description      string                 `json:"description"`
+	Provider         string                 `json:"provider"`
+	Model            string                 `json:"model"`
+	IsDefault        bool                   `json:"default"`
+	RuntimeStatus    string                 `json:"runtime_status"`
+	RuntimeLoaded    bool                   `json:"runtime_loaded"`
+	RuntimeRunning   bool                   `json:"runtime_running"`
+	RuntimeHost      string                 `json:"runtime_host"`
+	MemoryUsageBytes int64                  `json:"memory_usage_bytes"`
+	MemoryUsageHuman string                 `json:"memory_usage_human"`
+	GPUAllocation    string                 `json:"gpu_allocation"`
+	UptimeSeconds    int64                  `json:"uptime_seconds"`
+	UptimeHuman      string                 `json:"uptime_human"`
+	RuntimeMessage   string                 `json:"runtime_message"`
+	RuntimeDetails   map[string]interface{} `json:"runtime_details"`
 }
 
 // fetchAvailableModels fetches the list of available models for a project

--- a/cli/cmd/models_test.go
+++ b/cli/cmd/models_test.go
@@ -1,0 +1,77 @@
+package cmd
+
+import "testing"
+
+func TestFormatModelRuntimeSummary(t *testing.T) {
+	tests := []struct {
+		name     string
+		model    ModelInfo
+		expected string
+	}{
+		{
+			name:     "empty when no runtime status",
+			model:    ModelInfo{},
+			expected: "",
+		},
+		{
+			name: "status only",
+			model: ModelInfo{
+				RuntimeStatus: "idle",
+			},
+			expected: "idle",
+		},
+		{
+			name: "status with metrics",
+			model: ModelInfo{
+				RuntimeStatus:    "running",
+				MemoryUsageHuman: "4.2 GB",
+				GPUAllocation:    "3.6 GB",
+				UptimeHuman:      "12m",
+			},
+			expected: "running | Memory: 4.2 GB | GPU: 3.6 GB | Uptime: 12m",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatModelRuntimeSummary(tt.model)
+			if got != tt.expected {
+				t.Fatalf("formatModelRuntimeSummary() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestFormatModelRuntimeMessage(t *testing.T) {
+	tests := []struct {
+		name     string
+		model    ModelInfo
+		expected string
+	}{
+		{
+			name: "prints error-like runtime message",
+			model: ModelInfo{
+				RuntimeStatus:  "missing",
+				RuntimeMessage: "Configured model is not installed in Ollama",
+			},
+			expected: "Configured model is not installed in Ollama",
+		},
+		{
+			name: "suppresses redundant loaded message",
+			model: ModelInfo{
+				RuntimeStatus:  "loaded",
+				RuntimeMessage: "Model is loaded in Universal Runtime",
+			},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatModelRuntimeMessage(tt.model)
+			if got != tt.expected {
+				t.Fatalf("formatModelRuntimeMessage() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}

--- a/docs/website/docs/cli/lf-models.md
+++ b/docs/website/docs/cli/lf-models.md
@@ -19,7 +19,8 @@ If you omit `namespace/project`, the CLI resolves them from `llamafarm.yaml`.
 
 ### `lf models list`
 
-List all models configured in your project with their descriptions and providers.
+List all models configured in your project with their descriptions, providers,
+and current runtime state when the backing provider exposes it.
 
 ```bash
 lf models list                    # List models from current project
@@ -31,6 +32,9 @@ lf models list company/project    # List models from specific project
 - Description
 - Provider (ollama, lemonade, openai, etc.)
 - Default status
+- Runtime status (`running`, `loaded`, `idle`, `missing`, `unreachable`, etc.)
+- Memory / GPU allocation when the runtime reports it
+- Runtime host and provider-specific status notes
 
 ### `lf models path`
 

--- a/docs/website/docs/cli/lf-models.md
+++ b/docs/website/docs/cli/lf-models.md
@@ -34,7 +34,15 @@ lf models list company/project    # List models from specific project
 - Default status
 - Runtime status (`running`, `loaded`, `idle`, `missing`, `unreachable`, etc.)
 - Memory / GPU allocation when the runtime reports it
+- Uptime since the server first observed the model as loaded
 - Runtime host and provider-specific status notes
+
+**Uptime:** the server tracks a first-seen timestamp for each model the moment
+a provider reports it as loaded or running, and subtracts from `time.monotonic()`
+on every call. It resets when the model unloads or when the LlamaFarm server
+restarts — provider runtimes (Ollama, Lemonade, Universal) don't expose a
+true "loaded-at" timestamp, so this is a server-observed approximation rather
+than a ground-truth value from the runtime process itself.
 
 ### `lf models path`
 

--- a/docs/website/docs/models/index.md
+++ b/docs/website/docs/models/index.md
@@ -30,7 +30,7 @@ runtime:
 
 **Using multi-model:**
 - CLI: `lf chat --model powerful "your question"`
-- CLI: `lf models list` (shows all available models)
+- CLI: `lf models list` (shows configured models plus current runtime state)
 - API: `POST /v1/projects/{ns}/{id}/chat/completions` with `{"model": "powerful", ...}`
 
 **Legacy single-model configs are still supported** and automatically converted internally.

--- a/server/api/routers/projects/projects.py
+++ b/server/api/routers/projects/projects.py
@@ -97,7 +97,10 @@ class ModelResponse(Model):
     )
     runtime_status: str | None = Field(
         None,
-        description="Current runtime state for this model (for example running, loaded, idle, or unreachable).",
+        description=(
+            "Current runtime state for this model"
+            " (for example running, loaded, idle, or unreachable)."
+        ),
     )
     runtime_loaded: bool | None = Field(
         None,

--- a/server/api/routers/projects/projects.py
+++ b/server/api/routers/projects/projects.py
@@ -95,6 +95,50 @@ class ModelResponse(Model):
         False,
         description="Whether this model is the default model in the runtime config",
     )
+    runtime_status: str | None = Field(
+        None,
+        description="Current runtime state for this model (for example running, loaded, idle, or unreachable).",
+    )
+    runtime_loaded: bool | None = Field(
+        None,
+        description="Whether the model is currently loaded in the provider runtime.",
+    )
+    runtime_running: bool | None = Field(
+        None,
+        description="Whether the provider reports the model as actively running.",
+    )
+    runtime_host: str | None = Field(
+        None,
+        description="Runtime host that was queried for status information.",
+    )
+    memory_usage_bytes: int | None = Field(
+        None,
+        description="Approximate memory usage in bytes when the runtime exposes it.",
+    )
+    memory_usage_human: str | None = Field(
+        None,
+        description="Human-readable memory usage when available.",
+    )
+    gpu_allocation: str | None = Field(
+        None,
+        description="GPU allocation or device information when available.",
+    )
+    uptime_seconds: int | None = Field(
+        None,
+        description="Approximate uptime in seconds when the runtime exposes it.",
+    )
+    uptime_human: str | None = Field(
+        None,
+        description="Human-readable uptime when available.",
+    )
+    runtime_message: str | None = Field(
+        None,
+        description="Additional provider-specific runtime status information.",
+    )
+    runtime_details: dict[str, Any] | None = Field(
+        None,
+        description="Provider-specific runtime details.",
+    )
 
 
 class ListModelsResponse(BaseModel):
@@ -1676,6 +1720,7 @@ async def list_models(namespace: str, project_id: str):
 
     project_config = ProjectService.load_config(namespace, project_id)
     models = ModelService.list_models(project_config)
+    runtime_statuses = ModelService.list_model_runtime_statuses(project_config)
 
     default_model = project_config.runtime.default_model
 
@@ -1685,6 +1730,7 @@ async def list_models(namespace: str, project_id: str):
             ModelResponse(
                 **model.model_dump(mode="json", exclude_none=True),
                 default=model.name == default_model,
+                **runtime_statuses.get(model.name, {}),
             )
             for model in models
         ],

--- a/server/services/model_service.py
+++ b/server/services/model_service.py
@@ -7,6 +7,7 @@ for working with multi-model configurations.
 from collections.abc import AsyncIterator
 
 from config.datamodel import LlamaFarmConfig, Model, Provider  # noqa: E402
+from server.services.runtime_service.runtime_service import runtime_service
 from server.services.runtime_service.providers.base import CachedModel
 from server.services.runtime_service.providers.universal_provider import (
     UniversalProvider,  # noqa: E402
@@ -80,6 +81,33 @@ class ModelService:
             model, is_default
         """
         return project_config.runtime.models or []
+
+    @staticmethod
+    def list_model_runtime_statuses(project_config: LlamaFarmConfig) -> dict[str, dict]:
+        """Collect runtime status for each configured model.
+
+        Returns a dict keyed by the configured model alias so API callers can
+        merge the status fields into their existing model payload.
+        """
+        statuses: dict[str, dict] = {}
+        for model in project_config.runtime.models or []:
+            try:
+                provider = runtime_service.get_provider(model)
+                statuses[model.name] = provider.get_model_runtime_status().to_dict()
+            except Exception as e:  # pragma: no cover - defensive fallback
+                logger.warning(
+                    "Failed to collect model runtime status",
+                    model_name=model.name,
+                    provider=getattr(model.provider, "value", str(model.provider)),
+                    error=str(e),
+                )
+                statuses[model.name] = {
+                    "runtime_status": "unknown",
+                    "runtime_loaded": False,
+                    "runtime_running": False,
+                    "runtime_message": f"Failed to inspect runtime state: {e}",
+                }
+        return statuses
 
     @staticmethod
     def list_cached_models(

--- a/server/services/model_service.py
+++ b/server/services/model_service.py
@@ -4,11 +4,16 @@ This service handles model resolution and provides utilities
 for working with multi-model configurations.
 """
 
+import time
 from collections.abc import AsyncIterator
+from threading import Lock
 
 from config.datamodel import LlamaFarmConfig, Model, Provider  # noqa: E402
 from server.services.runtime_service.runtime_service import runtime_service
-from server.services.runtime_service.providers.base import CachedModel
+from server.services.runtime_service.providers.base import (
+    CachedModel,
+    format_duration,
+)
 from server.services.runtime_service.providers.universal_provider import (
     UniversalProvider,  # noqa: E402
 )
@@ -16,6 +21,32 @@ from server.services.runtime_service.providers.universal_provider import (
 from core.logging import FastAPIStructLogger
 
 logger = FastAPIStructLogger(__name__)
+
+
+# Tracks monotonic timestamps of when each (model_alias, provider, host) was
+# first observed as loaded/running, so we can report uptime for providers that
+# don't expose the value themselves (Ollama, Universal, Lemonade). The tracker
+# resets when the server restarts or when a model is no longer reported active,
+# which is the intended behavior and is documented in lf-models.md.
+_uptime_tracker: dict[tuple[str, str, str | None], float] = {}
+_uptime_lock = Lock()
+
+
+def _record_uptime(key: tuple[str, str, str | None], active: bool) -> int | None:
+    """Return uptime seconds for `key` if active, clearing it otherwise."""
+    now = time.monotonic()
+    with _uptime_lock:
+        if active:
+            first_seen = _uptime_tracker.setdefault(key, now)
+            return int(now - first_seen)
+        _uptime_tracker.pop(key, None)
+        return None
+
+
+def _reset_uptime_tracker() -> None:
+    """Test helper: clear the module-level uptime tracker."""
+    with _uptime_lock:
+        _uptime_tracker.clear()
 
 
 class ModelService:
@@ -91,22 +122,36 @@ class ModelService:
         """
         statuses: dict[str, dict] = {}
         for model in project_config.runtime.models or []:
+            provider_name = getattr(model.provider, "value", str(model.provider))
             try:
                 provider = runtime_service.get_provider(model)
-                statuses[model.name] = provider.get_model_runtime_status().to_dict()
+                status = provider.get_model_runtime_status()
             except Exception as e:  # pragma: no cover - defensive fallback
                 logger.warning(
                     "Failed to collect model runtime status",
                     model_name=model.name,
-                    provider=getattr(model.provider, "value", str(model.provider)),
+                    provider=provider_name,
                     error=str(e),
                 )
+                _record_uptime((model.name, provider_name, None), active=False)
                 statuses[model.name] = {
                     "runtime_status": "unknown",
                     "runtime_loaded": False,
                     "runtime_running": False,
                     "runtime_message": f"Failed to inspect runtime state: {e}",
                 }
+                continue
+
+            active = bool(status.loaded or status.running)
+            tracked_seconds = _record_uptime(
+                (model.name, provider_name, status.host), active=active
+            )
+            if active and status.uptime_seconds is None and tracked_seconds is not None:
+                status.uptime_seconds = tracked_seconds
+                if status.uptime_human is None:
+                    status.uptime_human = format_duration(tracked_seconds)
+
+            statuses[model.name] = status.to_dict()
         return statuses
 
     @staticmethod

--- a/server/services/runtime_service/providers/base.py
+++ b/server/services/runtime_service/providers/base.py
@@ -1,7 +1,8 @@
 """Base class for runtime providers."""
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Any
 
 from config.datamodel import Model
 
@@ -49,6 +50,31 @@ class RuntimeProvider(ABC):
         """
         pass
 
+    def get_model_runtime_status(self) -> "RuntimeModelStatus":
+        """Describe the current runtime state for this configured model.
+
+        Providers with richer runtime APIs should override this method.
+        The default behavior preserves a useful status for providers that
+        do not expose per-model loading information.
+        """
+        health = self.check_health()
+        host = None
+        if health.details:
+            host = health.details.get("host") or health.details.get("base_url")
+
+        if health.status in {"healthy", "degraded"}:
+            status = "reachable"
+        elif health.status == "reachable":
+            status = "remote"
+        else:
+            status = "unreachable"
+
+        return RuntimeModelStatus(
+            status=status,
+            host=host,
+            runtime_message=health.message,
+        )
+
 
 @dataclass
 class CachedModel:
@@ -58,3 +84,61 @@ class CachedModel:
     name: str
     size: int
     path: str
+
+
+@dataclass
+class RuntimeModelStatus:
+    """Structured runtime status for a configured model."""
+
+    status: str
+    host: str | None = None
+    loaded: bool = False
+    running: bool = False
+    memory_usage_bytes: int | None = None
+    memory_usage_human: str | None = None
+    gpu_allocation: str | None = None
+    uptime_seconds: int | None = None
+    uptime_human: str | None = None
+    runtime_message: str | None = None
+    details: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert runtime status to JSON-serializable output."""
+        data: dict[str, Any] = {
+            "runtime_status": self.status,
+            "runtime_loaded": self.loaded,
+            "runtime_running": self.running,
+        }
+        optional_fields = {
+            "runtime_host": self.host,
+            "memory_usage_bytes": self.memory_usage_bytes,
+            "memory_usage_human": self.memory_usage_human,
+            "gpu_allocation": self.gpu_allocation,
+            "uptime_seconds": self.uptime_seconds,
+            "uptime_human": self.uptime_human,
+            "runtime_message": self.runtime_message,
+            "runtime_details": self.details or None,
+        }
+        for key, value in optional_fields.items():
+            if value is not None:
+                data[key] = value
+        return data
+
+
+def format_bytes(value: int | float | None) -> str | None:
+    """Format a byte count using binary units."""
+    if value is None:
+        return None
+    num = float(value)
+    if num < 0:
+        return None
+
+    units = ["B", "KB", "MB", "GB", "TB", "PB"]
+    unit_index = 0
+    while num >= 1024 and unit_index < len(units) - 1:
+        num /= 1024
+        unit_index += 1
+
+    if unit_index == 0:
+        return f"{int(num)} {units[unit_index]}"
+    return f"{num:.1f} {units[unit_index]}"

--- a/server/services/runtime_service/providers/base.py
+++ b/server/services/runtime_service/providers/base.py
@@ -142,3 +142,26 @@ def format_bytes(value: int | float | None) -> str | None:
     if unit_index == 0:
         return f"{int(num)} {units[unit_index]}"
     return f"{num:.1f} {units[unit_index]}"
+
+
+def format_duration(seconds: int | float | None) -> str | None:
+    """Render a duration in a short human-readable form (e.g. 45s, 12m, 2h 5m)."""
+    if seconds is None:
+        return None
+    total = int(seconds)
+    if total < 0:
+        return None
+    if total < 60:
+        return f"{total}s"
+    minutes, _ = divmod(total, 60)
+    if minutes < 60:
+        return f"{minutes}m"
+    hours, rem_minutes = divmod(minutes, 60)
+    if hours < 24:
+        if rem_minutes == 0:
+            return f"{hours}h"
+        return f"{hours}h {rem_minutes}m"
+    days, rem_hours = divmod(hours, 24)
+    if rem_hours == 0:
+        return f"{days}d"
+    return f"{days}d {rem_hours}h"

--- a/server/services/runtime_service/providers/base.py
+++ b/server/services/runtime_service/providers/base.py
@@ -145,7 +145,10 @@ def format_bytes(value: int | float | None) -> str | None:
 
 
 def format_duration(seconds: int | float | None) -> str | None:
-    """Render a duration in a short human-readable form (e.g. 45s, 12m, 2h 5m)."""
+    """Render a duration in a short human-readable form.
+
+    Examples: 45s, 12m, 2h 5m, 1d 3h.
+    """
     if seconds is None:
         return None
     total = int(seconds)

--- a/server/services/runtime_service/providers/lemonade_provider.py
+++ b/server/services/runtime_service/providers/lemonade_provider.py
@@ -1,6 +1,7 @@
 """Lemonade runtime provider implementation."""
 
 import time
+from collections.abc import Iterable
 
 import requests
 
@@ -8,7 +9,7 @@ from agents.base.clients.client import LFAgentClient
 from agents.base.clients.openai import LFAgentClientOpenAI
 from core.settings import settings
 
-from .base import RuntimeProvider
+from .base import RuntimeModelStatus, RuntimeProvider
 from .health import HealthCheckResult
 
 
@@ -91,3 +92,62 @@ class LemonadeProvider(RuntimeProvider):
                 latency_ms=int(time.time() * 1000) - start,
                 details={"host": base},
             )
+
+    def get_model_runtime_status(self) -> RuntimeModelStatus:
+        """Get runtime status for the configured Lemonade model."""
+        base = self._base_url.replace("/api/v1", "")
+        model_name = self._model_config.model
+
+        try:
+            resp = requests.get(f"{base}/api/v1/models", timeout=1.5)
+            if not 200 <= resp.status_code < 300:
+                return RuntimeModelStatus(
+                    status="unreachable",
+                    host=base,
+                    runtime_message=f"{base} returned HTTP {resp.status_code}",
+                )
+
+            models = resp.json().get("data", [])
+            loaded = _find_named_model(models, model_name) is not None
+            return RuntimeModelStatus(
+                status="loaded" if loaded else "idle",
+                host=base,
+                loaded=loaded,
+                runtime_message=(
+                    "Model is loaded in Lemonade"
+                    if loaded
+                    else "Runtime reachable; model not reported as loaded"
+                ),
+            )
+        except requests.exceptions.Timeout:
+            return RuntimeModelStatus(
+                status="unreachable",
+                host=base,
+                runtime_message=f"Timeout connecting to {base}",
+            )
+        except Exception as e:
+            return RuntimeModelStatus(
+                status="unreachable",
+                host=base,
+                runtime_message=f"Error: {str(e)}",
+            )
+
+
+def _candidate_model_names(name: str) -> set[str]:
+    candidates = {name}
+    if ":" in name:
+        base, tag = name.rsplit(":", 1)
+        if tag == "latest":
+            candidates.add(base)
+    else:
+        candidates.add(f"{name}:latest")
+    return candidates
+
+
+def _find_named_model(models: Iterable[dict], configured_name: str) -> dict | None:
+    candidates = _candidate_model_names(configured_name)
+    for model in models:
+        model_id = model.get("id")
+        if isinstance(model_id, str) and model_id in candidates:
+            return model
+    return None

--- a/server/services/runtime_service/providers/ollama_provider.py
+++ b/server/services/runtime_service/providers/ollama_provider.py
@@ -1,6 +1,7 @@
 """Ollama runtime provider implementation."""
 
 import time
+from collections.abc import Iterable
 
 import requests
 
@@ -8,7 +9,7 @@ from agents.base.clients.client import LFAgentClient
 from agents.base.clients.ollama import LFAgentClientOllama
 from core.settings import settings
 
-from .base import RuntimeProvider
+from .base import RuntimeModelStatus, RuntimeProvider, format_bytes
 from .health import HealthCheckResult
 
 
@@ -86,3 +87,108 @@ class OllamaProvider(RuntimeProvider):
                 latency_ms=int(time.time() * 1000) - start,
                 details={"host": base},
             )
+
+    def get_model_runtime_status(self) -> RuntimeModelStatus:
+        """Get runtime status for the configured Ollama model."""
+        base = self._base_url.replace("/v1", "")
+        model_name = self._model_config.model
+
+        try:
+            ps_resp = requests.get(f"{base}/api/ps", timeout=1.5)
+            if 200 <= ps_resp.status_code < 300:
+                running_models = ps_resp.json().get("models", [])
+                match = _find_named_model(running_models, model_name)
+                if match:
+                    gpu_bytes = _coerce_int(match.get("size_vram"))
+                    memory_bytes = gpu_bytes or _coerce_int(match.get("size"))
+                    details = match.get("details", {})
+                    status_details = {}
+                    if isinstance(details, dict):
+                        if details.get("parameter_size"):
+                            status_details["parameter_size"] = details["parameter_size"]
+                        if details.get("quantization_level"):
+                            status_details["quantization_level"] = details[
+                                "quantization_level"
+                            ]
+                    if match.get("expires_at"):
+                        status_details["expires_at"] = match["expires_at"]
+
+                    return RuntimeModelStatus(
+                        status="running",
+                        host=base,
+                        loaded=True,
+                        running=True,
+                        memory_usage_bytes=memory_bytes,
+                        memory_usage_human=format_bytes(memory_bytes),
+                        gpu_allocation=(
+                            format_bytes(gpu_bytes) if gpu_bytes and gpu_bytes > 0 else None
+                        ),
+                        runtime_message="Model is currently loaded in Ollama",
+                        details=status_details,
+                    )
+
+            tags_resp = requests.get(f"{base}/api/tags", timeout=1.5)
+            if 200 <= tags_resp.status_code < 300:
+                installed_models = tags_resp.json().get("models", [])
+                installed = _find_named_model(installed_models, model_name)
+                if installed:
+                    return RuntimeModelStatus(
+                        status="idle",
+                        host=base,
+                        runtime_message="Model is installed in Ollama but not currently loaded",
+                    )
+                return RuntimeModelStatus(
+                    status="missing",
+                    host=base,
+                    runtime_message="Configured model is not installed in Ollama",
+                )
+
+            return RuntimeModelStatus(
+                status="unreachable",
+                host=base,
+                runtime_message=f"Ollama returned HTTP {tags_resp.status_code}",
+            )
+        except requests.exceptions.Timeout:
+            return RuntimeModelStatus(
+                status="unreachable",
+                host=base,
+                runtime_message=f"Timeout connecting to {base}",
+            )
+        except Exception as e:
+            return RuntimeModelStatus(
+                status="unreachable",
+                host=base,
+                runtime_message=f"Error: {str(e)}",
+            )
+
+
+def _candidate_model_names(name: str) -> set[str]:
+    candidates = {name}
+    if ":" in name:
+        base, tag = name.rsplit(":", 1)
+        if tag == "latest":
+            candidates.add(base)
+        else:
+            candidates.add(f"{name}:latest")
+    else:
+        candidates.add(f"{name}:latest")
+    return candidates
+
+
+def _find_named_model(models: Iterable[dict], configured_name: str) -> dict | None:
+    candidates = _candidate_model_names(configured_name)
+    for model in models:
+        name = model.get("name")
+        if isinstance(name, str) and name in candidates:
+            return model
+    return None
+
+
+def _coerce_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    return None

--- a/server/services/runtime_service/providers/ollama_provider.py
+++ b/server/services/runtime_service/providers/ollama_provider.py
@@ -100,7 +100,11 @@ class OllamaProvider(RuntimeProvider):
                 match = _find_named_model(running_models, model_name)
                 if match:
                     gpu_bytes = _coerce_int(match.get("size_vram"))
-                    memory_bytes = gpu_bytes or _coerce_int(match.get("size"))
+                    # size is total model memory; size_vram is the GPU portion.
+                    # Report total as memory_usage and VRAM separately as gpu_allocation.
+                    memory_bytes = (
+                        _coerce_int(match.get("size")) or gpu_bytes
+                    )
                     details = match.get("details", {})
                     status_details = {}
                     if isinstance(details, dict):
@@ -121,7 +125,9 @@ class OllamaProvider(RuntimeProvider):
                         memory_usage_bytes=memory_bytes,
                         memory_usage_human=format_bytes(memory_bytes),
                         gpu_allocation=(
-                            format_bytes(gpu_bytes) if gpu_bytes and gpu_bytes > 0 else None
+                            format_bytes(gpu_bytes)
+                            if gpu_bytes and gpu_bytes > 0
+                            else None
                         ),
                         runtime_message="Model is currently loaded in Ollama",
                         details=status_details,

--- a/server/services/runtime_service/providers/universal_provider.py
+++ b/server/services/runtime_service/providers/universal_provider.py
@@ -33,13 +33,23 @@ from api.errors import NotFoundError
 from core.logging import FastAPIStructLogger
 from core.settings import settings
 
-from .base import CachedModel, RuntimeProvider
+from .base import CachedModel, RuntimeModelStatus, RuntimeProvider, format_bytes
 from .health import HealthCheckResult
 
 logger = FastAPIStructLogger(__name__)
 
 # Chunk size for streaming downloads (1MB)
 DOWNLOAD_CHUNK_SIZE = 1024 * 1024
+
+
+def _coerce_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    return None
 
 
 def get_hf_token() -> str | None:
@@ -474,6 +484,87 @@ class UniversalProvider(RuntimeProvider):
                 message=f"Error: {str(e)}",
                 latency_ms=int(time.time() * 1000) - start,
                 details={"host": base, "error": str(e)},
+            )
+
+    def get_model_runtime_status(self) -> RuntimeModelStatus:
+        """Get runtime status for the configured Universal model."""
+        base = self._base_url.replace("/v1", "").rstrip("/")
+        model_name = self._model_config.model
+
+        try:
+            health_resp = requests.get(f"{base}/health", timeout=2.0)
+            if not 200 <= health_resp.status_code < 300:
+                return RuntimeModelStatus(
+                    status="unreachable",
+                    host=base,
+                    runtime_message=f"{base} returned HTTP {health_resp.status_code}",
+                )
+
+            health_data = health_resp.json()
+            loaded_models = health_data.get("loaded_models", [])
+            loaded = model_name in loaded_models
+
+            model_type = None
+            try:
+                models_resp = requests.get(f"{base}/v1/models", timeout=1.0)
+                if 200 <= models_resp.status_code < 300:
+                    for entry in models_resp.json().get("data", []):
+                        if entry.get("id") == model_name:
+                            model_type = entry.get("type")
+                            break
+            except Exception:
+                model_type = None
+
+            device_info = health_data.get("device", {})
+            if not isinstance(device_info, dict):
+                device_info = {"device": device_info}
+
+            device_type = (
+                device_info.get("type")
+                or device_info.get("device")
+                or "unknown"
+            )
+            gpu_name = device_info.get("gpu_name")
+            memory_bytes = None
+            if loaded and len(loaded_models) == 1:
+                memory_bytes = _coerce_int(device_info.get("gpu_memory_allocated"))
+
+            details = {}
+            if model_type:
+                details["type"] = model_type
+            if health_data.get("pid") is not None:
+                details["pid"] = health_data["pid"]
+
+            return RuntimeModelStatus(
+                status="loaded" if loaded else "idle",
+                host=base,
+                loaded=loaded,
+                running=False,
+                memory_usage_bytes=memory_bytes,
+                memory_usage_human=format_bytes(memory_bytes),
+                gpu_allocation=(
+                    str(gpu_name or device_type)
+                    if device_type in {"cuda", "mps"}
+                    else None
+                ),
+                runtime_message=(
+                    "Model is loaded in Universal Runtime"
+                    if loaded
+                    else "Model is configured but not currently loaded"
+                ),
+                details=details,
+            )
+        except requests.exceptions.Timeout:
+            return RuntimeModelStatus(
+                status="unreachable",
+                host=base,
+                runtime_message=f"Timeout connecting to {base}",
+            )
+        except Exception as e:
+            return RuntimeModelStatus(
+                status="unreachable",
+                host=base,
+                runtime_message=f"Error: {str(e)}",
             )
 
     @staticmethod

--- a/server/tests/test_model_service_runtime_status.py
+++ b/server/tests/test_model_service_runtime_status.py
@@ -2,15 +2,23 @@
 
 from types import SimpleNamespace
 
-from server.services.model_service import ModelService
+from server.services.model_service import ModelService, _reset_uptime_tracker
 from server.services.runtime_service.providers.base import RuntimeModelStatus
 
 
-def test_list_model_runtime_statuses_collects_provider_data(mocker):
-    model = SimpleNamespace(name="fast", provider=SimpleNamespace(value="ollama"))
-    project_config = SimpleNamespace(
-        runtime=SimpleNamespace(models=[model], default_model="fast")
+def _project_config_with(*models):
+    return SimpleNamespace(
+        runtime=SimpleNamespace(
+            models=list(models),
+            default_model=models[0].name if models else None,
+        )
     )
+
+
+def test_list_model_runtime_statuses_collects_provider_data(mocker):
+    _reset_uptime_tracker()
+    model = SimpleNamespace(name="fast", provider=SimpleNamespace(value="ollama"))
+    project_config = _project_config_with(model)
 
     provider = mocker.Mock()
     provider.get_model_runtime_status.return_value = RuntimeModelStatus(
@@ -28,25 +36,24 @@ def test_list_model_runtime_statuses_collects_provider_data(mocker):
 
     statuses = ModelService.list_model_runtime_statuses(project_config)
 
-    assert statuses == {
-        "fast": {
-            "runtime_status": "running",
-            "runtime_loaded": True,
-            "runtime_running": True,
-            "runtime_host": "http://localhost:11434",
-            "memory_usage_human": "4.2 GB",
-            "gpu_allocation": "3.8 GB",
-        }
-    }
+    status = statuses["fast"]
+    assert status["runtime_status"] == "running"
+    assert status["runtime_loaded"] is True
+    assert status["runtime_running"] is True
+    assert status["runtime_host"] == "http://localhost:11434"
+    assert status["memory_usage_human"] == "4.2 GB"
+    assert status["gpu_allocation"] == "3.8 GB"
+    # The service enriches the first sighting with an uptime of zero.
+    assert status["uptime_seconds"] == 0
+    assert status["uptime_human"] == "0s"
 
 
 def test_list_model_runtime_statuses_returns_unknown_on_provider_failure(mocker):
+    _reset_uptime_tracker()
     model = SimpleNamespace(
         name="powerful", provider=SimpleNamespace(value="universal")
     )
-    project_config = SimpleNamespace(
-        runtime=SimpleNamespace(models=[model], default_model="powerful")
-    )
+    project_config = _project_config_with(model)
 
     mocker.patch(
         "server.services.model_service.runtime_service.get_provider",
@@ -59,3 +66,109 @@ def test_list_model_runtime_statuses_returns_unknown_on_provider_failure(mocker)
     assert statuses["powerful"]["runtime_loaded"] is False
     assert statuses["powerful"]["runtime_running"] is False
     assert "boom" in statuses["powerful"]["runtime_message"]
+    assert "uptime_seconds" not in statuses["powerful"]
+
+
+def test_list_model_runtime_statuses_accumulates_uptime(mocker):
+    _reset_uptime_tracker()
+    model = SimpleNamespace(name="fast", provider=SimpleNamespace(value="ollama"))
+    project_config = _project_config_with(model)
+
+    def _fresh_status(*_args, **_kwargs):
+        return RuntimeModelStatus(
+            status="running",
+            host="http://localhost:11434",
+            loaded=True,
+            running=True,
+        )
+
+    provider = mocker.Mock()
+    provider.get_model_runtime_status.side_effect = _fresh_status
+    mocker.patch(
+        "server.services.model_service.runtime_service.get_provider",
+        return_value=provider,
+    )
+
+    monotonic_values = iter([100.0, 175.0])
+    mocker.patch(
+        "server.services.model_service.time.monotonic",
+        side_effect=lambda: next(monotonic_values),
+    )
+
+    first = ModelService.list_model_runtime_statuses(project_config)
+    second = ModelService.list_model_runtime_statuses(project_config)
+
+    assert first["fast"]["uptime_seconds"] == 0
+    assert second["fast"]["uptime_seconds"] == 75
+    assert second["fast"]["uptime_human"] == "1m"
+
+
+def test_list_model_runtime_statuses_resets_uptime_when_model_unloads(mocker):
+    _reset_uptime_tracker()
+    model = SimpleNamespace(name="fast", provider=SimpleNamespace(value="ollama"))
+    project_config = _project_config_with(model)
+
+    loaded = RuntimeModelStatus(
+        status="running",
+        host="http://localhost:11434",
+        loaded=True,
+        running=True,
+    )
+    idle = RuntimeModelStatus(
+        status="idle",
+        host="http://localhost:11434",
+        loaded=False,
+        running=False,
+    )
+    reloaded = RuntimeModelStatus(
+        status="running",
+        host="http://localhost:11434",
+        loaded=True,
+        running=True,
+    )
+    provider = mocker.Mock()
+    provider.get_model_runtime_status.side_effect = [loaded, idle, reloaded]
+    mocker.patch(
+        "server.services.model_service.runtime_service.get_provider",
+        return_value=provider,
+    )
+
+    monotonic_values = iter([10.0, 70.0, 200.0, 220.0])
+    mocker.patch(
+        "server.services.model_service.time.monotonic",
+        side_effect=lambda: next(monotonic_values),
+    )
+
+    first = ModelService.list_model_runtime_statuses(project_config)
+    second = ModelService.list_model_runtime_statuses(project_config)
+    third = ModelService.list_model_runtime_statuses(project_config)
+
+    assert first["fast"]["uptime_seconds"] == 0
+    assert "uptime_seconds" not in second["fast"]
+    # After a reload the counter starts over from the new first-seen timestamp.
+    assert third["fast"]["uptime_seconds"] == 0
+
+
+def test_list_model_runtime_statuses_preserves_provider_uptime(mocker):
+    _reset_uptime_tracker()
+    model = SimpleNamespace(name="fast", provider=SimpleNamespace(value="ollama"))
+    project_config = _project_config_with(model)
+
+    provider = mocker.Mock()
+    provider.get_model_runtime_status.return_value = RuntimeModelStatus(
+        status="running",
+        host="http://localhost:11434",
+        loaded=True,
+        running=True,
+        uptime_seconds=3723,
+        uptime_human="1h 2m",
+    )
+    mocker.patch(
+        "server.services.model_service.runtime_service.get_provider",
+        return_value=provider,
+    )
+
+    statuses = ModelService.list_model_runtime_statuses(project_config)
+
+    assert statuses["fast"]["uptime_seconds"] == 3723
+    assert statuses["fast"]["uptime_human"] == "1h 2m"

--- a/server/tests/test_model_service_runtime_status.py
+++ b/server/tests/test_model_service_runtime_status.py
@@ -1,0 +1,61 @@
+"""Tests for project model runtime status collection."""
+
+from types import SimpleNamespace
+
+from server.services.model_service import ModelService
+from server.services.runtime_service.providers.base import RuntimeModelStatus
+
+
+def test_list_model_runtime_statuses_collects_provider_data(mocker):
+    model = SimpleNamespace(name="fast", provider=SimpleNamespace(value="ollama"))
+    project_config = SimpleNamespace(
+        runtime=SimpleNamespace(models=[model], default_model="fast")
+    )
+
+    provider = mocker.Mock()
+    provider.get_model_runtime_status.return_value = RuntimeModelStatus(
+        status="running",
+        host="http://localhost:11434",
+        loaded=True,
+        running=True,
+        memory_usage_human="4.2 GB",
+        gpu_allocation="3.8 GB",
+    )
+    mocker.patch(
+        "server.services.model_service.runtime_service.get_provider",
+        return_value=provider,
+    )
+
+    statuses = ModelService.list_model_runtime_statuses(project_config)
+
+    assert statuses == {
+        "fast": {
+            "runtime_status": "running",
+            "runtime_loaded": True,
+            "runtime_running": True,
+            "runtime_host": "http://localhost:11434",
+            "memory_usage_human": "4.2 GB",
+            "gpu_allocation": "3.8 GB",
+        }
+    }
+
+
+def test_list_model_runtime_statuses_returns_unknown_on_provider_failure(mocker):
+    model = SimpleNamespace(
+        name="powerful", provider=SimpleNamespace(value="universal")
+    )
+    project_config = SimpleNamespace(
+        runtime=SimpleNamespace(models=[model], default_model="powerful")
+    )
+
+    mocker.patch(
+        "server.services.model_service.runtime_service.get_provider",
+        side_effect=RuntimeError("boom"),
+    )
+
+    statuses = ModelService.list_model_runtime_statuses(project_config)
+
+    assert statuses["powerful"]["runtime_status"] == "unknown"
+    assert statuses["powerful"]["runtime_loaded"] is False
+    assert statuses["powerful"]["runtime_running"] is False
+    assert "boom" in statuses["powerful"]["runtime_message"]

--- a/server/tests/test_runtime_provider_helpers.py
+++ b/server/tests/test_runtime_provider_helpers.py
@@ -1,0 +1,41 @@
+"""Tests for formatting helpers used by runtime providers."""
+
+import pytest
+
+from server.services.runtime_service.providers.base import (
+    format_bytes,
+    format_duration,
+)
+
+
+@pytest.mark.parametrize(
+    "seconds,expected",
+    [
+        (None, None),
+        (-1, None),
+        (0, "0s"),
+        (45, "45s"),
+        (60, "1m"),
+        (119, "1m"),
+        (3600, "1h"),
+        (3723, "1h 2m"),
+        (86400, "1d"),
+        (90061, "1d 1h"),
+    ],
+)
+def test_format_duration(seconds, expected):
+    assert format_duration(seconds) == expected
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (None, None),
+        (-1, None),
+        (0, "0 B"),
+        (1024, "1.0 KB"),
+        (1024 * 1024 * 3, "3.0 MB"),
+    ],
+)
+def test_format_bytes(value, expected):
+    assert format_bytes(value) == expected


### PR DESCRIPTION
## Summary

Implements [#798](https://github.com/llama-farm/llamafarm/issues/798) — a CLI command that displays real-time information about currently loaded and running models.

- **`lf models list`** now shows runtime status, memory usage, GPU allocation, and uptime for each configured model
- Uptime is tracked server-side from the first moment a provider reports a model as loaded; it resets on unload or server restart
- All three providers covered: **Ollama** (`/api/ps` + `/api/tags`), **Lemonade** (`/api/v1/models`), **Universal Runtime** (`/health` + `/v1/models`)
- Server API (`GET /v1/projects/{ns}/{id}/models`) extended with 9 runtime fields
- `format_duration()` helper added alongside the existing `format_bytes()` utility

## What the output looks like

\`\`\`
Models for default/my-project:

  • fast (default)
    Fast local model
    Provider: ollama | Model: gemma3:1b
    Status: running | Memory: 4.2 GB | GPU: 3.8 GB | Uptime: 12m
\`\`\`

## Changes

| Area | File |
|---|---|
| CLI display | `cli/cmd/models.go`, `cli/cmd/models_shared.go` |
| Server API | `server/api/routers/projects/projects.py` |
| Model service | `server/services/model_service.py` |
| Provider base | `server/services/runtime_service/providers/base.py` |
| Ollama provider | `server/services/runtime_service/providers/ollama_provider.py` |
| Lemonade provider | `server/services/runtime_service/providers/lemonade_provider.py` |
| Universal provider | `server/services/runtime_service/providers/universal_provider.py` |
| Tests | `server/tests/test_model_service_runtime_status.py`, `server/tests/test_runtime_provider_helpers.py`, `cli/cmd/models_test.go` |
| Docs | `docs/website/docs/cli/lf-models.md` |

## Test plan

- [x] `go test ./cli/cmd/...` — all packages green
- [x] `pytest server/tests/test_model_service_runtime_status.py server/tests/test_runtime_provider_helpers.py` — 20 passed
- [x] `pytest server/tests/test_models_endpoint.py` — 10 passed

---

**### > I'd love to join the LlamaFarm team — submitting this PR as part of the application process. Feel free to reach out through comments or email me on luvpatel2001@gmail.com!**