### PR TITLE
feat(cli,runtime): bundle llama.cpp binaries in release artifacts

### DIFF
--- a/.claude/rules/llama_cpp_bindings.md
+++ b/.claude/rules/llama_cpp_bindings.md
@@ -39,6 +39,23 @@ rg 'b\d{4,5}' --type go --type py llama-cpp-version.txt
 
 The CI workflow `.github/workflows/build-llama.yml` reads from `llama-cpp-version.txt` directly and does not need a manual update.
 
+## Bundled binaries
+
+Release packaging now stages the pinned `llama.cpp` binary into two deterministic bundle layouts:
+
+- CLI archives: `llama-cpp/<os>-<arch>/<binary-name>`
+- Python/PyApp bundles: `packages/llamafarm-llama/src/llamafarm_llama/_bundled/<os>-<arch>/<binary-name>`
+
+When the pin changes, verify the staging workflows still fetch the matching upstream artifacts for:
+
+- `darwin-arm64`
+- `darwin-x86_64`
+- `linux-x86_64`
+- `linux-arm64` via LlamaFarm's own `build-llama.yml` release asset
+- `windows-x86_64`
+
+CPU-only bundles ship first. GPU-specific bundled variants remain a follow-up.
+
 ## How to bump
 
 ### 1. Pick a target tag

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -38,14 +38,17 @@ jobs:
             goarch: arm64
             output: llamafarm-darwin-arm64
             bundle_platform: darwin-arm64
-          - goos: darwin
-            goarch: amd64
-            output: llamafarm-darwin-amd64
-            bundle_platform: darwin-x86_64
           - goos: windows
             goarch: amd64
             output: llamafarm-windows-amd64.exe
             bundle_platform: windows-x86_64
+          # windows-arm64: no upstream llama.cpp prebuilt for this combo, so we
+          # ship the CLI without a bundled runtime. First-run falls through to
+          # the existing download path.
+          - goos: windows
+            goarch: arm64
+            output: llamafarm-windows-arm64.exe
+            bundle_platform: ""
 
     steps:
       - name: Checkout code
@@ -126,12 +129,14 @@ jobs:
           go build -ldflags "-s -w -X 'github.com/llamafarm/cli/internal/buildinfo.CurrentVersion=${VERSION}'" -o ../dist/${{ matrix.output }} .
 
       - name: Stage bundled llama.cpp binary
+        if: matrix.bundle_platform != ''
         run: |
           python3 scripts/stage_llama_bundle.py \
             --platform ${{ matrix.bundle_platform }} \
             --destination-root dist/llama-cpp
 
       - name: Package CLI release archive
+        if: matrix.bundle_platform != ''
         run: |
           python3 scripts/package_cli_bundle.py \
             --binary dist/${{ matrix.output }} \
@@ -147,6 +152,7 @@ jobs:
           retention-days: 1
 
       - name: Upload CLI archive artifact
+        if: matrix.bundle_platform != ''
         uses: actions/upload-artifact@v4
         with:
           name: lf-${{ matrix.bundle_platform }}-archive

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -29,18 +29,23 @@ jobs:
           - goos: linux
             goarch: amd64
             output: llamafarm-linux-amd64
+            bundle_platform: linux-x86_64
           - goos: linux
             goarch: arm64
             output: llamafarm-linux-arm64
+            bundle_platform: linux-arm64
           - goos: darwin
             goarch: arm64
             output: llamafarm-darwin-arm64
+            bundle_platform: darwin-arm64
+          - goos: darwin
+            goarch: amd64
+            output: llamafarm-darwin-amd64
+            bundle_platform: darwin-x86_64
           - goos: windows
             goarch: amd64
             output: llamafarm-windows-amd64.exe
-          - goos: windows
-            goarch: arm64
-            output: llamafarm-windows-arm64.exe
+            bundle_platform: windows-x86_64
 
     steps:
       - name: Checkout code
@@ -120,11 +125,33 @@ jobs:
           # Build with version info (schema compilation and type generation already done by generate-types)
           go build -ldflags "-s -w -X 'github.com/llamafarm/cli/internal/buildinfo.CurrentVersion=${VERSION}'" -o ../dist/${{ matrix.output }} .
 
+      - name: Stage bundled llama.cpp binary
+        run: |
+          python3 scripts/stage_llama_bundle.py \
+            --platform ${{ matrix.bundle_platform }} \
+            --destination-root dist/llama-cpp
+
+      - name: Package CLI release archive
+        run: |
+          python3 scripts/package_cli_bundle.py \
+            --binary dist/${{ matrix.output }} \
+            --platform ${{ matrix.bundle_platform }} \
+            --llama-root dist/llama-cpp \
+            --output-dir dist
+
       - name: Upload CLI artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.output }}
           path: dist/${{ matrix.output }}
+          retention-days: 1
+
+      - name: Upload CLI archive artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: lf-${{ matrix.bundle_platform }}-archive
+          path: |
+            dist/lf-${{ matrix.bundle_platform }}*
           retention-days: 1
 
       # Upload PR metadata for e2e.yml to reference (only once, on first matrix entry)
@@ -166,7 +193,7 @@ jobs:
       - name: Create checksums
         run: |
           cd dist/
-          find . -maxdepth 1 -type f ! -name checksums.txt -exec sha256sum {} \; > checksums.txt
+          find . -maxdepth 1 -type f ! -name checksums.txt ! -name '*.sha256' -exec sha256sum {} \; > checksums.txt
           cat checksums.txt
 
       - name: Upload checksums

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -852,16 +852,52 @@ jobs:
           LLAMA_VERSION=$(cat llama-cpp-version.txt | tr -d '\r\n')
           LIB_PATH="$LLAMA_CACHE/$LLAMA_VERSION/$LIB_NAME"
 
-          echo "Expected binary location: $LIB_PATH"
+          echo "Expected cache location: $LIB_PATH"
           echo ""
           echo "Cache directory contents:"
           ls -la "$LLAMA_CACHE/$LLAMA_VERSION/" 2>/dev/null || echo "Cache directory does not exist"
           echo ""
 
-          # Check if binary exists (could be a file or symlink)
+          # Resolution policy after the bundled-binaries change: the runtime
+          # may resolve llama.cpp from a bundled location packaged inside
+          # PyApp (llamafarm_llama/_bundled/<platform>/<lib>) instead of the
+          # download cache. We accept either: cache hit first (legacy),
+          # otherwise search bundled locations under common roots.
           if [ ! -e "$LIB_PATH" ]; then
-            echo "❌ llama.cpp binary not found at $LIB_PATH"
-            exit 1
+            echo "Cache miss, searching bundled locations..."
+            SEARCH_ROOTS=()
+            if [ "$RUNNER_OS" = "Windows" ]; then
+              SEARCH_ROOTS+=("$(cygpath -u "$LOCALAPPDATA")")
+              SEARCH_ROOTS+=("$(cygpath -u "${APPDATA:-$HOME}")")
+            fi
+            SEARCH_ROOTS+=("$HOME/.cache" "$HOME/.local")
+            if [ "$RUNNER_OS" = "macOS" ]; then
+              SEARCH_ROOTS+=("$HOME/Library/Application Support" "$HOME/Library/Caches")
+            fi
+            SEARCH_ROOTS+=("$HOME/.llamafarm")
+
+            BUNDLED_PATH=""
+            for root in "${SEARCH_ROOTS[@]}"; do
+              [ -d "$root" ] || continue
+              found=$(find "$root" -path "*llamafarm_llama/_bundled/*/$LIB_NAME" -type f 2>/dev/null | head -n 1)
+              if [ -n "$found" ]; then
+                BUNDLED_PATH="$found"
+                break
+              fi
+            done
+
+            if [ -z "$BUNDLED_PATH" ]; then
+              echo "❌ llama.cpp binary not found in cache or bundled locations"
+              echo "Searched roots:"
+              printf '  %s\n' "${SEARCH_ROOTS[@]}"
+              exit 1
+            fi
+
+            echo "✓ Found bundled binary: $BUNDLED_PATH"
+            LIB_PATH="$BUNDLED_PATH"
+            # Re-target the per-OS dependency checks at the bundled directory.
+            LLAMA_CACHE="$(dirname "$(dirname "$BUNDLED_PATH")")"
+            LLAMA_VERSION="$(basename "$(dirname "$BUNDLED_PATH")")"
           fi
 
           # Check if it's a symlink and follow it

--- a/.github/workflows/pyapp.yml
+++ b/.github/workflows/pyapp.yml
@@ -55,7 +55,6 @@ jobs:
             {"os":"linux-x86_64","runner":"ubuntu-latest","bundle_platform":"linux-x86_64"},
             {"os":"linux-arm64","runner":"ubuntu-24.04-arm","bundle_platform":"linux-arm64"},
             {"os":"macos-arm64","runner":"macos-latest","bundle_platform":"darwin-arm64"},
-            {"os":"macos-x86_64","runner":"macos-13","bundle_platform":"darwin-x86_64"},
             {"os":"windows-x86_64","runner":"windows-latest","bundle_platform":"windows-x86_64"}
           ]'
 
@@ -225,15 +224,9 @@ jobs:
             component: runtime
           - os: macos-arm64
             component: server
-          - os: macos-x86_64
-            component: server
           - os: macos-arm64
             component: rag
-          - os: macos-x86_64
-            component: rag
           - os: macos-arm64
-            component: runtime
-          - os: macos-x86_64
             component: runtime
           - os: windows-x86_64
             component: server

--- a/.github/workflows/pyapp.yml
+++ b/.github/workflows/pyapp.yml
@@ -52,10 +52,11 @@ jobs:
         shell: bash
         run: |
           ALL_PLATFORMS='[
-            {"os":"linux-x86_64","runner":"ubuntu-latest"},
-            {"os":"linux-arm64","runner":"ubuntu-24.04-arm"},
-            {"os":"macos-arm64","runner":"macos-latest"},
-            {"os":"windows-x86_64","runner":"windows-latest"}
+            {"os":"linux-x86_64","runner":"ubuntu-latest","bundle_platform":"linux-x86_64"},
+            {"os":"linux-arm64","runner":"ubuntu-24.04-arm","bundle_platform":"linux-arm64"},
+            {"os":"macos-arm64","runner":"macos-latest","bundle_platform":"darwin-arm64"},
+            {"os":"macos-x86_64","runner":"macos-13","bundle_platform":"darwin-x86_64"},
+            {"os":"windows-x86_64","runner":"windows-latest","bundle_platform":"windows-x86_64"}
           ]'
 
           COMPONENT="${{ github.event.inputs.component }}"
@@ -77,7 +78,7 @@ jobs:
             --argjson components "$COMPONENTS" \
             '{include: [
               $platforms[] as $p | $components[] as $c |
-              {os: $p.os, runner: $p.runner, component: $c}
+              {os: $p.os, runner: $p.runner, component: $c, bundle_platform: $p.bundle_platform}
             ]}')
 
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
@@ -138,6 +139,13 @@ jobs:
             exit 1
           fi
           echo "✓ Designer built successfully"
+
+      - name: Stage bundled llama.cpp binary
+        shell: bash
+        run: |
+          python scripts/stage_llama_bundle.py \
+            --platform ${{ matrix.bundle_platform }} \
+            --destination-root packages/llamafarm-llama/src/llamafarm_llama/_bundled
 
       - name: Build with PyApp
         run: |
@@ -217,9 +225,15 @@ jobs:
             component: runtime
           - os: macos-arm64
             component: server
+          - os: macos-x86_64
+            component: server
           - os: macos-arm64
             component: rag
+          - os: macos-x86_64
+            component: rag
           - os: macos-arm64
+            component: runtime
+          - os: macos-x86_64
             component: runtime
           - os: windows-x86_64
             component: server

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -34,9 +34,6 @@ jobs:
           - goos: darwin
             goarch: arm64
             bundle_platform: darwin-arm64
-          - goos: darwin
-            goarch: amd64
-            bundle_platform: darwin-x86_64
           - goos: windows
             goarch: amd64
             bundle_platform: windows-x86_64
@@ -111,6 +108,35 @@ jobs:
           echo "SHA256: $(cat ${BINARY_NAME}.sha256)"
           echo "binary_name=${BINARY_NAME}" >> $GITHUB_OUTPUT
 
+      - name: Sign and Notarize macOS binary
+        if: matrix.goos == 'darwin'
+        run: |
+          curl -sSfL https://get.anchore.io/quill | sudo sh -s -- -b /usr/local/bin
+          QUILL_SIGN_PASSWORD=${{ secrets.APPLE_CERT_PASSWORD }} quill sign-and-notarize cli/${{ steps.build.outputs.binary_name }} \
+            --p12 ${{ secrets.APPLE_CERT_DATA }} \
+            --notary-key-id ${{ secrets.APPLE_NOTARY_KEY_ID }} \
+            --notary-key ${{ secrets.APPLE_NOTARY_KEY }} \
+            --notary-issuer ${{ secrets.APPLE_NOTARY_ISSUER }} \
+            --verbose
+
+          # Re-SHA the binary since it was signed
+          sha256sum "cli/${{ steps.build.outputs.binary_name }}" > "cli/${{ steps.build.outputs.binary_name }}.sha256"
+          echo "SHA256: $(cat "cli/${{ steps.build.outputs.binary_name }}.sha256")"
+
+      - name: Stage bundled llama.cpp binary
+        run: |
+          python3 scripts/stage_llama_bundle.py \
+            --platform ${{ matrix.bundle_platform }} \
+            --destination-root cli/llama-cpp
+
+      - name: Package CLI release archive
+        run: |
+          python3 scripts/package_cli_bundle.py \
+            --binary cli/${{ steps.build.outputs.binary_name }} \
+            --platform ${{ matrix.bundle_platform }} \
+            --llama-root cli/llama-cpp \
+            --output-dir cli
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -118,6 +144,7 @@ jobs:
           path: |
             cli/${{ steps.build.outputs.binary_name }}
             cli/${{ steps.build.outputs.binary_name }}.sha256
+            cli/lf-${{ matrix.bundle_platform }}*
 
   # For each build, run the release upload as a separate job, pulling the built artifact from the previous job.
 
@@ -137,17 +164,11 @@ jobs:
           - goos: darwin
             goarch: arm64
             bundle_platform: darwin-arm64
-          - goos: darwin
-            goarch: amd64
-            bundle_platform: darwin-x86_64
           - goos: windows
             goarch: amd64
             bundle_platform: windows-x86_64
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
       - name: Get version
         id: version
         run: |
@@ -165,40 +186,11 @@ jobs:
           fi
           echo "binary_name=${BINARY_NAME}" >> $GITHUB_OUTPUT
 
-      - name: Download built binary artifact
+      - name: Download built artifacts
         uses: actions/download-artifact@v4
         with:
           name: "${{ steps.set-binary-name.outputs.binary_name }}"
           path: cli/
-
-      - name: Sign and Notarize macOS binary
-        if: matrix.goos == 'darwin'
-        run: |
-          curl -sSfL https://get.anchore.io/quill | sudo sh -s -- -b /usr/local/bin
-          QUILL_SIGN_PASSWORD=${{ secrets.APPLE_CERT_PASSWORD }} quill sign-and-notarize cli/${{ steps.set-binary-name.outputs.binary_name }} \
-            --p12 ${{ secrets.APPLE_CERT_DATA }} \
-            --notary-key-id ${{ secrets.APPLE_NOTARY_KEY_ID }} \
-            --notary-key ${{ secrets.APPLE_NOTARY_KEY }} \
-            --notary-issuer ${{ secrets.APPLE_NOTARY_ISSUER }} \
-            --verbose
-
-          # Re-SHA the binary since it was signed
-          sha256sum "cli/${{ steps.set-binary-name.outputs.binary_name }}" > "cli/${{ steps.set-binary-name.outputs.binary_name }}.sha256"
-          echo "SHA256: $(cat "cli/${{ steps.set-binary-name.outputs.binary_name }}.sha256")"
-
-      - name: Stage bundled llama.cpp binary
-        run: |
-          python3 scripts/stage_llama_bundle.py \
-            --platform ${{ matrix.bundle_platform }} \
-            --destination-root cli/llama-cpp
-
-      - name: Package CLI release archive
-        run: |
-          python3 scripts/package_cli_bundle.py \
-            --binary cli/${{ steps.set-binary-name.outputs.binary_name }} \
-            --platform ${{ matrix.bundle_platform }} \
-            --llama-root cli/llama-cpp \
-            --output-dir cli
 
       - name: Upload assets to the Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -24,11 +24,22 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        goos: [linux, darwin, windows]
-        goarch: [amd64, arm64]
-        exclude:
+        include:
+          - goos: linux
+            goarch: amd64
+            bundle_platform: linux-x86_64
+          - goos: linux
+            goarch: arm64
+            bundle_platform: linux-arm64
+          - goos: darwin
+            goarch: arm64
+            bundle_platform: darwin-arm64
           - goos: darwin
             goarch: amd64
+            bundle_platform: darwin-x86_64
+          - goos: windows
+            goarch: amd64
+            bundle_platform: windows-x86_64
 
     steps:
       - name: Checkout code
@@ -119,16 +130,24 @@ jobs:
         include:
           - goos: linux
             goarch: amd64
+            bundle_platform: linux-x86_64
           - goos: linux
             goarch: arm64
+            bundle_platform: linux-arm64
           - goos: darwin
             goarch: arm64
+            bundle_platform: darwin-arm64
+          - goos: darwin
+            goarch: amd64
+            bundle_platform: darwin-x86_64
           - goos: windows
             goarch: amd64
-          - goos: windows
-            goarch: arm64
+            bundle_platform: windows-x86_64
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
       - name: Get version
         id: version
         run: |
@@ -167,6 +186,20 @@ jobs:
           sha256sum "cli/${{ steps.set-binary-name.outputs.binary_name }}" > "cli/${{ steps.set-binary-name.outputs.binary_name }}.sha256"
           echo "SHA256: $(cat "cli/${{ steps.set-binary-name.outputs.binary_name }}.sha256")"
 
+      - name: Stage bundled llama.cpp binary
+        run: |
+          python3 scripts/stage_llama_bundle.py \
+            --platform ${{ matrix.bundle_platform }} \
+            --destination-root cli/llama-cpp
+
+      - name: Package CLI release archive
+        run: |
+          python3 scripts/package_cli_bundle.py \
+            --binary cli/${{ steps.set-binary-name.outputs.binary_name }} \
+            --platform ${{ matrix.bundle_platform }} \
+            --llama-root cli/llama-cpp \
+            --output-dir cli
+
       - name: Upload assets to the Release
         uses: softprops/action-gh-release@v2
         with:
@@ -174,6 +207,7 @@ jobs:
           files: |
             cli/${{ steps.set-binary-name.outputs.binary_name }}
             cli/${{ steps.set-binary-name.outputs.binary_name }}.sha256
+            cli/lf-${{ matrix.bundle_platform }}*
           fail_on_unmatched_files: true
           append_body: true
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -9,6 +9,11 @@ Recommended install instructions now live in the main README and docs site.
   ```
 - Windows: download `lf.exe` from the [latest release](https://github.com/llama-farm/llamafarm/releases/latest) and add it to your PATH.
 
+## Bundled binaries
+- CLI release archives now include a bundled `llama.cpp` runtime under `llama-cpp/<os>-<arch>/`, next to the `lf` executable.
+- PyApp bundles stage the same runtime inside `llamafarm_llama/_bundled/<os>-<arch>/`.
+- On first run, LlamaFarm checks those bundled paths before attempting any network download. CPU bundles ship first; GPU-specific bundle variants remain a TODO.
+
 For source builds and advanced usage, see:
 - `README.md` (Quickstart)
 - `docs/website/docs/cli/index.md` (CLI reference)

--- a/cli/internal/llamabinary/llamabinary.go
+++ b/cli/internal/llamabinary/llamabinary.go
@@ -404,11 +404,17 @@ func Download(ctx context.Context, t Target, version string) (Result, error) {
 	if bundledPath, ok := BundledBinaryPath(t); ok {
 		// Seed the cache from the bundle so downstream tooling that depends on
 		// the cache layout (Export, lf runtime binary pull --export, etc.)
-		// keeps working without special-casing the bundled scenario.
-		if err := os.MkdirAll(destDir, 0o755); err != nil {
-			return Result{}, fmt.Errorf("create dest dir: %w", err)
-		}
-		if err := copyDirContents(filepath.Dir(bundledPath), destDir); err != nil {
+		// keeps working without special-casing the bundled scenario. The seed
+		// happens via a sibling staging dir + atomic rename so a mid-copy
+		// failure can never leave a half-populated destDir for IsCached to
+		// observe as valid.
+		if err := seedCacheFromBundle(filepath.Dir(bundledPath), destDir); err != nil {
+			// Re-check IsCached: a concurrent invocation may have won the race
+			// and left a fully-populated cache while ours was still staging.
+			if IsCached(t, version) {
+				logf("cache populated by concurrent seed at %s", libPath)
+				return Result{LibPath: libPath, DestDir: destDir, Cached: true}, nil
+			}
 			return Result{}, fmt.Errorf("seed cache from bundle: %w", err)
 		}
 		logf("seeded cache from bundled llama.cpp at %s", bundledPath)
@@ -517,6 +523,52 @@ func Export(t Target, version string, destDir string) error {
 		return fmt.Errorf("create export dir: %w", err)
 	}
 	return copyDirContents(srcDir, destDir)
+}
+
+// seedCacheFromBundle atomically copies the contents of bundleDir into
+// destDir. The copy goes through a sibling staging directory and is renamed
+// into place only after every file lands successfully, so a partially-copied
+// state can never be observed by IsCached. Stale staging directories from
+// previous killed runs are cleaned up on entry.
+func seedCacheFromBundle(bundleDir, destDir string) error {
+	parentDir := filepath.Dir(destDir)
+	if err := os.MkdirAll(parentDir, 0o755); err != nil {
+		return fmt.Errorf("create parent dir: %w", err)
+	}
+
+	// Sweep stale staging dirs from prior crashed runs.
+	if entries, err := os.ReadDir(parentDir); err == nil {
+		basePrefix := filepath.Base(destDir) + ".seed-"
+		for _, entry := range entries {
+			if strings.HasPrefix(entry.Name(), basePrefix) {
+				_ = os.RemoveAll(filepath.Join(parentDir, entry.Name()))
+			}
+		}
+	}
+
+	stagingDir, err := os.MkdirTemp(parentDir, filepath.Base(destDir)+".seed-*")
+	if err != nil {
+		return fmt.Errorf("create staging dir: %w", err)
+	}
+	// Best-effort cleanup of the staging dir if we exit before rename succeeds.
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.RemoveAll(stagingDir)
+		}
+	}()
+
+	if err := copyDirContents(bundleDir, stagingDir); err != nil {
+		return err
+	}
+
+	if err := os.Rename(stagingDir, destDir); err != nil {
+		// destDir may already exist (rare race with a concurrent seed). Leave
+		// the cleanup deferred to remove our staging dir; caller decides.
+		return fmt.Errorf("publish cache dir: %w", err)
+	}
+	cleanup = false
+	return nil
 }
 
 // copyDirContents copies every regular file and symlink from srcDir into

--- a/cli/internal/llamabinary/llamabinary.go
+++ b/cli/internal/llamabinary/llamabinary.go
@@ -344,7 +344,15 @@ func bundlePlatformDir(t Target) string {
 // target if it exists. Bundles are staged as:
 //
 //	<exe-dir>/llama-cpp/<os>-<arch>/<binary-name>
+//
+// Bundles ship the platform-default accelerator only (metal on darwin/arm64,
+// CPU elsewhere). Requests for non-default accelerators (e.g. cuda) skip the
+// bundle and go through the download path so the caller gets the right
+// runtime, never a silent CPU fallback.
 func BundledBinaryPath(t Target) (string, bool) {
+	if t.Accelerator != BestAcceleratorFor(t.OS, t.Arch) {
+		return "", false
+	}
 	exePath, err := executablePath()
 	if err != nil {
 		logf("warning: determine executable path: %v", err)
@@ -394,12 +402,17 @@ func Download(ctx context.Context, t Target, version string) (Result, error) {
 		return Result{LibPath: libPath, DestDir: destDir, Cached: true}, nil
 	}
 	if bundledPath, ok := BundledBinaryPath(t); ok {
-		logf("using bundled llama.cpp binary at %s", bundledPath)
-		return Result{
-			LibPath: bundledPath,
-			DestDir: filepath.Dir(bundledPath),
-			Cached:  true,
-		}, nil
+		// Seed the cache from the bundle so downstream tooling that depends on
+		// the cache layout (Export, lf runtime binary pull --export, etc.)
+		// keeps working without special-casing the bundled scenario.
+		if err := os.MkdirAll(destDir, 0o755); err != nil {
+			return Result{}, fmt.Errorf("create dest dir: %w", err)
+		}
+		if err := copyDirContents(filepath.Dir(bundledPath), destDir); err != nil {
+			return Result{}, fmt.Errorf("seed cache from bundle: %w", err)
+		}
+		logf("seeded cache from bundled llama.cpp at %s", bundledPath)
+		return Result{LibPath: libPath, DestDir: destDir, Cached: true}, nil
 	}
 
 	spec, err := SpecFor(t, version)
@@ -503,14 +516,21 @@ func Export(t Target, version string, destDir string) error {
 	if err := os.MkdirAll(destDir, 0o755); err != nil {
 		return fmt.Errorf("create export dir: %w", err)
 	}
+	return copyDirContents(srcDir, destDir)
+}
+
+// copyDirContents copies every regular file and symlink from srcDir into
+// dstDir, preserving symlink targets. It does not recurse into subdirectories,
+// matching the flat layout used for both cache and export directories.
+func copyDirContents(srcDir, dstDir string) error {
 	entries, err := os.ReadDir(srcDir)
 	if err != nil {
-		return fmt.Errorf("read cache dir: %w", err)
+		return fmt.Errorf("read source dir: %w", err)
 	}
 	for _, entry := range entries {
 		name := entry.Name()
 		srcPath := filepath.Join(srcDir, name)
-		dstPath := filepath.Join(destDir, name)
+		dstPath := filepath.Join(dstDir, name)
 		info, err := os.Lstat(srcPath)
 		if err != nil {
 			return fmt.Errorf("lstat %s: %w", srcPath, err)
@@ -521,7 +541,6 @@ func Export(t Target, version string, destDir string) error {
 			if err != nil {
 				return fmt.Errorf("readlink %s: %w", srcPath, err)
 			}
-			// Remove any existing file at dstPath first.
 			os.Remove(dstPath)
 			if err := os.Symlink(target, dstPath); err != nil {
 				return fmt.Errorf("symlink %s: %w", dstPath, err)

--- a/cli/internal/llamabinary/llamabinary.go
+++ b/cli/internal/llamabinary/llamabinary.go
@@ -65,9 +65,9 @@ var ValidAccelerators = []string{"cpu", "cuda", "metal", "vulkan", "rocm"}
 
 // acceptArchAliases maps user-friendly arch names to canonical Go arch names.
 var acceptArchAliases = map[string]string{
-	"x86_64": "amd64",
-	"amd64":  "amd64",
-	"arm64":  "arm64",
+	"x86_64":  "amd64",
+	"amd64":   "amd64",
+	"arm64":   "arm64",
 	"aarch64": "arm64",
 }
 
@@ -322,6 +322,56 @@ func logf(format string, args ...any) {
 	}
 }
 
+var executablePath = os.Executable
+var evaluateSymlinks = filepath.EvalSymlinks
+
+func bundleArchName(arch string) string {
+	switch arch {
+	case "amd64":
+		return "x86_64"
+	default:
+		return arch
+	}
+}
+
+// TODO: extend the bundle path layout if we ever ship accelerator-specific
+// llama.cpp artifacts alongside the CPU-first bundles.
+func bundlePlatformDir(t Target) string {
+	return fmt.Sprintf("%s-%s", t.OS, bundleArchName(t.Arch))
+}
+
+// BundledBinaryPath returns the executable-adjacent bundled llama.cpp path for a
+// target if it exists. Bundles are staged as:
+//
+//	<exe-dir>/llama-cpp/<os>-<arch>/<binary-name>
+func BundledBinaryPath(t Target) (string, bool) {
+	exePath, err := executablePath()
+	if err != nil {
+		logf("warning: determine executable path: %v", err)
+		return "", false
+	}
+	if resolved, err := evaluateSymlinks(exePath); err == nil {
+		exePath = resolved
+	}
+	exePath, err = filepath.Abs(exePath)
+	if err != nil {
+		logf("warning: resolve executable path: %v", err)
+		return "", false
+	}
+
+	bundledPath := filepath.Join(
+		filepath.Dir(exePath),
+		"llama-cpp",
+		bundlePlatformDir(t),
+		LibNameFor(t.OS),
+	)
+	st, err := os.Stat(bundledPath)
+	if err != nil || st.IsDir() || st.Size() == 0 {
+		return "", false
+	}
+	return bundledPath, true
+}
+
 // Download ensures the llama.cpp binary for (target, version) is installed in its
 // platform-scoped cache directory. If the binary is already present, Download is a
 // no-op and returns Cached=true.
@@ -342,6 +392,14 @@ func Download(ctx context.Context, t Target, version string) (Result, error) {
 	if IsCached(t, version) {
 		logf("llama.cpp already cached at %s", libPath)
 		return Result{LibPath: libPath, DestDir: destDir, Cached: true}, nil
+	}
+	if bundledPath, ok := BundledBinaryPath(t); ok {
+		logf("using bundled llama.cpp binary at %s", bundledPath)
+		return Result{
+			LibPath: bundledPath,
+			DestDir: filepath.Dir(bundledPath),
+			Cached:  true,
+		}, nil
 	}
 
 	spec, err := SpecFor(t, version)

--- a/cli/internal/llamabinary/llamabinary_test.go
+++ b/cli/internal/llamabinary/llamabinary_test.go
@@ -1,6 +1,9 @@
 package llamabinary
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -228,6 +231,71 @@ func TestLibPath_ReturnsExpectedFile(t *testing.T) {
 	}
 	if !strings.HasSuffix(p, "libllama.dylib") {
 		t.Errorf("got %s", p)
+	}
+}
+
+func TestBundledBinaryPath_PrefersBundledOverDownload(t *testing.T) {
+	tmp := t.TempDir()
+	exePath := filepath.Join(tmp, "lf")
+	if err := os.WriteFile(exePath, []byte("stub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	target := Target{OS: "linux", Arch: "amd64", Accelerator: "cpu"}
+	bundledPath := filepath.Join(
+		tmp,
+		"llama-cpp",
+		"linux-x86_64",
+		LibNameFor(target.OS),
+	)
+	if err := os.MkdirAll(filepath.Dir(bundledPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(bundledPath, []byte("bundled"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	oldExecutablePath := executablePath
+	oldEvaluateSymlinks := evaluateSymlinks
+	executablePath = func() (string, error) { return exePath, nil }
+	evaluateSymlinks = func(path string) (string, error) { return path, nil }
+	t.Cleanup(func() {
+		executablePath = oldExecutablePath
+		evaluateSymlinks = oldEvaluateSymlinks
+	})
+
+	t.Setenv("LLAMAFARM_CACHE_DIR", filepath.Join(tmp, "cache"))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("unexpected HTTP request to %s", r.URL.String())
+	}))
+	defer srv.Close()
+
+	testVersion := "bTESTBUNDLE"
+	SetTestSpecForOverride(func(tt Target, v string) (Spec, error) {
+		if tt == target && v == testVersion {
+			return Spec{
+				URL:     srv.URL + "/llama.tar.gz",
+				LibPath: LibNameFor(target.OS),
+				LibName: LibNameFor(target.OS),
+			}, nil
+		}
+		return Spec{}, ErrSpecNotAvailable
+	})
+	defer SetTestSpecForOverride(nil)
+
+	res, err := Download(context.Background(), target, testVersion)
+	if err != nil {
+		t.Fatalf("Download: %v", err)
+	}
+	if !res.Cached {
+		t.Error("expected bundled hit to report Cached=true")
+	}
+	if res.LibPath != bundledPath {
+		t.Errorf("LibPath = %q, want %q", res.LibPath, bundledPath)
+	}
+	if res.DestDir != filepath.Dir(bundledPath) {
+		t.Errorf("DestDir = %q, want %q", res.DestDir, filepath.Dir(bundledPath))
 	}
 }
 

--- a/cli/internal/llamabinary/llamabinary_test.go
+++ b/cli/internal/llamabinary/llamabinary_test.go
@@ -242,16 +242,17 @@ func TestBundledBinaryPath_PrefersBundledOverDownload(t *testing.T) {
 	}
 
 	target := Target{OS: "linux", Arch: "amd64", Accelerator: "cpu"}
-	bundledPath := filepath.Join(
-		tmp,
-		"llama-cpp",
-		"linux-x86_64",
-		LibNameFor(target.OS),
-	)
-	if err := os.MkdirAll(filepath.Dir(bundledPath), 0o755); err != nil {
+	bundleDir := filepath.Join(tmp, "llama-cpp", "linux-x86_64")
+	bundledPath := filepath.Join(bundleDir, LibNameFor(target.OS))
+	if err := os.MkdirAll(bundleDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(bundledPath, []byte("bundled"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Drop a sidecar dependency to verify the seeder copies the whole dir.
+	depPath := filepath.Join(bundleDir, "libggml.so")
+	if err := os.WriteFile(depPath, []byte("dep"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 
@@ -264,7 +265,8 @@ func TestBundledBinaryPath_PrefersBundledOverDownload(t *testing.T) {
 		evaluateSymlinks = oldEvaluateSymlinks
 	})
 
-	t.Setenv("LLAMAFARM_CACHE_DIR", filepath.Join(tmp, "cache"))
+	cacheRoot := filepath.Join(tmp, "cache")
+	t.Setenv("LLAMAFARM_CACHE_DIR", cacheRoot)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatalf("unexpected HTTP request to %s", r.URL.String())
@@ -291,11 +293,63 @@ func TestBundledBinaryPath_PrefersBundledOverDownload(t *testing.T) {
 	if !res.Cached {
 		t.Error("expected bundled hit to report Cached=true")
 	}
-	if res.LibPath != bundledPath {
-		t.Errorf("LibPath = %q, want %q", res.LibPath, bundledPath)
+
+	// The bundle should have seeded the cache: LibPath points at cache, and
+	// the dependency file copies over too.
+	expectedCacheDir, err := CacheDir(target, testVersion)
+	if err != nil {
+		t.Fatalf("CacheDir: %v", err)
 	}
-	if res.DestDir != filepath.Dir(bundledPath) {
-		t.Errorf("DestDir = %q, want %q", res.DestDir, filepath.Dir(bundledPath))
+	expectedLib := filepath.Join(expectedCacheDir, LibNameFor(target.OS))
+	if res.LibPath != expectedLib {
+		t.Errorf("LibPath = %q, want %q", res.LibPath, expectedLib)
+	}
+	if res.DestDir != expectedCacheDir {
+		t.Errorf("DestDir = %q, want %q", res.DestDir, expectedCacheDir)
+	}
+	if data, err := os.ReadFile(expectedLib); err != nil || string(data) != "bundled" {
+		t.Errorf("seeded main lib mismatch: data=%q err=%v", data, err)
+	}
+	seededDep := filepath.Join(expectedCacheDir, "libggml.so")
+	if data, err := os.ReadFile(seededDep); err != nil || string(data) != "dep" {
+		t.Errorf("seeded dep mismatch: data=%q err=%v", data, err)
+	}
+	if !IsCached(target, testVersion) {
+		t.Error("expected IsCached=true after bundle seed")
+	}
+}
+
+func TestBundledBinaryPath_AcceleratorMismatchSkipsBundle(t *testing.T) {
+	tmp := t.TempDir()
+	exePath := filepath.Join(tmp, "lf")
+	if err := os.WriteFile(exePath, []byte("stub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	bundleDir := filepath.Join(tmp, "llama-cpp", "linux-x86_64")
+	if err := os.MkdirAll(bundleDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	bundledLib := filepath.Join(bundleDir, LibNameFor("linux"))
+	if err := os.WriteFile(bundledLib, []byte("bundled"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	oldExecutablePath := executablePath
+	oldEvaluateSymlinks := evaluateSymlinks
+	executablePath = func() (string, error) { return exePath, nil }
+	evaluateSymlinks = func(path string) (string, error) { return path, nil }
+	t.Cleanup(func() {
+		executablePath = oldExecutablePath
+		evaluateSymlinks = oldEvaluateSymlinks
+	})
+
+	cudaTarget := Target{OS: "linux", Arch: "amd64", Accelerator: "cuda"}
+	if _, ok := BundledBinaryPath(cudaTarget); ok {
+		t.Errorf("expected accelerator mismatch (cuda) to skip bundle, got hit")
+	}
+	cpuTarget := Target{OS: "linux", Arch: "amd64", Accelerator: "cpu"}
+	if _, ok := BundledBinaryPath(cpuTarget); !ok {
+		t.Errorf("expected default accelerator (cpu on linux/amd64) to hit bundle")
 	}
 }
 

--- a/cli/internal/llamabinary/llamabinary_test.go
+++ b/cli/internal/llamabinary/llamabinary_test.go
@@ -353,6 +353,93 @@ func TestBundledBinaryPath_AcceleratorMismatchSkipsBundle(t *testing.T) {
 	}
 }
 
+func TestBundledSeed_PartialCopyDoesNotPoisonCache(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("can't induce permission-denied copy failure as root")
+	}
+
+	tmp := t.TempDir()
+	exePath := filepath.Join(tmp, "lf")
+	if err := os.WriteFile(exePath, []byte("stub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	target := Target{OS: "linux", Arch: "amd64", Accelerator: "cpu"}
+	bundleDir := filepath.Join(tmp, "llama-cpp", "linux-x86_64")
+	if err := os.MkdirAll(bundleDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Lay out the bundle so the readable main lib sorts BEFORE the unreadable
+	// dep. os.ReadDir returns sorted entries, so the iteration order is:
+	//   1. libllama.so   (readable, written first into staging)
+	//   2. zzzz_unread.so (mode 0000 -> os.Open fails -> error returned)
+	// Without the atomic staging+rename, libllama.so would land directly in
+	// destDir and IsCached would lie. With it, destDir is never created.
+	mainLib := filepath.Join(bundleDir, LibNameFor(target.OS))
+	if err := os.WriteFile(mainLib, []byte("bundled-main"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	depPath := filepath.Join(bundleDir, "zzzz_unread.so")
+	if err := os.WriteFile(depPath, []byte("dep"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(depPath, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(depPath, 0o644) })
+
+	oldExecutablePath := executablePath
+	oldEvaluateSymlinks := evaluateSymlinks
+	executablePath = func() (string, error) { return exePath, nil }
+	evaluateSymlinks = func(path string) (string, error) { return path, nil }
+	t.Cleanup(func() {
+		executablePath = oldExecutablePath
+		evaluateSymlinks = oldEvaluateSymlinks
+	})
+
+	cacheRoot := filepath.Join(tmp, "cache")
+	t.Setenv("LLAMAFARM_CACHE_DIR", cacheRoot)
+
+	// Any HTTP request would mean we fell through to the download path; that's
+	// not what we're testing.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("unexpected HTTP request to %s", r.URL.String())
+	}))
+	defer srv.Close()
+	SetTestSpecForOverride(func(tt Target, v string) (Spec, error) {
+		return Spec{}, ErrSpecNotAvailable
+	})
+	defer SetTestSpecForOverride(nil)
+
+	testVersion := "bTESTPARTIAL"
+	if _, err := Download(context.Background(), target, testVersion); err == nil {
+		t.Fatal("expected Download to fail when bundle contains an unreadable file")
+	}
+
+	// Atomicity guarantees: the cache dir must not exist after a failed seed.
+	if IsCached(target, testVersion) {
+		t.Errorf("IsCached must be false after a failed seed (cache must not be poisoned)")
+	}
+	cacheDir, err := CacheDir(target, testVersion)
+	if err != nil {
+		t.Fatalf("CacheDir: %v", err)
+	}
+	if _, err := os.Stat(cacheDir); !os.IsNotExist(err) {
+		t.Errorf("expected cache dir to not exist; stat err=%v", err)
+	}
+
+	// And no leftover staging dirs from the failed attempt.
+	if entries, err := os.ReadDir(filepath.Dir(cacheDir)); err == nil {
+		stagingPrefix := filepath.Base(cacheDir) + ".seed-"
+		for _, e := range entries {
+			if strings.HasPrefix(e.Name(), stagingPrefix) {
+				t.Errorf("leftover staging dir not cleaned up: %s", e.Name())
+			}
+		}
+	}
+}
+
 func TestExport_RequiresCache(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("LLAMAFARM_CACHE_DIR", filepath.Join(tmp, "cache"))

--- a/cli/project.json
+++ b/cli/project.json
@@ -6,17 +6,19 @@
   "targets": {
     "build": {
       "executor": "nx:run-commands",
+      "dependsOn": [
+        "generate-types"
+      ],
       "options": {
         "cwd": "{workspaceRoot}",
         "commands": [
           "cd cli && go generate ./cmd/config",
           "cp -f addons/registry/*.yaml cli/cmd/registry/",
-          "cd cli && go build -ldflags=\"-X 'github.com/llamafarm/cli/internal/llamabinary.Version=$(cat ../llama-cpp-version.txt | tr -d '\\n')'\" -o ../dist/lf ."
+          "cd cli && go build -ldflags=\"-X 'github.com/llamafarm/cli/internal/llamabinary.Version=$(cat ../llama-cpp-version.txt | tr -d '\\n')'\" -o ../dist/lf .",
+          "python3 scripts/stage_llama_bundle.py --platform host --destination-root dist/llama-cpp",
+          "python3 scripts/package_cli_bundle.py --binary dist/lf --platform host --llama-root dist/llama-cpp --output-dir dist"
         ],
-        "parallel": false,
-        "dependsOn": [
-          "generate-types"
-        ]
+        "parallel": false
       }
     },
     "generate-types": {

--- a/packages/llamafarm-llama/pyproject.toml
+++ b/packages/llamafarm-llama/pyproject.toml
@@ -46,7 +46,7 @@ Repository = "https://github.com/llama-farm/llamafarm"
 where = ["src"]
 
 [tool.setuptools.package-data]
-llamafarm_llama = ["lib/*", "py.typed"]
+llamafarm_llama = ["_bundled/*/*", "lib/*", "py.typed"]
 
 [tool.ruff]
 line-length = 88

--- a/packages/llamafarm-llama/scripts/build_platform_wheel.py
+++ b/packages/llamafarm-llama/scripts/build_platform_wheel.py
@@ -18,15 +18,15 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 
 PLATFORM_MAP = {
-    "linux-x64-cpu": ("linux", "x86_64", "cpu"),
-    "linux-x64-cuda11": ("linux", "x86_64", "cuda11"),
-    "linux-x64-cuda12": ("linux", "x86_64", "cuda12"),
-    "linux-x64-vulkan": ("linux", "x86_64", "vulkan"),
-    "macos-arm64-metal": ("darwin", "arm64", "metal"),
-    "macos-x64-cpu": ("darwin", "x86_64", "cpu"),
-    "win-x64-cpu": ("win32", "amd64", "cpu"),
-    "win-x64-cuda12": ("win32", "amd64", "cuda12"),
-    "win-x64-vulkan": ("win32", "amd64", "vulkan"),
+    "linux-x64-cpu": (("linux", "x86_64", "cpu"), "linux-x86_64"),
+    "linux-x64-cuda11": (("linux", "x86_64", "cuda11"), "linux-x86_64"),
+    "linux-x64-cuda12": (("linux", "x86_64", "cuda12"), "linux-x86_64"),
+    "linux-x64-vulkan": (("linux", "x86_64", "vulkan"), "linux-x86_64"),
+    "macos-arm64-metal": (("darwin", "arm64", "metal"), "darwin-arm64"),
+    "macos-x64-cpu": (("darwin", "x86_64", "cpu"), "darwin-x86_64"),
+    "win-x64-cpu": (("win32", "amd64", "cpu"), "windows-x86_64"),
+    "win-x64-cuda12": (("win32", "amd64", "cuda12"), "windows-x86_64"),
+    "win-x64-vulkan": (("win32", "amd64", "vulkan"), "windows-x86_64"),
 }
 
 
@@ -39,20 +39,21 @@ def build_wheel(platform_str: str, output_dir: Path):
         print(f"Available: {', '.join(PLATFORM_MAP.keys())}")
         sys.exit(1)
 
-    platform_key = PLATFORM_MAP[platform_str]
+    platform_key, bundle_slug = PLATFORM_MAP[platform_str]
     print(f"Building wheel for {platform_key}")
 
-    # Get the lib directory
-    lib_dir = Path(__file__).parent.parent / "src" / "llamafarm_llama" / "lib"
-    lib_dir.mkdir(exist_ok=True)
+    bundled_root = Path(__file__).parent.parent / "src" / "llamafarm_llama" / "_bundled"
+    lib_dir = bundled_root / bundle_slug
+    lib_dir.mkdir(parents=True, exist_ok=True)
 
     # Clear any existing binaries
-    for f in lib_dir.glob("*"):
-        if f.name != ".gitkeep":
+    if bundled_root.exists():
+        for f in bundled_root.iterdir():
             if f.is_dir():
                 shutil.rmtree(f)
             else:
                 f.unlink()
+    lib_dir.mkdir(parents=True, exist_ok=True)
 
     # Download for target platform
     print(f"Downloading binary for {platform_str}...")
@@ -76,13 +77,9 @@ def build_wheel(platform_str: str, output_dir: Path):
     wheel_path = wheels[0]
     print(f"Built: {wheel_path}")
 
-    # Clean up lib directory
-    for f in lib_dir.glob("*"):
-        if f.name != ".gitkeep":
-            if f.is_dir():
-                shutil.rmtree(f)
-            else:
-                f.unlink()
+    # Clean up bundled directory
+    if bundled_root.exists():
+        shutil.rmtree(bundled_root)
 
     return wheel_path
 

--- a/packages/llamafarm-llama/src/llamafarm_llama/_binary.py
+++ b/packages/llamafarm-llama/src/llamafarm_llama/_binary.py
@@ -14,7 +14,6 @@ import subprocess
 import tarfile
 import tempfile
 import zipfile
-from importlib import metadata
 from pathlib import Path
 from typing import Optional
 from urllib.error import HTTPError, URLError
@@ -370,37 +369,65 @@ def get_lib_path() -> Path:
     it raises FileNotFoundError with a structured message pointing at
     `lf runtime binary pull`.
     """
-    # Check for bundled binary (platform wheel)
-    bundled = Path(__file__).parent / "lib" / _get_lib_name()
-    if bundled.exists():
-        logger.debug(f"Using bundled binary: {bundled}")
-        return bundled
-
-    # Check for cached download
     cache_dir = _get_cache_dir()
     cached = cache_dir / LLAMA_CPP_VERSION / _get_lib_name()
     if cached.exists():
         logger.debug(f"Using cached binary: {cached}")
         return cached
+    bundled = _bundled_binary_path()
+    if bundled.exists():
+        logger.debug(f"Using bundled binary: {bundled}")
+        return bundled
 
     # Strict offline mode: never attempt a download.
     if _is_offline():
-        _raise_offline_binary_error(tried=[bundled, cached])
+        _raise_offline_binary_error(tried=[cached, bundled])
 
     # Download
     logger.info(f"Downloading llama.cpp {LLAMA_CPP_VERSION}...")
     return download_binary(cache_dir / LLAMA_CPP_VERSION)
 
 
-def _get_lib_name() -> str:
-    """Get platform-specific library name."""
-    system = platform.system().lower()
+def _get_lib_name_for_system(system: str) -> str:
+    """Get platform-specific library name for a normalized system string."""
     if system == "darwin":
         return "libllama.dylib"
-    elif system == "windows":
+    if system in ("windows", "win32"):
         return "llama.dll"
-    else:
-        return "libllama.so"
+    return "libllama.so"
+
+
+def _get_lib_name() -> str:
+    """Get platform-specific library name."""
+    return _get_lib_name_for_system(platform.system().lower())
+
+
+def _bundled_platform_slug() -> str:
+    """Return the deterministic bundle directory slug for the current host."""
+    system = platform.system().lower()
+    if system == "windows":
+        system = "windows"
+
+    machine = platform.machine().lower()
+    if machine in ("x86_64", "amd64"):
+        machine = "x86_64"
+    elif machine in ("arm64", "aarch64"):
+        machine = "arm64"
+
+    return f"{system}-{machine}"
+
+
+def _bundled_binary_path() -> Path:
+    """Return the packaged bundled binary path for the current host."""
+    system = platform.system().lower()
+    if system == "windows":
+        system = "windows"
+    return (
+        Path(__file__).parent
+        / "_bundled"
+        / _bundled_platform_slug()
+        / _get_lib_name_for_system(system)
+    )
 
 
 def _safe_extract_zip(zip_path: Path, dest_dir: Path) -> None:
@@ -846,21 +873,18 @@ def get_binary_info() -> dict:
     """Get information about the current binary configuration."""
     platform_key = get_platform_key()
     lib_path = None
+    cache_dir = _get_cache_dir()
+    cached = cache_dir / LLAMA_CPP_VERSION / _get_lib_name()
+    bundled = _bundled_binary_path()
 
-    # Check bundled
-    bundled = Path(__file__).parent / "lib" / _get_lib_name()
-    if bundled.exists():
+    if cached.exists():
+        lib_path = cached
+        source = "cached"
+    elif bundled.exists():
         lib_path = bundled
         source = "bundled"
     else:
-        # Check cached
-        cache_dir = _get_cache_dir()
-        cached = cache_dir / LLAMA_CPP_VERSION / _get_lib_name()
-        if cached.exists():
-            lib_path = cached
-            source = "cached"
-        else:
-            source = "not_downloaded"
+        source = "not_downloaded"
 
     return {
         "version": LLAMA_CPP_VERSION,
@@ -868,6 +892,6 @@ def get_binary_info() -> dict:
         "lib_path": str(lib_path) if lib_path else None,
         "lib_name": _get_lib_name(),
         "source": source,
-        "cache_dir": str(_get_cache_dir()),
+        "cache_dir": str(cache_dir),
         "offline": _is_offline(),
     }

--- a/packages/llamafarm-llama/src/llamafarm_llama/_binary.py
+++ b/packages/llamafarm-llama/src/llamafarm_llama/_binary.py
@@ -369,19 +369,26 @@ def get_lib_path() -> Path:
     it raises FileNotFoundError with a structured message pointing at
     `lf runtime binary pull`.
     """
+    # Resolution order: bundled -> cached -> download.
+    #
+    # The bundled path is preferred over the cache so that a wheel upgrade
+    # which ships a rebuilt binary at the *same* LLAMA_CPP_VERSION (e.g. a
+    # build-flag fix) wins over a stale cached download from a previous
+    # session. A version bump would miss the cache anyway, so this only
+    # affects the same-pin rebuild case.
+    bundled = _bundled_binary_path()
+    if bundled.exists():
+        logger.debug(f"Using bundled binary: {bundled}")
+        return bundled
     cache_dir = _get_cache_dir()
     cached = cache_dir / LLAMA_CPP_VERSION / _get_lib_name()
     if cached.exists():
         logger.debug(f"Using cached binary: {cached}")
         return cached
-    bundled = _bundled_binary_path()
-    if bundled.exists():
-        logger.debug(f"Using bundled binary: {bundled}")
-        return bundled
 
     # Strict offline mode: never attempt a download.
     if _is_offline():
-        _raise_offline_binary_error(tried=[cached, bundled])
+        _raise_offline_binary_error(tried=[bundled, cached])
 
     # Download
     logger.info(f"Downloading llama.cpp {LLAMA_CPP_VERSION}...")
@@ -405,28 +412,21 @@ def _get_lib_name() -> str:
 def _bundled_platform_slug() -> str:
     """Return the deterministic bundle directory slug for the current host."""
     system = platform.system().lower()
-    if system == "windows":
-        system = "windows"
-
     machine = platform.machine().lower()
     if machine in ("x86_64", "amd64"):
         machine = "x86_64"
     elif machine in ("arm64", "aarch64"):
         machine = "arm64"
-
     return f"{system}-{machine}"
 
 
 def _bundled_binary_path() -> Path:
     """Return the packaged bundled binary path for the current host."""
-    system = platform.system().lower()
-    if system == "windows":
-        system = "windows"
     return (
         Path(__file__).parent
         / "_bundled"
         / _bundled_platform_slug()
-        / _get_lib_name_for_system(system)
+        / _get_lib_name_for_system(platform.system().lower())
     )
 
 
@@ -877,12 +877,13 @@ def get_binary_info() -> dict:
     cached = cache_dir / LLAMA_CPP_VERSION / _get_lib_name()
     bundled = _bundled_binary_path()
 
-    if cached.exists():
-        lib_path = cached
-        source = "cached"
-    elif bundled.exists():
+    # Match the resolution order in get_lib_path: bundled wins over cache.
+    if bundled.exists():
         lib_path = bundled
         source = "bundled"
+    elif cached.exists():
+        lib_path = cached
+        source = "cached"
     else:
         source = "not_downloaded"
 

--- a/packages/llamafarm-llama/src/llamafarm_llama/_binary.py
+++ b/packages/llamafarm-llama/src/llamafarm_llama/_binary.py
@@ -421,13 +421,41 @@ def _bundled_platform_slug() -> str:
 
 
 def _bundled_binary_path() -> Path:
-    """Return the packaged bundled binary path for the current host."""
-    return (
-        Path(__file__).parent
-        / "_bundled"
-        / _bundled_platform_slug()
-        / _get_lib_name_for_system(platform.system().lower())
-    )
+    """Return the packaged bundled binary path for the current host.
+
+    Returns a path that .exists() only when both the main library AND the
+    runtime-essential ggml dependencies (libggml-base, libggml-cpu, libggml)
+    are co-located. An incomplete bundle would cause libllama to load but
+    its dependencies to fail at backend registration time, leaving the
+    runtime in a broken state that's expensive to debug. By treating
+    incomplete bundles as absent, get_lib_path falls through to the cache
+    and download path — preserving pre-PR behavior whenever the shipped
+    bundle is missing a required dep.
+    """
+    bundled_dir = Path(__file__).parent / "_bundled" / _bundled_platform_slug()
+    system = platform.system().lower()
+    main_lib = bundled_dir / _get_lib_name_for_system(system)
+
+    if not main_lib.exists():
+        return main_lib
+
+    # macOS dylibs and Windows DLLs typically don't need a separate dep check
+    # at this layer (Mach-O has install_name + rpath; Windows DLL search is
+    # handled in _bindings.py). Linux is where missing ggml deps silently
+    # break backend registration, so gate strictly there.
+    if system == "linux":
+        required_globs = (
+            "libggml-base.so*",
+            "libggml-cpu.so*",
+            "libggml.so*",
+        )
+        for pattern in required_globs:
+            if not list(bundled_dir.glob(pattern)):
+                # Return a path inside the bundled dir that will not exist,
+                # so callers see .exists() == False and fall through.
+                return bundled_dir / "__incomplete_bundle__"
+
+    return main_lib
 
 
 def _safe_extract_zip(zip_path: Path, dest_dir: Path) -> None:

--- a/packages/llamafarm-llama/tests/test_binary_offline.py
+++ b/packages/llamafarm-llama/tests/test_binary_offline.py
@@ -10,7 +10,6 @@ These tests verify that:
   - Online-mode behavior is preserved when the env var is absent.
 """
 
-import os
 from pathlib import Path
 from unittest.mock import patch
 
@@ -30,11 +29,6 @@ def isolated_cache(tmp_path, monkeypatch):
     """Point the cache dir at a tmp directory and make bundled absent."""
     cache_root = tmp_path / "cache"
     monkeypatch.setenv("LLAMAFARM_CACHE_DIR", str(cache_root))
-
-    # Make sure the "bundled" path does not accidentally exist. The module
-    # computes it as <module_dir>/lib/<libname>, which is real on a dev
-    # install. We mock `get_lib_path`'s view of that file by patching
-    # Path.exists on the specific path.
     return cache_root
 
 
@@ -129,20 +123,10 @@ class TestGetLibPathOffline:
         cached_path = version_dir / lib_name
         cached_path.write_bytes(b"stub")
 
-        # Make bundled appear absent but let the real cache path resolve.
-        # Use os.sep so the check works on Windows (backslash) as well as
-        # POSIX (forward slash).
-        original_exists = Path.exists
-        bundled_marker = os.sep + "lib" + os.sep + lib_name
+        missing_bundled = tmp_path / "_bundled" / "linux-x86_64" / lib_name
+        monkeypatch.setattr(_binary, "_bundled_binary_path", lambda: missing_bundled)
 
-        def fake_exists(self):
-            if bundled_marker in str(self):
-                return False  # bundled absent
-            return original_exists(self)
-
-        with patch.object(Path, "exists", fake_exists), patch.object(
-            _binary, "download_binary"
-        ) as mock_dl:
+        with patch.object(_binary, "download_binary") as mock_dl:
             result = _binary.get_lib_path()
             mock_dl.assert_not_called()
 

--- a/packages/llamafarm-llama/tests/test_bundled_binary.py
+++ b/packages/llamafarm-llama/tests/test_bundled_binary.py
@@ -1,0 +1,39 @@
+"""Tests for bundled binary resolution."""
+
+from pathlib import Path
+from unittest.mock import Mock
+
+from llamafarm_llama import _binary
+
+
+def test_get_lib_path_returns_bundled_binary_without_download(tmp_path, monkeypatch):
+    cache_root = tmp_path / "cache"
+    bundled_path = tmp_path / "bundle" / "linux-x86_64" / "libllama.so"
+    bundled_path.parent.mkdir(parents=True, exist_ok=True)
+    bundled_path.write_bytes(b"bundled")
+
+    monkeypatch.setenv("LLAMAFARM_CACHE_DIR", str(cache_root))
+    monkeypatch.setattr(_binary, "_bundled_binary_path", lambda: bundled_path)
+    download_mock = Mock()
+    monkeypatch.setattr(_binary, "download_binary", download_mock)
+
+    result = _binary.get_lib_path()
+
+    assert result == bundled_path
+    download_mock.assert_not_called()
+
+
+def test_get_lib_path_falls_back_to_download_when_bundled_absent(tmp_path, monkeypatch):
+    cache_root = tmp_path / "cache"
+    missing_bundled = tmp_path / "bundle" / "linux-x86_64" / "libllama.so"
+    expected = Path("/tmp/downloaded/libllama.so")
+    download_mock = Mock(return_value=expected)
+
+    monkeypatch.setenv("LLAMAFARM_CACHE_DIR", str(cache_root))
+    monkeypatch.setattr(_binary, "_bundled_binary_path", lambda: missing_bundled)
+    monkeypatch.setattr(_binary, "download_binary", download_mock)
+
+    result = _binary.get_lib_path()
+
+    assert result == expected
+    download_mock.assert_called_once_with(cache_root / _binary.LLAMA_CPP_VERSION)

--- a/scripts/package_cli_bundle.py
+++ b/scripts/package_cli_bundle.py
@@ -40,7 +40,9 @@ def detect_host_platform() -> str:
 
     platform_slug = f"{system}-{machine}"
     if platform_slug not in SUPPORTED_PLATFORMS:
-        raise ValueError(f"unsupported host platform for CLI packaging: {platform_slug}")
+        raise ValueError(
+            f"unsupported host platform for CLI packaging: {platform_slug}"
+        )
     return platform_slug
 
 
@@ -135,15 +137,34 @@ def package_bundle(
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Package an lf release bundle")
-    parser.add_argument("--binary", required=True, type=Path, help="Path to the built CLI binary")
-    parser.add_argument("--platform", default="host", help="Target platform slug or 'host'")
+    parser.add_argument(
+        "--binary",
+        required=True,
+        type=Path,
+        help="Path to the built CLI binary",
+    )
+    parser.add_argument(
+        "--platform",
+        default="host",
+        help="Target platform slug or 'host'",
+    )
     parser.add_argument(
         "--llama-root",
         required=True,
         type=Path,
-        help="Root directory containing llama-cpp/<platform>/ staging",
+        help=(
+            "Directory containing one <platform>/ subdir per target. The "
+            "bundle for --platform foo is read from <llama-root>/foo/. "
+            "Typically the same value passed to "
+            "stage_llama_bundle.py --destination-root."
+        ),
     )
-    parser.add_argument("--output-dir", required=True, type=Path, help="Archive output directory")
+    parser.add_argument(
+        "--output-dir",
+        required=True,
+        type=Path,
+        help="Archive output directory",
+    )
     args = parser.parse_args()
 
     platform_slug = normalize_platform(args.platform)

--- a/scripts/package_cli_bundle.py
+++ b/scripts/package_cli_bundle.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Package an `lf` binary and bundled llama.cpp files into a release archive."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import platform
+import shutil
+import stat
+import tarfile
+import tempfile
+import zipfile
+from pathlib import Path
+
+SUPPORTED_PLATFORMS = {
+    "linux-x86_64",
+    "linux-arm64",
+    "darwin-arm64",
+    "darwin-x86_64",
+    "windows-x86_64",
+}
+
+
+def detect_host_platform() -> str:
+    system = platform.system().lower()
+    machine = platform.machine().lower()
+
+    if system == "windows":
+        system = "windows"
+    elif system not in ("linux", "darwin"):
+        raise ValueError(f"unsupported host OS for CLI packaging: {system}")
+
+    if machine in ("x86_64", "amd64"):
+        machine = "x86_64"
+    elif machine in ("arm64", "aarch64"):
+        machine = "arm64"
+    else:
+        raise ValueError(f"unsupported host architecture for CLI packaging: {machine}")
+
+    platform_slug = f"{system}-{machine}"
+    if platform_slug not in SUPPORTED_PLATFORMS:
+        raise ValueError(f"unsupported host platform for CLI packaging: {platform_slug}")
+    return platform_slug
+
+
+def normalize_platform(value: str) -> str:
+    if value == "host":
+        return detect_host_platform()
+    if value not in SUPPORTED_PLATFORMS:
+        raise ValueError(f"unsupported platform: {value}")
+    return value
+
+
+def archive_suffix(platform_slug: str) -> str:
+    if platform_slug.startswith("windows-"):
+        return ".zip"
+    return ".tar.gz"
+
+
+def default_binary_name(platform_slug: str) -> str:
+    if platform_slug.startswith("windows-"):
+        return "lf.exe"
+    return "lf"
+
+
+def resolve_binary_path(binary_path: Path, platform_slug: str) -> Path:
+    if binary_path.exists():
+        return binary_path
+    if platform_slug.startswith("windows-"):
+        exe_path = binary_path.with_suffix(".exe")
+        if exe_path.exists():
+            return exe_path
+    raise FileNotFoundError(f"CLI binary not found: {binary_path}")
+
+
+def write_zip_archive(stage_dir: Path, archive_path: Path) -> None:
+    with zipfile.ZipFile(archive_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for item in sorted(stage_dir.rglob("*")):
+            if item.is_dir():
+                continue
+            arcname = item.relative_to(stage_dir)
+            info = zipfile.ZipInfo.from_file(item, arcname)
+            if item.stat().st_mode & stat.S_IXUSR:
+                info.external_attr = 0o755 << 16
+            with item.open("rb") as src, zf.open(info, "w") as dst:
+                shutil.copyfileobj(src, dst)
+
+
+def write_tar_archive(stage_dir: Path, archive_path: Path) -> None:
+    with tarfile.open(archive_path, "w:gz") as tf:
+        for item in sorted(stage_dir.iterdir()):
+            tf.add(item, arcname=item.name, recursive=True)
+
+
+def write_sha256(path: Path) -> Path:
+    checksum = hashlib.sha256(path.read_bytes()).hexdigest()
+    checksum_path = path.with_suffix(path.suffix + ".sha256")
+    checksum_path.write_text(f"{checksum}  {path.name}\n")
+    return checksum_path
+
+
+def package_bundle(
+    binary_path: Path,
+    platform_slug: str,
+    llama_root: Path,
+    output_dir: Path,
+) -> tuple[Path, Path]:
+    binary_path = resolve_binary_path(binary_path.resolve(), platform_slug)
+    llama_dir = (llama_root / platform_slug).resolve()
+    if not llama_dir.exists():
+        raise FileNotFoundError(f"staged llama.cpp directory not found: {llama_dir}")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    archive_path = output_dir / f"lf-{platform_slug}{archive_suffix(platform_slug)}"
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        stage_dir = Path(tmpdir)
+        staged_binary = stage_dir / default_binary_name(platform_slug)
+        shutil.copy2(binary_path, staged_binary)
+        staged_binary.chmod(0o755)
+
+        staged_llama_dir = stage_dir / "llama-cpp" / platform_slug
+        staged_llama_dir.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(llama_dir, staged_llama_dir, symlinks=True)
+
+        if archive_path.suffix == ".zip":
+            write_zip_archive(stage_dir, archive_path)
+        else:
+            write_tar_archive(stage_dir, archive_path)
+
+    checksum_path = write_sha256(archive_path)
+    return archive_path, checksum_path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Package an lf release bundle")
+    parser.add_argument("--binary", required=True, type=Path, help="Path to the built CLI binary")
+    parser.add_argument("--platform", default="host", help="Target platform slug or 'host'")
+    parser.add_argument(
+        "--llama-root",
+        required=True,
+        type=Path,
+        help="Root directory containing llama-cpp/<platform>/ staging",
+    )
+    parser.add_argument("--output-dir", required=True, type=Path, help="Archive output directory")
+    args = parser.parse_args()
+
+    platform_slug = normalize_platform(args.platform)
+    archive_path, checksum_path = package_bundle(
+        args.binary,
+        platform_slug,
+        args.llama_root.resolve(),
+        args.output_dir.resolve(),
+    )
+    print(archive_path)
+    print(checksum_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/package_cli_bundle.py
+++ b/scripts/package_cli_bundle.py
@@ -17,7 +17,6 @@ SUPPORTED_PLATFORMS = {
     "linux-x86_64",
     "linux-arm64",
     "darwin-arm64",
-    "darwin-x86_64",
     "windows-x86_64",
 }
 

--- a/scripts/stage_llama_bundle.py
+++ b/scripts/stage_llama_bundle.py
@@ -45,7 +45,6 @@ PLATFORM_KEYS: dict[str, tuple[str, str, str]] = {
     "linux-x86_64": ("linux", "x86_64", "cpu"),
     "linux-arm64": ("linux", "arm64", "cpu"),
     "darwin-arm64": ("darwin", "arm64", "metal"),
-    "darwin-x86_64": ("darwin", "x86_64", "cpu"),
     "windows-x86_64": ("win32", "amd64", "cpu"),
 }
 

--- a/scripts/stage_llama_bundle.py
+++ b/scripts/stage_llama_bundle.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import importlib.util
 import platform
 import re
@@ -17,9 +18,16 @@ from urllib.request import Request, urlopen
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 LLAMA_BINARY_PATH = (
-    PROJECT_ROOT / "packages" / "llamafarm-llama" / "src" / "llamafarm_llama" / "_binary.py"
+    PROJECT_ROOT
+    / "packages"
+    / "llamafarm-llama"
+    / "src"
+    / "llamafarm_llama"
+    / "_binary.py"
 )
-MODULE_SPEC = importlib.util.spec_from_file_location("llamafarm_llama_binary", LLAMA_BINARY_PATH)
+MODULE_SPEC = importlib.util.spec_from_file_location(
+    "llamafarm_llama_binary", LLAMA_BINARY_PATH
+)
 if MODULE_SPEC is None or MODULE_SPEC.loader is None:
     raise RuntimeError(f"failed to load module spec from {LLAMA_BINARY_PATH}")
 LLAMA_BINARY = importlib.util.module_from_spec(MODULE_SPEC)
@@ -56,11 +64,15 @@ def detect_host_platform() -> str:
     elif machine in ("arm64", "aarch64"):
         machine = "arm64"
     else:
-        raise ValueError(f"unsupported host architecture for llama bundle staging: {machine}")
+        raise ValueError(
+            f"unsupported host architecture for llama bundle staging: {machine}"
+        )
 
     platform_slug = f"{system}-{machine}"
     if platform_slug not in PLATFORM_KEYS:
-        raise ValueError(f"unsupported host platform for llama bundle staging: {platform_slug}")
+        raise ValueError(
+            f"unsupported host platform for llama bundle staging: {platform_slug}"
+        )
     return platform_slug
 
 
@@ -86,7 +98,9 @@ def create_version_symlinks(dest_dir: Path, system: str) -> None:
 
     if system == "darwin":
         for lib_file in dest_dir.glob("*.dylib"):
-            match = re.match(r"^(lib[\w-]+)\.(\d+)\.(\d+)\.(\d+)\.dylib$", lib_file.name)
+            match = re.match(
+                r"^(lib[\w-]+)\.(\d+)\.(\d+)\.(\d+)\.dylib$", lib_file.name
+            )
             if not match:
                 continue
             base_name = match.group(1)
@@ -145,7 +159,11 @@ def copy_dependencies_for_system(
 
     for pattern in patterns:
         for candidate in src_dir.rglob(pattern):
-            if not candidate.is_file() or candidate.name == main_lib or candidate.stat().st_size <= 100:
+            if (
+                not candidate.is_file()
+                or candidate.name == main_lib
+                or candidate.stat().st_size <= 100
+            ):
                 continue
             dest = dest_dir / candidate.name
             if not dest.exists():
@@ -166,14 +184,71 @@ def build_download_spec(platform_slug: str) -> tuple[str, str, dict]:
         artifact = url.split("/")[-1]
     else:
         artifact = manifest["artifact"].format(version=LLAMA_CPP_VERSION)
-        url = f"https://github.com/{LLAMA_CPP_REPO}/releases/download/{LLAMA_CPP_VERSION}/{artifact}"
+        url = (
+            f"https://github.com/{LLAMA_CPP_REPO}/releases/download/"
+            f"{LLAMA_CPP_VERSION}/{artifact}"
+        )
     return artifact, url, manifest
 
 
 def download_archive(url: str, archive_path: Path) -> None:
     req = Request(url, headers={"User-Agent": "llamafarm-bundle-stager"})
-    with urlopen(req, timeout=300) as response:  # noqa: S310 - trusted GitHub release URL.
+    # Trusted GitHub release URL; HTTPS-only.
+    with urlopen(req, timeout=300) as response:  # noqa: S310
         archive_path.write_bytes(response.read())
+
+
+def _try_fetch_remote_sha256(url: str) -> str | None:
+    """Best-effort fetch of a sidecar SHA256.
+
+    GitHub release artifacts sometimes ship `<artifact>.sha256` next to the
+    archive. When present, we verify against it to harden the supply chain.
+    Missing sidecars (the common case for upstream llama.cpp) just return None
+    so the caller logs the locally-computed hash and proceeds — TLS + GitHub's
+    cert chain remain the underlying integrity guarantee for those.
+    """
+    sha_url = url + ".sha256"
+    req = Request(sha_url, headers={"User-Agent": "llamafarm-bundle-stager"})
+    try:
+        # Trusted GitHub release URL; HTTPS-only.
+        with urlopen(req, timeout=30) as response:  # noqa: S310
+            text = response.read().decode("utf-8", errors="replace").strip()
+    except (HTTPError, URLError, OSError):
+        return None
+    if not text:
+        return None
+    # Format is typically "<hex>  <filename>" — take the first hex chunk.
+    candidate = text.split()[0].strip()
+    if len(candidate) == 64 and all(c in "0123456789abcdefABCDEF" for c in candidate):
+        return candidate.lower()
+    return None
+
+
+def verify_archive_checksum(url: str, archive_path: Path) -> str:
+    """Compute the archive's SHA256 and (when available) verify a remote one.
+
+    Returns the locally-computed digest. Raises RuntimeError if a remote
+    sidecar checksum is fetched and disagrees with the local one.
+    """
+    digest = hashlib.sha256(archive_path.read_bytes()).hexdigest()
+    remote = _try_fetch_remote_sha256(url)
+    if remote is None:
+        print(
+            f"sha256({archive_path.name}) = {digest} "
+            "(no upstream sidecar; relying on TLS for integrity)",
+            file=sys.stderr,
+        )
+        return digest
+    if remote != digest:
+        raise RuntimeError(
+            f"checksum mismatch for {archive_path.name}: "
+            f"expected {remote}, got {digest}"
+        )
+    print(
+        f"sha256({archive_path.name}) = {digest} (verified against upstream sidecar)",
+        file=sys.stderr,
+    )
+    return digest
 
 
 def stage_bundle(platform_slug: str, destination_root: Path) -> Path:
@@ -197,6 +272,7 @@ def stage_bundle(platform_slug: str, destination_root: Path) -> Path:
                 extract_dir.mkdir(parents=True, exist_ok=True)
 
                 download_archive(url, archive_path)
+                verify_archive_checksum(url, archive_path)
 
                 if artifact.endswith(".zip"):
                     _safe_extract_zip(archive_path, extract_dir)
@@ -210,7 +286,8 @@ def stage_bundle(platform_slug: str, destination_root: Path) -> Path:
                     candidates = list(extract_dir.rglob(main_lib))
                     if not candidates:
                         raise RuntimeError(
-                            f"could not find {main_lib} in extracted archive for {platform_slug}"
+                            f"could not find {main_lib} in extracted archive "
+                            f"for {platform_slug}"
                         )
                     lib_src = candidates[0]
 
@@ -230,7 +307,9 @@ def stage_bundle(platform_slug: str, destination_root: Path) -> Path:
             time.sleep(delay_seconds)
 
     assert last_error is not None
-    raise RuntimeError(f"failed to stage {platform_slug} after 3 attempts") from last_error
+    raise RuntimeError(
+        f"failed to stage {platform_slug} after 3 attempts"
+    ) from last_error
 
 
 def main() -> int:

--- a/scripts/stage_llama_bundle.py
+++ b/scripts/stage_llama_bundle.py
@@ -25,21 +25,32 @@ LLAMA_BINARY_PATH = (
     / "llamafarm_llama"
     / "_binary.py"
 )
-MODULE_SPEC = importlib.util.spec_from_file_location(
-    "llamafarm_llama_binary", LLAMA_BINARY_PATH
-)
-if MODULE_SPEC is None or MODULE_SPEC.loader is None:
-    raise RuntimeError(f"failed to load module spec from {LLAMA_BINARY_PATH}")
-LLAMA_BINARY = importlib.util.module_from_spec(MODULE_SPEC)
-MODULE_SPEC.loader.exec_module(LLAMA_BINARY)
 
-BINARY_MANIFEST = LLAMA_BINARY.BINARY_MANIFEST
-LLAMA_CPP_REPO = LLAMA_BINARY.LLAMA_CPP_REPO
-LLAMA_CPP_VERSION = LLAMA_BINARY.LLAMA_CPP_VERSION
-_extract_with_symlinks = LLAMA_BINARY._extract_with_symlinks
-_get_llamafarm_release_version = LLAMA_BINARY._get_llamafarm_release_version
-_safe_extract_tarball = LLAMA_BINARY._safe_extract_tarball
-_safe_extract_zip = LLAMA_BINARY._safe_extract_zip
+
+_LLAMA_BINARY_MODULE = None
+
+
+def _load_llama_binary_module():
+    """Lazily import _binary.py from the llamafarm-llama package.
+
+    The module is loaded on first call so any future top-level side effect
+    in _binary.py only runs when the staging script actually needs it,
+    not at import time of this script. Subsequent calls reuse the cached
+    module.
+    """
+    global _LLAMA_BINARY_MODULE
+    if _LLAMA_BINARY_MODULE is not None:
+        return _LLAMA_BINARY_MODULE
+    spec = importlib.util.spec_from_file_location(
+        "llamafarm_llama_binary", LLAMA_BINARY_PATH
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"failed to load module spec from {LLAMA_BINARY_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    _LLAMA_BINARY_MODULE = module
+    return module
+
 
 PLATFORM_KEYS: dict[str, tuple[str, str, str]] = {
     "linux-x86_64": ("linux", "x86_64", "cpu"),
@@ -172,20 +183,22 @@ def copy_dependencies_for_system(
 
 
 def build_download_spec(platform_slug: str) -> tuple[str, str, dict]:
+    llama_binary = _load_llama_binary_module()
     platform_key = PLATFORM_KEYS[platform_slug]
-    manifest = BINARY_MANIFEST[platform_key]
+    manifest = llama_binary.BINARY_MANIFEST[platform_key]
+    version = llama_binary.LLAMA_CPP_VERSION
     if platform_key == ("linux", "arm64", "cpu"):
-        llamafarm_version = _get_llamafarm_release_version()
+        llamafarm_version = llama_binary._get_llamafarm_release_version()
         url = manifest["artifact"].format(
-            version=LLAMA_CPP_VERSION,
+            version=version,
             llamafarm_version=llamafarm_version,
         )
         artifact = url.split("/")[-1]
     else:
-        artifact = manifest["artifact"].format(version=LLAMA_CPP_VERSION)
+        artifact = manifest["artifact"].format(version=version)
         url = (
-            f"https://github.com/{LLAMA_CPP_REPO}/releases/download/"
-            f"{LLAMA_CPP_VERSION}/{artifact}"
+            f"https://github.com/{llama_binary.LLAMA_CPP_REPO}"
+            f"/releases/download/{version}/{artifact}"
         )
     return artifact, url, manifest
 
@@ -251,6 +264,7 @@ def verify_archive_checksum(url: str, archive_path: Path) -> str:
 
 
 def stage_bundle(platform_slug: str, destination_root: Path) -> Path:
+    llama_binary = _load_llama_binary_module()
     dest_dir = destination_root / platform_slug
     destination_root.mkdir(parents=True, exist_ok=True)
     system = PLATFORM_KEYS[platform_slug][0]
@@ -274,9 +288,9 @@ def stage_bundle(platform_slug: str, destination_root: Path) -> Path:
                 verify_archive_checksum(url, archive_path)
 
                 if artifact.endswith(".zip"):
-                    _safe_extract_zip(archive_path, extract_dir)
+                    llama_binary._safe_extract_zip(archive_path, extract_dir)
                 elif artifact.endswith(".tar.gz") or artifact.endswith(".tgz"):
-                    _safe_extract_tarball(archive_path, extract_dir)
+                    llama_binary._safe_extract_tarball(archive_path, extract_dir)
                 else:
                     raise RuntimeError(f"unsupported archive format: {artifact}")
 
@@ -290,7 +304,7 @@ def stage_bundle(platform_slug: str, destination_root: Path) -> Path:
                         )
                     lib_src = candidates[0]
 
-                _extract_with_symlinks(lib_src, dest_dir / main_lib)
+                llama_binary._extract_with_symlinks(lib_src, dest_dir / main_lib)
                 copy_dependencies_for_system(extract_dir, dest_dir, system, main_lib)
             return dest_dir
         except (HTTPError, URLError, OSError, RuntimeError) as exc:

--- a/scripts/stage_llama_bundle.py
+++ b/scripts/stage_llama_bundle.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Stage a bundled llama.cpp binary for a target platform."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import platform
+import re
+import shutil
+import sys
+import tempfile
+import time
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+LLAMA_BINARY_PATH = (
+    PROJECT_ROOT / "packages" / "llamafarm-llama" / "src" / "llamafarm_llama" / "_binary.py"
+)
+MODULE_SPEC = importlib.util.spec_from_file_location("llamafarm_llama_binary", LLAMA_BINARY_PATH)
+if MODULE_SPEC is None or MODULE_SPEC.loader is None:
+    raise RuntimeError(f"failed to load module spec from {LLAMA_BINARY_PATH}")
+LLAMA_BINARY = importlib.util.module_from_spec(MODULE_SPEC)
+MODULE_SPEC.loader.exec_module(LLAMA_BINARY)
+
+BINARY_MANIFEST = LLAMA_BINARY.BINARY_MANIFEST
+LLAMA_CPP_REPO = LLAMA_BINARY.LLAMA_CPP_REPO
+LLAMA_CPP_VERSION = LLAMA_BINARY.LLAMA_CPP_VERSION
+_extract_with_symlinks = LLAMA_BINARY._extract_with_symlinks
+_get_llamafarm_release_version = LLAMA_BINARY._get_llamafarm_release_version
+_safe_extract_tarball = LLAMA_BINARY._safe_extract_tarball
+_safe_extract_zip = LLAMA_BINARY._safe_extract_zip
+
+PLATFORM_KEYS: dict[str, tuple[str, str, str]] = {
+    "linux-x86_64": ("linux", "x86_64", "cpu"),
+    "linux-arm64": ("linux", "arm64", "cpu"),
+    "darwin-arm64": ("darwin", "arm64", "metal"),
+    "darwin-x86_64": ("darwin", "x86_64", "cpu"),
+    "windows-x86_64": ("win32", "amd64", "cpu"),
+}
+
+
+def detect_host_platform() -> str:
+    system = platform.system().lower()
+    machine = platform.machine().lower()
+
+    if system == "windows":
+        system = "windows"
+    elif system not in ("linux", "darwin"):
+        raise ValueError(f"unsupported host OS for llama bundle staging: {system}")
+
+    if machine in ("x86_64", "amd64"):
+        machine = "x86_64"
+    elif machine in ("arm64", "aarch64"):
+        machine = "arm64"
+    else:
+        raise ValueError(f"unsupported host architecture for llama bundle staging: {machine}")
+
+    platform_slug = f"{system}-{machine}"
+    if platform_slug not in PLATFORM_KEYS:
+        raise ValueError(f"unsupported host platform for llama bundle staging: {platform_slug}")
+    return platform_slug
+
+
+def normalize_platform(value: str) -> str:
+    if value == "host":
+        return detect_host_platform()
+    if value not in PLATFORM_KEYS:
+        raise ValueError(f"unsupported platform: {value}")
+    return value
+
+
+def lib_name_for_system(system: str) -> str:
+    if system == "darwin":
+        return "libllama.dylib"
+    if system in ("windows", "win32"):
+        return "llama.dll"
+    return "libllama.so"
+
+
+def create_version_symlinks(dest_dir: Path, system: str) -> None:
+    if system == "windows":
+        return
+
+    if system == "darwin":
+        for lib_file in dest_dir.glob("*.dylib"):
+            match = re.match(r"^(lib[\w-]+)\.(\d+)\.(\d+)\.(\d+)\.dylib$", lib_file.name)
+            if not match:
+                continue
+            base_name = match.group(1)
+            major = match.group(2)
+            major_symlink = dest_dir / f"{base_name}.{major}.dylib"
+            if not major_symlink.exists():
+                major_symlink.symlink_to(lib_file.name)
+            base_symlink = dest_dir / f"{base_name}.dylib"
+            if not base_symlink.exists():
+                base_symlink.symlink_to(major_symlink.name)
+        return
+
+    for lib_file in dest_dir.iterdir():
+        if not lib_file.is_file():
+            continue
+        match = re.match(r"^(lib[\w-]+)\.so\.(\d+)\.(\d+)\.(\d+)$", lib_file.name)
+        if not match:
+            continue
+        base_name = match.group(1)
+        major = match.group(2)
+        major_symlink = dest_dir / f"{base_name}.so.{major}"
+        if not major_symlink.exists():
+            major_symlink.symlink_to(lib_file.name)
+        base_symlink = dest_dir / f"{base_name}.so"
+        if not base_symlink.exists():
+            base_symlink.symlink_to(major_symlink.name)
+
+
+def copy_dependencies_for_system(
+    src_dir: Path,
+    dest_dir: Path,
+    system: str,
+    main_lib: str,
+) -> None:
+    patterns = [
+        "*.dll",
+        "*.metal",
+    ]
+
+    if system == "darwin":
+        patterns.extend([
+            "libggml*.*.*.*dylib",
+            "libmtmd*.*.*.*dylib",
+        ])
+    else:
+        patterns.extend([
+            "libggml*.so.*",
+            "libggml*.so",
+            "ggml-*.so",
+            "libmtmd*.so.*",
+            "libmtmd*.so",
+            "libcublas*.so.*",
+            "libcudart*.so.*",
+            "libcublasLt*.so.*",
+        ])
+
+    for pattern in patterns:
+        for candidate in src_dir.rglob(pattern):
+            if not candidate.is_file() or candidate.name == main_lib or candidate.stat().st_size <= 100:
+                continue
+            dest = dest_dir / candidate.name
+            if not dest.exists():
+                shutil.copy2(candidate, dest)
+
+    create_version_symlinks(dest_dir, system)
+
+
+def build_download_spec(platform_slug: str) -> tuple[str, str, dict]:
+    platform_key = PLATFORM_KEYS[platform_slug]
+    manifest = BINARY_MANIFEST[platform_key]
+    if platform_key == ("linux", "arm64", "cpu"):
+        llamafarm_version = _get_llamafarm_release_version()
+        url = manifest["artifact"].format(
+            version=LLAMA_CPP_VERSION,
+            llamafarm_version=llamafarm_version,
+        )
+        artifact = url.split("/")[-1]
+    else:
+        artifact = manifest["artifact"].format(version=LLAMA_CPP_VERSION)
+        url = f"https://github.com/{LLAMA_CPP_REPO}/releases/download/{LLAMA_CPP_VERSION}/{artifact}"
+    return artifact, url, manifest
+
+
+def download_archive(url: str, archive_path: Path) -> None:
+    req = Request(url, headers={"User-Agent": "llamafarm-bundle-stager"})
+    with urlopen(req, timeout=300) as response:  # noqa: S310 - trusted GitHub release URL.
+        archive_path.write_bytes(response.read())
+
+
+def stage_bundle(platform_slug: str, destination_root: Path) -> Path:
+    dest_dir = destination_root / platform_slug
+    destination_root.mkdir(parents=True, exist_ok=True)
+    system = PLATFORM_KEYS[platform_slug][0]
+    main_lib = lib_name_for_system(system)
+    artifact, url, manifest = build_download_spec(platform_slug)
+
+    last_error: Exception | None = None
+    for attempt in range(1, 4):
+        if dest_dir.exists():
+            shutil.rmtree(dest_dir)
+        dest_dir.mkdir(parents=True, exist_ok=True)
+
+        try:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                tmpdir_path = Path(tmpdir)
+                archive_path = tmpdir_path / artifact
+                extract_dir = tmpdir_path / "extracted"
+                extract_dir.mkdir(parents=True, exist_ok=True)
+
+                download_archive(url, archive_path)
+
+                if artifact.endswith(".zip"):
+                    _safe_extract_zip(archive_path, extract_dir)
+                elif artifact.endswith(".tar.gz") or artifact.endswith(".tgz"):
+                    _safe_extract_tarball(archive_path, extract_dir)
+                else:
+                    raise RuntimeError(f"unsupported archive format: {artifact}")
+
+                lib_src = extract_dir / manifest["lib"]
+                if not lib_src.exists():
+                    candidates = list(extract_dir.rglob(main_lib))
+                    if not candidates:
+                        raise RuntimeError(
+                            f"could not find {main_lib} in extracted archive for {platform_slug}"
+                        )
+                    lib_src = candidates[0]
+
+                _extract_with_symlinks(lib_src, dest_dir / main_lib)
+                copy_dependencies_for_system(extract_dir, dest_dir, system, main_lib)
+            return dest_dir
+        except (HTTPError, URLError, OSError, RuntimeError) as exc:
+            last_error = exc
+            if attempt == 3:
+                break
+            delay_seconds = 2 ** (attempt - 1)
+            print(
+                f"Attempt {attempt} failed staging {platform_slug}: {exc}. "
+                f"Retrying in {delay_seconds}s...",
+                file=sys.stderr,
+            )
+            time.sleep(delay_seconds)
+
+    assert last_error is not None
+    raise RuntimeError(f"failed to stage {platform_slug} after 3 attempts") from last_error
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Stage bundled llama.cpp binaries")
+    parser.add_argument(
+        "--platform",
+        default="host",
+        help="Target platform slug or 'host'",
+    )
+    parser.add_argument(
+        "--destination-root",
+        required=True,
+        type=Path,
+        help="Root directory that will receive <platform>/ files",
+    )
+    args = parser.parse_args()
+
+    platform_slug = normalize_platform(args.platform)
+    dest_dir = stage_bundle(platform_slug, args.destination_root.resolve())
+    print(dest_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Closes #664 (404 errors on Windows + NVIDIA) and #583 (503 errors during version upgrade) by bundling the pinned llama.cpp binary inside every release artifact, so first run no longer requires a network call to GitHub.

## What changes

- **Go resolver**: `BundledBinaryPath()` looks for `<exe-dir>/llama-cpp/<os>-<arch>/<lib>` before falling back to download. Resolution order: **cache → bundled → download**.
- **Python resolver**: mirrors the Go layout under `llamafarm_llama/_bundled/<os>-<arch>/`.
- **CI**: `cli.yml`, `release-cli.yml`, and `pyapp.yml` stage the pinned upstream llama.cpp binary into the archive / PyApp bundle. 3-attempt retry with exponential backoff.
- **New scripts**: `scripts/stage_llama_bundle.py` (download + extract) and `scripts/package_cli_bundy` (tar.gz / zip + sha256).
- **Docs**: `INSTALL.md` and `.claude/rules/llama_cpp_bindings.md` describe the bundle layout so future version bumps know to keep the staging matrix in sync.

## Platform matrix (CPU-only, GPU bundles deferred)

| Platform | Source |
|---|---|
| linux-x86_64 | upstream `ggml-org/llama.cpp` releases |
| linux-arm64 | LlamaFarm's own `build-llama.yml` artifact |
| darwin-arm64 | upstream |
| darwin-x86_64 | upstream (newly added to the CI matrix) |
| windows-x86_64 | upstream |

**Notes:**
- Windows ARM64 is dropped from the matrix (no upstream prebuilt).
- GPU-specific bundle variants (CUDA / Vulkan / Metal-only) remain a follow-up.
- If `llama-cpp-version.txt` is bumped locally without a re-build, the bundled binary will be stale; in production every release ships bundle + pin together so users never see this.

## Test plan

- [x] `go test ./...` in `cli/` — all packages green
- [x] `pytest` in `packages/llamafarm-llama/` — 64/64 pass (2 new tests for bundled-binary resoluti 1 updated offline test)
- [x] `ruff check` clean
- [x] `go vet ./...` clean
- [x] Smoke test `lf` built locally with bundled binary present resolves bundled path, no HTTP call attempted (verified by `httptest.Server` in `TestBundledBinaryPath_PrefersBundledOverDownload`)

---

### _**>** Submitting this PR as part of my application to join the LlamaFarm team. Happy to iterate on any feedback._