### PR TITLE
chore(edge): instrument startup path for SIGSEGV diagnosis

### DIFF
--- a/runtimes/edge/server.py
+++ b/runtimes/edge/server.py
@@ -426,33 +426,56 @@ async def lifespan(app: FastAPI):
 
     # Emit the single-line offline-mode status so operators can verify
     # LLAMAFARM_OFFLINE / LLAMAFARM_MODEL_DIR are being honored.
+    logger.info("startup-step BEGIN: offline-mode-log")
     _offline_mode_bootstrap.log_startup_mode()
+    logger.info("startup-step END: offline-mode-log")
 
+    logger.info("startup-step BEGIN: model-cleanup-task-spawn")
     _cleanup_task = asyncio.create_task(_cleanup_idle_models())
+    logger.info("startup-step END: model-cleanup-task-spawn")
 
     # Start KV cache manager
+    logger.info("startup-step BEGIN: kv-cache-imports")
     from utils.kv_cache_manager import (
         KVCacheManager,
         start_kv_cache_gc,
         stop_kv_cache_gc,
     )
+    logger.info("startup-step END: kv-cache-imports")
+
     global _kv_cache_manager
+    logger.info("startup-step BEGIN: kv-cache-manager-init")
     _kv_cache_manager = KVCacheManager()
+    logger.info("startup-step END: kv-cache-manager-init")
+
+    logger.info("startup-step BEGIN: kv-cache-router-wiring")
     from routers.cache import set_cache_language_loader, set_cache_manager
     set_cache_manager(_kv_cache_manager)
     set_cache_language_loader(load_language)
     ChatCompletionsService.set_cache_manager(_kv_cache_manager)
-    start_kv_cache_gc(_kv_cache_manager)
+    logger.info("startup-step END: kv-cache-router-wiring")
 
+    logger.info("startup-step BEGIN: kv-cache-gc-start")
+    start_kv_cache_gc(_kv_cache_manager)
+    logger.info("startup-step END: kv-cache-gc-start")
+
+    logger.info("startup-step BEGIN: session-cleanup-start")
     start_session_cleanup()
+    logger.info("startup-step END: session-cleanup-start")
 
     # Start Zenoh IPC interface (non-blocking — falls back to HTTP-only on failure)
+    logger.info("startup-step BEGIN: zenoh-ipc-init")
     _zenoh_ipc = ZenohIPC(inference_fn=_zenoh_inference)
+    logger.info("startup-step END: zenoh-ipc-init")
+
+    logger.info("startup-step BEGIN: zenoh-ipc-start")
     await _zenoh_ipc.start()
+    logger.info("startup-step END: zenoh-ipc-start")
 
     # Preload and pin models if configured
     preload_csv = os.getenv("PRELOAD_MODELS", "").strip()
     if preload_csv:
+        logger.info("startup-step BEGIN: preload-models-loop")
         preload_n_ctx_str = os.getenv("PRELOAD_N_CTX", "").strip()
         preload_n_ctx = None
         if preload_n_ctx_str:
@@ -468,16 +491,21 @@ async def lifespan(app: FastAPI):
             if not model_id:
                 continue
             try:
+                logger.info(f"startup-step BEGIN: preload:{model_id}")
                 await load_language(model_id, n_ctx=preload_n_ctx, trusted=True)
+                logger.info(f"startup-step END: preload:{model_id}")
                 # Construct the same cache key load_language() uses
                 cache_key = (
                     f"language:{model_id}:ctx{preload_n_ctx or 'auto'}:"
                     f"gpuauto:quantdefault"
                 )
+                logger.info(f"startup-step BEGIN: pin:{model_id}")
                 _models.pin(cache_key)
                 logger.info(f"Preloaded and pinned model: {model_id} ({cache_key})")
+                logger.info(f"startup-step END: pin:{model_id}")
             except Exception as e:
                 logger.warning(f"Failed to preload model '{model_id}': {e}")
+        logger.info("startup-step END: preload-models-loop")
 
     yield
 

--- a/runtimes/edge/services/zenoh_ipc.py
+++ b/runtimes/edge/services/zenoh_ipc.py
@@ -59,6 +59,7 @@ class ZenohIPC:
             logger.info("Zenoh IPC disabled (ZENOH_ENABLED=false)")
             return False
 
+        logger.info("startup-step BEGIN: %s", "zenoh-import")
         try:
             import zenoh
         except ImportError:
@@ -66,17 +67,22 @@ class ZenohIPC:
                 "eclipse-zenoh package not installed, Zenoh IPC unavailable"
             )
             return False
+        logger.info("startup-step END: %s", "zenoh-import")
 
         try:
+            logger.info("startup-step BEGIN: %s", "zenoh-config")
             config = zenoh.Config()
             config.insert_json5(
                 "connect/endpoints",
                 json.dumps([ZENOH_ENDPOINT]),
             )
             config.insert_json5("scouting/multicast/enabled", "false")
+            logger.info("startup-step END: %s", "zenoh-config")
 
+            logger.info("startup-step BEGIN: %s", "zenoh-session-open")
             self._session = zenoh.open(config)
             logger.info("Zenoh session open (endpoint=%s)", ZENOH_ENDPOINT)
+            logger.info("startup-step END: %s", "zenoh-session-open")
         except Exception:
             logger.warning(
                 "Failed to connect to Zenoh at %s — continuing HTTP-only",
@@ -86,11 +92,16 @@ class ZenohIPC:
             return False
 
         self._loop = asyncio.get_event_loop()
+        logger.info("startup-step BEGIN: %s", "zenoh-subscriber-declare")
         self._subscriber = self._session.declare_subscriber(
             TOPIC_REQUEST, self._on_request
         )
         logger.info("Subscribed to %s", TOPIC_REQUEST)
+        logger.info("startup-step END: %s", "zenoh-subscriber-declare")
+
+        logger.info("startup-step BEGIN: %s", "zenoh-heartbeat-spawn")
         self._tasks.append(asyncio.create_task(self._heartbeat_loop()))
+        logger.info("startup-step END: %s", "zenoh-heartbeat-spawn")
         return True
 
     async def stop(self):


### PR DESCRIPTION
## Summary

Adds INFO-level `startup-step BEGIN: <name>` / `startup-step END: <name>` log lines around each discrete step in the edge-runtime startup chain, so the next post-warmup SIGSEGV crash-loop pins the failing component to a specific log line.

**Logging only.** No production logic, error handling, log levels, imports, or dependencies changed. Trivially reverts once the bug is pinned.

## Why

Edge-runtime SIGSEGVs after warmup completes, retries 1–14 times before one boot succeeds. The crash happens between `Warmup completed in NNN ms` and `Application startup complete.` — a region with very few existing log lines. There is currently no signal as to which step in the lifespan/Zenoh-init chain is faulting. After this lands, the operator can `grep 'startup-step '` the next cascade and identify the last `BEGIN` without a matching `END`.

## Steps instrumented

**`runtimes/edge/server.py::lifespan`** (11 step pairs):
- `offline-mode-log`
- `model-cleanup-task-spawn`
- `kv-cache-imports` (silent step — no existing log)
- `kv-cache-manager-init` (silent step)
- `kv-cache-router-wiring` (silent step)
- `kv-cache-gc-start`
- `session-cleanup-start`
- `zenoh-ipc-init`
- `zenoh-ipc-start`
- `preload-models-loop`
- `preload:<model_id>` and `pin:<model_id>` per preloaded model

**`runtimes/edge/services/zenoh_ipc.py::start`** (5 step pairs):
- `zenoh-import`
- `zenoh-config`
- `zenoh-session-open` (top crash candidate)
- `zenoh-subscriber-declare` (closest equivalent to the queryable-registration crash candidate — this codebase has no `declare_queryable`, only `declare_subscriber`)
- `zenoh-heartbeat-spawn`

## Notes

- The three KV-cache steps (`kv-cache-imports`, `kv-cache-manager-init`, `kv-cache-router-wiring`) had no existing log lines on the healthy-boot reference sequence. They're silent today, so they're prime crash-site candidates per the "instrument the steps with no signal" guideline.
- Existing `try/except` blocks in `ZenohIPC.start` are untouched — if a wrapped step inside one of them raises, its `END` line correctly does not fire, which is the intended signal.
- No `declare_queryable` exists in the edge runtime today; subscriber registration was instrumented as the closest equivalent.

## Sample log excerpt — local healthy boot

Built with `docker build -f runtimes/edge/Dockerfile --build-arg ENABLE_VISION=false -t edge-runtime-lite:debug-startup .` and run with `docker run --rm -p 11540:11540 -e LLAMAFARM_OFFLINE=1 --name edge-debug edge-runtime-lite:debug-startup`.

All 14 instrumented BEGIN/END pairs fire in order, every BEGIN has a matching END, and existing log lines (`Zenoh session open ...`, `Subscribed to local/llm/request`, `Status heartbeat started`, `Model cleanup task started`) appear correctly interleaved inside their wrappers:

```
2026-04-27T19:29:40.523864Z [info     ] startup-step BEGIN: offline-mode-log [edge-runtime]
2026-04-27T19:29:40.523934Z [info     ] llamafarm_offline_mode         [llamafarm_common.offline_mode] hf_hub_offline=1 mode=offline model_dir=None transformers_offline=1
2026-04-27T19:29:40.523999Z [info     ] startup-step END: offline-mode-log [edge-runtime]
2026-04-27T19:29:40.524049Z [info     ] startup-step BEGIN: model-cleanup-task-spawn [edge-runtime]
2026-04-27T19:29:40.524196Z [info     ] startup-step END: model-cleanup-task-spawn [edge-runtime]
2026-04-27T19:29:40.524294Z [info     ] startup-step BEGIN: kv-cache-imports [edge-runtime]
2026-04-27T19:29:40.530261Z [info     ] startup-step END: kv-cache-imports [edge-runtime]
2026-04-27T19:29:40.530348Z [info     ] startup-step BEGIN: kv-cache-manager-init [edge-runtime]
2026-04-27T19:29:40.530598Z [info     ] startup-step END: kv-cache-manager-init [edge-runtime]
2026-04-27T19:29:40.530666Z [info     ] startup-step BEGIN: kv-cache-router-wiring [edge-runtime]
2026-04-27T19:29:40.537341Z [info     ] startup-step END: kv-cache-router-wiring [edge-runtime]
2026-04-27T19:29:40.537460Z [info     ] startup-step BEGIN: kv-cache-gc-start [edge-runtime]
2026-04-27T19:29:40.537516Z [info     ] startup-step END: kv-cache-gc-start [edge-runtime]
2026-04-27T19:29:40.537598Z [info     ] startup-step BEGIN: session-cleanup-start [edge-runtime]
2026-04-27T19:29:40.537682Z [info     ] startup-step END: session-cleanup-start [edge-runtime]
2026-04-27T19:29:40.537743Z [info     ] startup-step BEGIN: zenoh-ipc-init [edge-runtime]
2026-04-27T19:29:40.537839Z [info     ] startup-step END: zenoh-ipc-init [edge-runtime]
2026-04-27T19:29:40.537927Z [info     ] startup-step BEGIN: zenoh-ipc-start [edge-runtime]
2026-04-27T19:29:40.538049Z [info     ] startup-step BEGIN: zenoh-import [edge-runtime.zenoh]
2026-04-27T19:29:40.557056Z [info     ] startup-step END: zenoh-import [edge-runtime.zenoh]
2026-04-27T19:29:40.557149Z [info     ] startup-step BEGIN: zenoh-config [edge-runtime.zenoh]
2026-04-27T19:29:40.571645Z [info     ] startup-step END: zenoh-config [edge-runtime.zenoh]
2026-04-27T19:29:40.571761Z [info     ] startup-step BEGIN: zenoh-session-open [edge-runtime.zenoh]
2026-04-27T19:29:41.090002Z [info     ] Zenoh session open (endpoint=unixsock-stream//run/arc/zenoh.sock) [edge-runtime.zenoh]
2026-04-27T19:29:41.090296Z [info     ] startup-step END: zenoh-session-open [edge-runtime.zenoh]
2026-04-27T19:29:41.090521Z [info     ] startup-step BEGIN: zenoh-subscriber-declare [edge-runtime.zenoh]
2026-04-27T19:29:41.098659Z [info     ] Subscribed to local/llm/request [edge-runtime.zenoh]
2026-04-27T19:29:41.098755Z [info     ] startup-step END: zenoh-subscriber-declare [edge-runtime.zenoh]
2026-04-27T19:29:41.098789Z [info     ] startup-step BEGIN: zenoh-heartbeat-spawn [edge-runtime.zenoh]
2026-04-27T19:29:41.098860Z [info     ] startup-step END: zenoh-heartbeat-spawn [edge-runtime.zenoh]
2026-04-27T19:29:41.098913Z [info     ] startup-step END: zenoh-ipc-start [edge-runtime]
2026-04-27T19:29:41.099098Z [info     ] Model cleanup task started (timeout=300s, check_interval=30s) [edge-runtime]
2026-04-27T19:29:41.099413Z [info     ] Status heartbeat started (interval=5.0s, topic=local/llm/status) [edge-runtime.zenoh]
2026-04-27T19:29:41.099833Z [info     ] Application startup complete.  [uvicorn]
2026-04-27T19:29:41.102236Z [info     ] Uvicorn running on http://0.0.0.0:11540 (Press CTRL+C to quit) [uvicorn]
```

**Notable timings** (useful for reading the next cascade):
- `zenoh-session-open` is the slowest step at ~520 ms — top crash candidate
- `kv-cache-imports` and `kv-cache-router-wiring` each take ~7 ms — silent before, now have signal
- Everything else completes in <1 ms

The `preload-models-loop` block did not fire because `PRELOAD_MODELS` was unset — that path is exercised by adding `-e PRELOAD_MODELS=<model> -v <gguf_dir>:/models:ro` to the docker run.

## Test plan

- [x] `docker build -f runtimes/edge/Dockerfile --build-arg ENABLE_VISION=false -t edge-runtime-lite:debug-startup .` succeeds
- [x] Container runs and reaches `Application startup complete.` on Mac arm64
- [x] All 14 BEGIN/END pairs fire in the documented healthy-boot order
- [x] Every `BEGIN` has a matching `END` in a healthy boot
- [x] Existing log lines (`Zenoh session open ...`, `Subscribed to ...`, etc.) appear correctly interleaved
- [x] Server listens on 11540
- [ ] Real reproduction happens on the next Pi deploy — operator looks for the last `BEGIN` with no matching `END` to identify the crash site