### PR TITLE
fix(common): guard detect_model_format HF fallback in offline mode

### DIFF
--- a/common/llamafarm_common/model_format.py
+++ b/common/llamafarm_common/model_format.py
@@ -17,6 +17,7 @@ import logging
 from huggingface_hub import HfApi, scan_cache_dir
 from huggingface_hub.utils import HFCacheInfo
 
+from . import offline_mode
 from .model_dir import resolve_from_model_dir
 from .model_utils import (
     GGUF_QUANTIZATION_PREFERENCE_ORDER,
@@ -177,6 +178,17 @@ def detect_model_format(
             "LLAMAFARM_MODEL_DIR lookup rejected alias %r: %s; falling back to network",
             alias_candidate,
             e,
+        )
+
+    # Strict offline mode: never call the HF API. Mirrors the guard in
+    # list_gguf_files() (see model_utils.py) so callers get a structured
+    # FileNotFoundError instead of an OfflineModeIsEnabled traceback from
+    # deep inside huggingface_hub.
+    if offline_mode.is_offline():
+        raise FileNotFoundError(
+            f"detect_model_format({base_model_id!r}) refused in offline mode "
+            f"(LLAMAFARM_OFFLINE=1). Place the model under $LLAMAFARM_MODEL_DIR "
+            f"or pre-populate the HuggingFace cache."
         )
 
     # Not in local cache or model dir - must query API

--- a/common/llamafarm_common/model_format.py
+++ b/common/llamafarm_common/model_format.py
@@ -40,6 +40,7 @@ _local_cache_info: HFCacheInfo | None = None
 # Re-export commonly used functions for backward compatibility
 __all__ = [
     "GGUF_QUANTIZATION_PREFERENCE_ORDER",
+    "OfflineModelNotCachedError",
     "parse_model_with_quantization",
     "parse_quantization_from_filename",
     "select_gguf_file",
@@ -49,6 +50,15 @@ __all__ = [
     "get_gguf_file_path",
     "clear_format_cache",
 ]
+
+
+class OfflineModelNotCachedError(FileNotFoundError):
+    """Raised when a model lookup is refused because strict offline mode is on
+    and the model is not present in any local source (LLAMAFARM_MODEL_DIR or
+    HuggingFace cache). Subclasses FileNotFoundError so existing callers that
+    only catch FileNotFoundError still work, while new callers can match on
+    the dedicated type instead of substring-matching the error message.
+    """
 
 
 def _check_local_cache_for_model(model_id: str) -> list[str] | None:
@@ -185,7 +195,7 @@ def detect_model_format(
     # FileNotFoundError instead of an OfflineModeIsEnabled traceback from
     # deep inside huggingface_hub.
     if offline_mode.is_offline():
-        raise FileNotFoundError(
+        raise OfflineModelNotCachedError(
             f"detect_model_format({base_model_id!r}) refused in offline mode "
             f"(LLAMAFARM_OFFLINE=1). Place the model under $LLAMAFARM_MODEL_DIR "
             f"or pre-populate the HuggingFace cache."

--- a/common/tests/test_model_format_offline.py
+++ b/common/tests/test_model_format_offline.py
@@ -51,7 +51,7 @@ class TestDetectModelFormatOffline:
 
         monkeypatch.setattr(model_format, "HfApi", _fail)
 
-        with pytest.raises(FileNotFoundError, match="LLAMAFARM_OFFLINE"):
+        with pytest.raises(model_format.OfflineModelNotCachedError, match="LLAMAFARM_OFFLINE"):
             model_format.detect_model_format("org/some-model")
 
     def test_offline_message_points_at_model_dir_fix(self, monkeypatch):

--- a/common/tests/test_model_format_offline.py
+++ b/common/tests/test_model_format_offline.py
@@ -1,0 +1,148 @@
+"""Offline-mode tests for llamafarm_common.model_format.detect_model_format.
+
+The function previously fell through to `huggingface_hub.HfApi.list_repo_files`
+when no local cache or LLAMAFARM_MODEL_DIR hit was found, even with
+LLAMAFARM_OFFLINE=1. That produced an OfflineModeIsEnabled traceback from
+inside huggingface_hub instead of the structured FileNotFoundError that the
+rest of llamafarm_common already raises (see list_gguf_files in model_utils).
+
+These tests pin the new offline guard: when LLAMAFARM_OFFLINE=1, the function
+must raise FileNotFoundError without constructing HfApi.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from llamafarm_common import model_format, offline_mode
+
+
+@pytest.fixture(autouse=True)
+def _reset_offline_state(monkeypatch):
+    monkeypatch.delenv("LLAMAFARM_OFFLINE", raising=False)
+    monkeypatch.delenv("LLAMAFARM_MODEL_DIR", raising=False)
+    model_format.clear_format_cache()
+    offline_mode.reset_for_tests()
+    yield
+
+
+class TestDetectModelFormatOffline:
+    def test_offline_raises_filenotfounderror_without_calling_api(self, monkeypatch):
+        monkeypatch.setenv("LLAMAFARM_OFFLINE", "1")
+
+        # Force the local-cache and LLAMAFARM_MODEL_DIR paths to miss so we
+        # exercise the network-fallback branch — which must now short-circuit.
+        monkeypatch.setattr(
+            model_format,
+            "_check_local_cache_for_model",
+            lambda model_id: None,
+        )
+        monkeypatch.setattr(
+            model_format,
+            "resolve_from_model_dir",
+            lambda alias: None,
+        )
+
+        def _fail(*a, **kw):
+            raise AssertionError(
+                "HfApi must not be constructed in offline mode — "
+                "detect_model_format should short-circuit before reaching the network"
+            )
+
+        monkeypatch.setattr(model_format, "HfApi", _fail)
+
+        with pytest.raises(FileNotFoundError, match="LLAMAFARM_OFFLINE"):
+            model_format.detect_model_format("org/some-model")
+
+    def test_offline_message_points_at_model_dir_fix(self, monkeypatch):
+        monkeypatch.setenv("LLAMAFARM_OFFLINE", "1")
+        monkeypatch.setattr(
+            model_format, "_check_local_cache_for_model", lambda model_id: None
+        )
+        monkeypatch.setattr(
+            model_format, "resolve_from_model_dir", lambda alias: None
+        )
+        monkeypatch.setattr(
+            model_format,
+            "HfApi",
+            lambda: pytest.fail("HfApi must not be constructed"),
+        )
+
+        with pytest.raises(FileNotFoundError) as excinfo:
+            model_format.detect_model_format("org/some-model")
+
+        msg = str(excinfo.value)
+        assert "LLAMAFARM_MODEL_DIR" in msg
+        assert "HuggingFace cache" in msg
+
+    def test_offline_short_circuit_does_not_block_local_cache_hits(
+        self, monkeypatch
+    ):
+        """Offline mode + local cache hit → returns without raising."""
+        monkeypatch.setenv("LLAMAFARM_OFFLINE", "1")
+        monkeypatch.setattr(
+            model_format,
+            "_check_local_cache_for_model",
+            lambda model_id: ["foo.Q4_K_M.gguf"],
+        )
+
+        # If the cache-hit path were skipped, this would fail.
+        monkeypatch.setattr(
+            model_format,
+            "HfApi",
+            lambda: pytest.fail("HfApi must not be constructed"),
+        )
+
+        result = model_format.detect_model_format("org/some-model")
+        assert result == "gguf"
+
+    def test_offline_short_circuit_does_not_block_model_dir_hits(self, monkeypatch):
+        """Offline mode + LLAMAFARM_MODEL_DIR hit → returns without raising."""
+        monkeypatch.setenv("LLAMAFARM_OFFLINE", "1")
+        monkeypatch.setattr(
+            model_format, "_check_local_cache_for_model", lambda model_id: None
+        )
+
+        class FakeResolved:
+            weights_path = "/fake/path/foo.gguf"
+
+        monkeypatch.setattr(
+            model_format, "resolve_from_model_dir", lambda alias: FakeResolved()
+        )
+        monkeypatch.setattr(
+            model_format,
+            "HfApi",
+            lambda: pytest.fail("HfApi must not be constructed"),
+        )
+
+        result = model_format.detect_model_format("org/some-model")
+        assert result == "gguf"
+
+    def test_online_still_calls_api(self, monkeypatch):
+        """When offline mode is OFF, the network path is reached as before."""
+        monkeypatch.setattr(
+            model_format, "_check_local_cache_for_model", lambda model_id: None
+        )
+        monkeypatch.setattr(
+            model_format, "resolve_from_model_dir", lambda alias: None
+        )
+
+        class MockApi:
+            def list_repo_files(self, repo_id, token=None):
+                return ["weights.gguf", "tokenizer.json"]
+
+        monkeypatch.setattr(model_format, "HfApi", MockApi)
+
+        result = model_format.detect_model_format("org/some-model")
+        assert result == "gguf"
+
+    def test_gguf_extension_short_circuit_works_in_offline_mode(self, monkeypatch):
+        """A bare .gguf filename never needs the network — and shouldn't."""
+        monkeypatch.setenv("LLAMAFARM_OFFLINE", "1")
+        monkeypatch.setattr(
+            model_format,
+            "HfApi",
+            lambda: pytest.fail("HfApi must not be constructed"),
+        )
+
+        assert model_format.detect_model_format("model.gguf") == "gguf"

--- a/runtimes/edge/routers/chat_completions/service.py
+++ b/runtimes/edge/routers/chat_completions/service.py
@@ -1550,6 +1550,8 @@ class ChatCompletionsService:
                 HfHubHTTPError = RepositoryNotFoundError = GatedRepoError = ()  # type: ignore[assignment,misc]
                 LocalEntryNotFoundError = EntryNotFoundError = OfflineModeIsEnabled = ()  # type: ignore[assignment,misc]
 
+            from llamafarm_common.model_format import OfflineModelNotCachedError
+
             if isinstance(e, (RepositoryNotFoundError, LocalEntryNotFoundError, EntryNotFoundError)):
                 logger.warning(f"Model repository not found: {e}")
                 raise HTTPException(
@@ -1572,11 +1574,11 @@ class ChatCompletionsService:
                     },
                 ) from e
             # llamafarm_common short-circuits offline-mode HF probes with a
-            # FileNotFoundError carrying "LLAMAFARM_OFFLINE=1" in its message.
-            # Map that to the same 404 the OfflineModeIsEnabled branch produces,
-            # so API consumers see a stable contract whether the offline guard
-            # fires in our code or inside huggingface_hub.
-            if isinstance(e, FileNotFoundError) and "LLAMAFARM_OFFLINE" in str(e):
+            # dedicated OfflineModelNotCachedError. Map it to the same 404 the
+            # OfflineModeIsEnabled branch produces so API consumers see a
+            # stable contract whether the offline guard fires in our code or
+            # inside huggingface_hub.
+            if isinstance(e, OfflineModelNotCachedError):
                 logger.warning(f"Model not cached locally (offline mode): {e}")
                 raise HTTPException(
                     status_code=404,

--- a/runtimes/edge/routers/chat_completions/service.py
+++ b/runtimes/edge/routers/chat_completions/service.py
@@ -1571,6 +1571,23 @@ class ChatCompletionsService:
                         ),
                     },
                 ) from e
+            # llamafarm_common short-circuits offline-mode HF probes with a
+            # FileNotFoundError carrying "LLAMAFARM_OFFLINE=1" in its message.
+            # Map that to the same 404 the OfflineModeIsEnabled branch produces,
+            # so API consumers see a stable contract whether the offline guard
+            # fires in our code or inside huggingface_hub.
+            if isinstance(e, FileNotFoundError) and "LLAMAFARM_OFFLINE" in str(e):
+                logger.warning(f"Model not cached locally (offline mode): {e}")
+                raise HTTPException(
+                    status_code=404,
+                    detail={
+                        "error": "model_not_cached",
+                        "message": (
+                            f"Model '{chat_request.model}' is not cached locally "
+                            "and offline mode is enabled"
+                        ),
+                    },
+                ) from e
             if isinstance(e, GatedRepoError):
                 raise HTTPException(
                     status_code=403,

--- a/runtimes/edge/routers/completions.py
+++ b/runtimes/edge/routers/completions.py
@@ -46,30 +46,29 @@ async def completions(request: CompletionRequest):
     """Raw text completions — no chat template applied."""
     from server import load_language
 
+    from llamafarm_common.model_format import OfflineModelNotCachedError
+
     try:
         model = await load_language(
             request.model,
             n_ctx=request.n_ctx,
             n_gpu_layers=request.n_gpu_layers,
         )
-    except FileNotFoundError as e:
-        # llamafarm_common short-circuits offline-mode HF probes with a
-        # FileNotFoundError carrying "LLAMAFARM_OFFLINE=1" in its message.
-        # Map that to a 404 model_not_cached, mirroring chat-completions, so
-        # API consumers see a stable contract instead of a generic 500.
-        if "LLAMAFARM_OFFLINE" in str(e):
-            logger.warning(f"Model not cached locally (offline mode): {e}")
-            raise HTTPException(
-                status_code=404,
-                detail={
-                    "error": "model_not_cached",
-                    "message": (
-                        f"Model '{request.model}' is not cached locally "
-                        "and offline mode is enabled"
-                    ),
-                },
-            ) from e
-        raise
+    except OfflineModelNotCachedError as e:
+        # Mirror chat-completions: surface a structured 404 instead of a
+        # generic 500 when the requested model is not cached and strict
+        # offline mode is on.
+        logger.warning(f"Model not cached locally (offline mode): {e}")
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "error": "model_not_cached",
+                "message": (
+                    f"Model '{request.model}' is not cached locally "
+                    "and offline mode is enabled"
+                ),
+            },
+        ) from e
 
     max_tokens = request.max_tokens if request.max_tokens is not None else 512
     stop = request.stop if isinstance(request.stop, list) else ([request.stop] if request.stop else [])

--- a/runtimes/edge/routers/completions.py
+++ b/runtimes/edge/routers/completions.py
@@ -9,7 +9,7 @@ import logging
 import time
 import uuid
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
 router = APIRouter()
@@ -46,11 +46,30 @@ async def completions(request: CompletionRequest):
     """Raw text completions — no chat template applied."""
     from server import load_language
 
-    model = await load_language(
-        request.model,
-        n_ctx=request.n_ctx,
-        n_gpu_layers=request.n_gpu_layers,
-    )
+    try:
+        model = await load_language(
+            request.model,
+            n_ctx=request.n_ctx,
+            n_gpu_layers=request.n_gpu_layers,
+        )
+    except FileNotFoundError as e:
+        # llamafarm_common short-circuits offline-mode HF probes with a
+        # FileNotFoundError carrying "LLAMAFARM_OFFLINE=1" in its message.
+        # Map that to a 404 model_not_cached, mirroring chat-completions, so
+        # API consumers see a stable contract instead of a generic 500.
+        if "LLAMAFARM_OFFLINE" in str(e):
+            logger.warning(f"Model not cached locally (offline mode): {e}")
+            raise HTTPException(
+                status_code=404,
+                detail={
+                    "error": "model_not_cached",
+                    "message": (
+                        f"Model '{request.model}' is not cached locally "
+                        "and offline mode is enabled"
+                    ),
+                },
+            ) from e
+        raise
 
     max_tokens = request.max_tokens if request.max_tokens is not None else 512
     stop = request.stop if isinstance(request.stop, list) else ([request.stop] if request.stop else [])

--- a/runtimes/edge/tests/test_completions_offline.py
+++ b/runtimes/edge/tests/test_completions_offline.py
@@ -1,0 +1,62 @@
+"""Tests for /v1/completions offline-mode error mapping.
+
+When LLAMAFARM_OFFLINE=1 and the requested model is not cached locally,
+``load_language()`` raises ``FileNotFoundError`` from llamafarm_common.
+The endpoint must translate that into a 404 ``model_not_cached`` response
+matching /v1/chat/completions, not a generic 500.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from routers import completions as completions_router
+
+
+@pytest.fixture
+def client(monkeypatch):
+    async def _raise_offline(model, n_ctx=None, n_gpu_layers=None):
+        raise FileNotFoundError(
+            f"detect_model_format({model!r}) refused in offline mode "
+            "(LLAMAFARM_OFFLINE=1). Place the model under $LLAMAFARM_MODEL_DIR "
+            "or pre-populate the HuggingFace cache."
+        )
+
+    async def _raise_other(model, n_ctx=None, n_gpu_layers=None):
+        raise FileNotFoundError("some other missing file")
+
+    import sys
+    import types
+
+    fake_server = types.ModuleType("server")
+    fake_server.load_language = _raise_offline
+    monkeypatch.setitem(sys.modules, "server", fake_server)
+
+    app = FastAPI()
+    app.include_router(completions_router.router)
+    return TestClient(app, raise_server_exceptions=False), fake_server, _raise_other
+
+
+def test_offline_returns_404_model_not_cached(client):
+    test_client, _, _ = client
+    resp = test_client.post(
+        "/v1/completions",
+        json={"model": "some/missing-model", "prompt": "hi"},
+    )
+    assert resp.status_code == 404
+    body = resp.json()
+    assert body["detail"]["error"] == "model_not_cached"
+    assert "some/missing-model" in body["detail"]["message"]
+
+
+def test_non_offline_filenotfounderror_propagates(client):
+    test_client, fake_server, raise_other = client
+    fake_server.load_language = raise_other
+    resp = test_client.post(
+        "/v1/completions",
+        json={"model": "some/model", "prompt": "hi"},
+    )
+    # FastAPI surfaces unhandled exceptions as 500.
+    assert resp.status_code == 500

--- a/runtimes/edge/tests/test_completions_offline.py
+++ b/runtimes/edge/tests/test_completions_offline.py
@@ -1,9 +1,10 @@
 """Tests for /v1/completions offline-mode error mapping.
 
 When LLAMAFARM_OFFLINE=1 and the requested model is not cached locally,
-``load_language()`` raises ``FileNotFoundError`` from llamafarm_common.
-The endpoint must translate that into a 404 ``model_not_cached`` response
-matching /v1/chat/completions, not a generic 500.
+``load_language()`` raises ``OfflineModelNotCachedError`` from
+llamafarm_common. The endpoint must translate that into a 404
+``model_not_cached`` response matching /v1/chat/completions, not a
+generic 500.
 """
 
 from __future__ import annotations
@@ -11,6 +12,7 @@ from __future__ import annotations
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from llamafarm_common.model_format import OfflineModelNotCachedError
 
 from routers import completions as completions_router
 
@@ -18,7 +20,7 @@ from routers import completions as completions_router
 @pytest.fixture
 def client(monkeypatch):
     async def _raise_offline(model, n_ctx=None, n_gpu_layers=None):
-        raise FileNotFoundError(
+        raise OfflineModelNotCachedError(
             f"detect_model_format({model!r}) refused in offline mode "
             "(LLAMAFARM_OFFLINE=1). Place the model under $LLAMAFARM_MODEL_DIR "
             "or pre-populate the HuggingFace cache."


### PR DESCRIPTION
## Summary

- `detect_model_format` in `llamafarm_common.model_format` previously fell through to `huggingface_hub.HfApi.list_repo_files` even when `LLAMAFARM_OFFLINE=1`, producing an `OfflineModeIsEnabled` traceback from deep inside `huggingface_hub` instead of the structured `FileNotFoundError` that `list_gguf_files` (in the same package) already raises.
- Add a matching offline guard mirroring the `list_gguf_files` pattern.
- Map the new `FileNotFoundError` to the same `404 model_not_cached` response that the existing `OfflineModeIsEnabled` branch produces in the edge runtime's chat-completions handler, so the API contract is unchanged.

## Background — what was broken

`common/llamafarm_common/model_format.py:detect_model_format` walks four resolution tiers:

1. `model_id.endswith(".gguf")` short-circuit — file extension only, no I/O.
2. `_check_local_cache_for_model` — scans the HuggingFace cache.
3. `resolve_from_model_dir` — checks `$LLAMAFARM_MODEL_DIR`.
4. `HfApi().list_repo_files(...)` — HTTP call to huggingface.co.

Tier 4 had **no offline guard**. `list_gguf_files` in the same package (`model_utils.py:419`) already raises a structured `FileNotFoundError` when `LLAMAFARM_OFFLINE=1` is set. `_binary.py` in `llamafarm-llama` does the same via `_is_offline()` / `get_lib_path()` (`_binary.py:323,387`). `detect_model_format` was the outlier — likely missed during the refactor train (`3eed3558 fix(common): remove filesystem probing from detect_model_format entirely`, `e29ecde9 fix(common): check LLAMAFARM_MODEL_DIR before HuggingFace API in detect_model_format`).

Verified the gap exists in the released v0.0.32 via `git show v0.0.32:common/llamafarm_common/model_format.py` — `list_repo_files` is called unconditionally on line 185.

When the offline guard is missing, the call falls into `huggingface_hub` which sees `HF_HUB_OFFLINE=1` (propagated from `LLAMAFARM_OFFLINE` by our bootstrap) and raises `OfflineModeIsEnabled`. The exception bubbles up as a noisy traceback when a clean `FileNotFoundError` with operator guidance ("place the model under `$LLAMAFARM_MODEL_DIR` or pre-populate the HuggingFace cache") would be much more useful — and consistent with the rest of the package.

## What changed

**`common/llamafarm_common/model_format.py`**
Added `from . import offline_mode` and a guard between the `LLAMAFARM_MODEL_DIR` check and the `HfApi()` construction:

```python
if offline_mode.is_offline():
    raise FileNotFoundError(
        f"detect_model_format({base_model_id!r}) refused in offline mode "
        f"(LLAMAFARM_OFFLINE=1). Place the model under $LLAMAFARM_MODEL_DIR "
        f"or pre-populate the HuggingFace cache."
    )
```

This mirrors the existing `list_gguf_files` shape exactly.

**`runtimes/edge/routers/chat_completions/service.py`**
The existing handler at line 1562 catches `huggingface_hub.errors.OfflineModeIsEnabled` and converts it to a `404 model_not_cached`. With the guard in place, that exception is no longer raised — `FileNotFoundError` is. Added a parallel `isinstance(e, FileNotFoundError) and "LLAMAFARM_OFFLINE" in str(e)` branch that produces the **same 404 response**, so API consumers see no contract change. The `LLAMAFARM_OFFLINE` substring check keeps this from accidentally swallowing other `FileNotFoundError`s (e.g. a missing GGUF file in a non-offline scenario).

The universal runtime's chat handler does not have an analogous `OfflineModeIsEnabled` branch, so no change is needed there.

**`common/tests/test_model_format_offline.py`** (new)
6 tests covering:
- Offline + cache miss + model-dir miss → `FileNotFoundError` with `LLAMAFARM_OFFLINE` in the message, and `HfApi` is never constructed.
- Offline + local-cache hit → still resolves cleanly without touching the network.
- Offline + `LLAMAFARM_MODEL_DIR` hit → still resolves cleanly.
- Online (no env var) → network path is reached as before.
- `.gguf` extension short-circuit works regardless of offline state.

## Out of scope

- The flight-safety status-propagation work (`feat(edge): surface backend-init state on local/llm/status`) is in #830. This PR is the complementary fix on the `common` side: even with the status propagation in place, suppressing the `OfflineModeIsEnabled` traceback noise is its own win for operators.
- The HF-fallback path inside `list_gguf_files` and `_binary.py` are already correctly guarded — no change needed there.
- The `is_offline()` env-var check in `_binary.py` (`_is_offline()` / `get_lib_path()`) is verified present and correct in v0.0.32. It is **not** a regression.

## Test plan

- [x] `cd common && uv run pytest tests/` — 135/135 passing (6 new tests in `test_model_format_offline.py`).
- [x] `cd runtimes/universal && uv run pytest tests/test_model_format.py` — 6/6 passing (existing tests unaffected).
- [x] `cd runtimes/edge && uv run pytest tests/` — 23/23 passing.
- [ ] Manual smoke: with `LLAMAFARM_OFFLINE=1` and a model not present locally, hit `/v1/chat/completions` and confirm a clean `404 model_not_cached` response with no `OfflineModeIsEnabled` traceback in the logs.
- [ ] CI: full Linux/macOS/Windows matrix.