### PR TITLE
feat(runtime): build and host Linux x86_64 CUDA llama.cpp binaries

### DIFF
--- a/.github/workflows/build-llama.yml
+++ b/.github/workflows/build-llama.yml
@@ -117,6 +117,17 @@ jobs:
           apt-get update
           apt-get install -y --no-install-recommends \
             build-essential cmake git ca-certificates curl zip
+          # GitHub runners have no NVIDIA driver, so libcuda.so.1 (the runtime
+          # driver lib) is absent. NVIDIA's CUDA devel image ships a stub at
+          # /usr/local/cuda/lib64/stubs/libcuda.so for build-time linking, but
+          # the file is unversioned while libggml-cuda.so declares a SONAME of
+          # libcuda.so.1 — so ld -rpath-link can't satisfy the NEEDED entry by
+          # filename. Symlink the versioned name to the stub so the executables
+          # can link cleanly. We don't ship the tools (only the .so libraries),
+          # so a stub link is sufficient — they wouldn't run on the build host
+          # without a real driver but they don't need to.
+          ln -sf /usr/local/cuda/lib64/stubs/libcuda.so \
+                 /usr/local/cuda/lib64/stubs/libcuda.so.1
 
       - name: Checkout LlamaFarm (for version file)
         uses: actions/checkout@v6

--- a/.github/workflows/build-llama.yml
+++ b/.github/workflows/build-llama.yml
@@ -147,6 +147,14 @@ jobs:
       - name: Configure CMake
         run: |
           cd llama.cpp
+          # GitHub Actions runners have no NVIDIA driver, so libcuda.so.1 is
+          # absent on the build host. The nvidia/cuda devel image ships a stub
+          # libcuda.so at /usr/local/cuda/lib64/stubs/ for exactly this case;
+          # add it to the linker search path so llama.cpp's executables (tools)
+          # can resolve cuMemCreate/cuDeviceGet/etc. at link time. We don't run
+          # them on the build host — we only ship the .so libraries — so a stub
+          # link is sufficient.
+          STUB_LDFLAGS="-Wl,-rpath-link,/usr/local/cuda/lib64/stubs -L/usr/local/cuda/lib64/stubs"
           cmake -S . -B build \
             -DCMAKE_BUILD_TYPE=Release \
             -DBUILD_SHARED_LIBS=ON \
@@ -154,7 +162,9 @@ jobs:
             -DLLAMA_BUILD_EXAMPLES=OFF \
             -DLLAMA_CURL=OFF \
             -DGGML_NATIVE=OFF \
-            -DGGML_CUDA=ON
+            -DGGML_CUDA=ON \
+            -DCMAKE_EXE_LINKER_FLAGS="$STUB_LDFLAGS" \
+            -DCMAKE_SHARED_LINKER_FLAGS="$STUB_LDFLAGS"
 
       - name: Build
         run: |

--- a/.github/workflows/build-llama.yml
+++ b/.github/workflows/build-llama.yml
@@ -96,3 +96,95 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: llama.cpp/${{ steps.artifact.outputs.name }}
+
+  build-llama-cpp-cuda:
+    name: Build llama.cpp (${{ matrix.cuda.backend }})
+    runs-on: ubuntu-24.04
+    container: ${{ matrix.cuda.image }}
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        cuda:
+          - backend: cuda12
+            image: nvidia/cuda:12.6.3-devel-ubuntu22.04
+          - backend: cuda13
+            image: nvidia/cuda:13.0.1-devel-ubuntu22.04
+    steps:
+      - name: Install dependencies
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            build-essential cmake git ca-certificates curl zip
+
+      - name: Checkout LlamaFarm (for version file)
+        uses: actions/checkout@v6
+        with:
+          path: llamafarm
+          sparse-checkout: |
+            llama-cpp-version.txt
+
+      - name: Determine llama.cpp version
+        id: version
+        run: |
+          if [ -n "${{ inputs.llama_version }}" ]; then
+            echo "version=${{ inputs.llama_version }}" >> $GITHUB_OUTPUT
+            echo "Using input version: ${{ inputs.llama_version }}"
+          else
+            VERSION=$(cat llamafarm/llama-cpp-version.txt | tr -d '\n')
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
+            echo "Using version from llama-cpp-version.txt: $VERSION"
+          fi
+
+      - name: Checkout llama.cpp
+        uses: actions/checkout@v6
+        with:
+          repository: ggml-org/llama.cpp
+          ref: ${{ steps.version.outputs.version }}
+          path: llama.cpp
+
+      - name: Configure CMake
+        run: |
+          cd llama.cpp
+          cmake -S . -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_SHARED_LIBS=ON \
+            -DLLAMA_BUILD_TESTS=OFF \
+            -DLLAMA_BUILD_EXAMPLES=OFF \
+            -DLLAMA_CURL=OFF \
+            -DGGML_NATIVE=OFF \
+            -DGGML_CUDA=ON
+
+      - name: Build
+        run: |
+          cd llama.cpp
+          cmake --build build --config Release -j $(nproc)
+
+      - name: Prepare Artifact
+        id: artifact
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          ARTIFACT_NAME="llama-${VERSION}-bin-linux-${{ matrix.cuda.backend }}-x86_64.zip"
+          echo "name=$ARTIFACT_NAME" >> $GITHUB_OUTPUT
+
+          cd llama.cpp
+          mkdir -p dist/bin
+          cp build/bin/libllama.so dist/bin/
+          # Copy dependencies (libggml.so, libggml-cuda.so, etc.) if they exist
+          find build/bin -name "*.so*" -not -name "libllama.so" -exec cp {} dist/bin/ \;
+
+          cd dist
+          zip -r ../$ARTIFACT_NAME .
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.artifact.outputs.name }}
+          path: llama.cpp/${{ steps.artifact.outputs.name }}
+
+      - name: Release
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: llama.cpp/${{ steps.artifact.outputs.name }}

--- a/.github/workflows/build-llama.yml
+++ b/.github/workflows/build-llama.yml
@@ -110,7 +110,7 @@ jobs:
           - backend: cuda12
             image: nvidia/cuda:12.6.3-devel-ubuntu22.04
           - backend: cuda13
-            image: nvidia/cuda:13.0.1-devel-ubuntu22.04
+            image: nvidia/cuda:13.0-devel-ubuntu22.04
     steps:
       - name: Install dependencies
         run: |

--- a/cli/internal/llamabinary/llamabinary.go
+++ b/cli/internal/llamabinary/llamabinary.go
@@ -33,7 +33,7 @@ var Version = "b8816"
 type Target struct {
 	OS          string // "linux", "darwin", "windows"
 	Arch        string // "amd64", "arm64" (canonical Go arch names)
-	Accelerator string // "cpu", "cuda", "metal", "vulkan", "rocm"
+	Accelerator string // "cpu", "cuda", "cuda12", "cuda13", "metal", "vulkan", "rocm"
 }
 
 // String returns a compact stable identifier like "linux/arm64/cpu".
@@ -61,7 +61,7 @@ var ValidOSes = []string{"linux", "darwin", "windows"}
 var ValidArches = []string{"amd64", "arm64"}
 
 // ValidAccelerators lists the supported compute backends.
-var ValidAccelerators = []string{"cpu", "cuda", "metal", "vulkan", "rocm"}
+var ValidAccelerators = []string{"cpu", "cuda", "cuda12", "cuda13", "metal", "vulkan", "rocm"}
 
 // acceptArchAliases maps user-friendly arch names to canonical Go arch names.
 var acceptArchAliases = map[string]string{
@@ -184,9 +184,28 @@ func SpecFor(t Target, version string) (Spec, error) {
 			LibPath: libName,
 			LibName: libName,
 		}, nil
-	case t.OS == "linux" && t.Arch == "amd64" && (t.Accelerator == "cuda" || t.Accelerator == "rocm"):
-		// Upstream no longer ships Linux CUDA or ROCm binaries; fall back to Vulkan which
-		// typically gives similar GPU acceleration on supported hardware.
+	case t.OS == "linux" && t.Arch == "amd64" && (t.Accelerator == "cuda" || t.Accelerator == "cuda12" || t.Accelerator == "cuda13"):
+		// LlamaFarm hosts its own Linux x86_64 CUDA builds since upstream stopped
+		// shipping them after b7694. Bare "cuda" defaults to cuda12 because it covers
+		// a broader range of installed drivers; callers that know their CUDA major
+		// (e.g. via the Python downloader's nvidia-smi probe) should pass cuda13
+		// explicitly when supported.
+		major := "cuda12"
+		if t.Accelerator == "cuda13" {
+			major = "cuda13"
+		}
+		lfVersion := llamafarmReleaseVersion()
+		return Spec{
+			URL: fmt.Sprintf(
+				"https://github.com/llama-farm/llamafarm/releases/download/%s/llama-%s-bin-linux-%s-x86_64.zip",
+				lfVersion, version, major,
+			),
+			LibPath: libName,
+			LibName: libName,
+		}, nil
+	case t.OS == "linux" && t.Arch == "amd64" && t.Accelerator == "rocm":
+		// Upstream does not ship Linux ROCm binaries; fall back to Vulkan which
+		// typically gives similar GPU acceleration on supported AMD hardware.
 		return Spec{
 			URL:     urlBase(fmt.Sprintf("llama-%s-bin-ubuntu-vulkan-x64.tar.gz", version)),
 			LibPath: libName,
@@ -212,7 +231,10 @@ func SpecFor(t Target, version string) (Spec, error) {
 			LibPath: libName,
 			LibName: libName,
 		}, nil
-	case t.OS == "windows" && t.Arch == "amd64" && t.Accelerator == "cuda":
+	case t.OS == "windows" && t.Arch == "amd64" && (t.Accelerator == "cuda" || t.Accelerator == "cuda12"):
+		// Upstream's Windows CUDA artifact is built against CUDA 12.4 — both
+		// "cuda" (legacy) and the explicit "cuda12" key resolve here. There is
+		// no Windows cuda13 artifact upstream as of b8816.
 		return Spec{
 			URL:     urlBase(fmt.Sprintf("llama-%s-bin-win-cuda-12.4-x64.zip", version)),
 			LibPath: libName,

--- a/cli/internal/llamabinary/llamabinary.go
+++ b/cli/internal/llamabinary/llamabinary.go
@@ -231,10 +231,11 @@ func SpecFor(t Target, version string) (Spec, error) {
 			LibPath: libName,
 			LibName: libName,
 		}, nil
-	case t.OS == "windows" && t.Arch == "amd64" && (t.Accelerator == "cuda" || t.Accelerator == "cuda12"):
-		// Upstream's Windows CUDA artifact is built against CUDA 12.4 — both
-		// "cuda" (legacy) and the explicit "cuda12" key resolve here. There is
-		// no Windows cuda13 artifact upstream as of b8816.
+	case t.OS == "windows" && t.Arch == "amd64" && (t.Accelerator == "cuda" || t.Accelerator == "cuda12" || t.Accelerator == "cuda13"):
+		// Upstream's Windows CUDA artifact is built against CUDA 12.4. There is
+		// no separate Windows cuda13 artifact upstream as of b8816, but a
+		// CUDA 13 driver can load a CUDA 12 binary, so cuda13 forward-falls-back
+		// here rather than degrading to CPU.
 		return Spec{
 			URL:     urlBase(fmt.Sprintf("llama-%s-bin-win-cuda-12.4-x64.zip", version)),
 			LibPath: libName,

--- a/cli/internal/llamabinary/llamabinary_test.go
+++ b/cli/internal/llamabinary/llamabinary_test.go
@@ -123,6 +123,9 @@ func TestSpecFor_LinuxAmd64Cuda13UsesLlamaFarmHost(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SpecFor: %v", err)
 	}
+	if !strings.Contains(spec.URL, "llama-farm/llamafarm") {
+		t.Errorf("expected llama-farm host, got %s", spec.URL)
+	}
 	if !strings.Contains(spec.URL, "bin-linux-cuda13-x86_64.zip") {
 		t.Errorf("unexpected artifact in URL: %s", spec.URL)
 	}

--- a/cli/internal/llamabinary/llamabinary_test.go
+++ b/cli/internal/llamabinary/llamabinary_test.go
@@ -75,6 +75,68 @@ func TestSpecFor_WindowsAmd64Cuda(t *testing.T) {
 	}
 }
 
+func TestSpecFor_WindowsAmd64Cuda12Alias(t *testing.T) {
+	spec, err := SpecFor(Target{OS: "windows", Arch: "amd64", Accelerator: "cuda12"}, "b8816")
+	if err != nil {
+		t.Fatalf("SpecFor: %v", err)
+	}
+	if !strings.Contains(spec.URL, "cuda-12.4") {
+		t.Errorf("expected cuda12 to map to upstream cuda-12.4 artifact, got %s", spec.URL)
+	}
+}
+
+func TestSpecFor_LinuxAmd64Cuda12UsesLlamaFarmHost(t *testing.T) {
+	spec, err := SpecFor(Target{OS: "linux", Arch: "amd64", Accelerator: "cuda12"}, "b8816")
+	if err != nil {
+		t.Fatalf("SpecFor: %v", err)
+	}
+	if !strings.Contains(spec.URL, "llama-farm/llamafarm") {
+		t.Errorf("expected llama-farm host, got %s", spec.URL)
+	}
+	if !strings.Contains(spec.URL, "bin-linux-cuda12-x86_64.zip") {
+		t.Errorf("unexpected artifact in URL: %s", spec.URL)
+	}
+	if spec.LibName != "libllama.so" {
+		t.Errorf("expected libllama.so, got %s", spec.LibName)
+	}
+}
+
+func TestSpecFor_LinuxAmd64Cuda13UsesLlamaFarmHost(t *testing.T) {
+	spec, err := SpecFor(Target{OS: "linux", Arch: "amd64", Accelerator: "cuda13"}, "b8816")
+	if err != nil {
+		t.Fatalf("SpecFor: %v", err)
+	}
+	if !strings.Contains(spec.URL, "bin-linux-cuda13-x86_64.zip") {
+		t.Errorf("unexpected artifact in URL: %s", spec.URL)
+	}
+}
+
+func TestSpecFor_LinuxAmd64BareCudaDefaultsToCuda12(t *testing.T) {
+	// Bare "cuda" must NOT silently fall back to Vulkan now that LlamaFarm
+	// publishes Linux x86_64 CUDA binaries. It defaults to cuda12 because that
+	// covers the broader range of installed drivers.
+	spec, err := SpecFor(Target{OS: "linux", Arch: "amd64", Accelerator: "cuda"}, "b8816")
+	if err != nil {
+		t.Fatalf("SpecFor: %v", err)
+	}
+	if !strings.Contains(spec.URL, "bin-linux-cuda12-x86_64.zip") {
+		t.Errorf("expected bare cuda to default to cuda12 artifact, got %s", spec.URL)
+	}
+	if strings.Contains(spec.URL, "vulkan") {
+		t.Errorf("bare cuda must not fall back to Vulkan, got %s", spec.URL)
+	}
+}
+
+func TestSpecFor_LinuxAmd64RocmFallsBackToVulkan(t *testing.T) {
+	spec, err := SpecFor(Target{OS: "linux", Arch: "amd64", Accelerator: "rocm"}, "b8816")
+	if err != nil {
+		t.Fatalf("SpecFor: %v", err)
+	}
+	if !strings.Contains(spec.URL, "vulkan") {
+		t.Errorf("expected rocm to fall back to vulkan artifact, got %s", spec.URL)
+	}
+}
+
 func TestSpecFor_InvalidCombo(t *testing.T) {
 	_, err := SpecFor(Target{OS: "darwin", Arch: "arm64", Accelerator: "cuda"}, "b8816")
 	if err == nil {

--- a/cli/internal/llamabinary/llamabinary_test.go
+++ b/cli/internal/llamabinary/llamabinary_test.go
@@ -75,6 +75,23 @@ func TestSpecFor_WindowsAmd64Cuda(t *testing.T) {
 	}
 }
 
+func TestSpecFor_WindowsAmd64Cuda13FallsBackToCuda12Artifact(t *testing.T) {
+	// There is no separate Windows cuda13 artifact upstream; a CUDA 13 driver
+	// can load the cuda-12.4 binary, so cuda13 must resolve there rather than
+	// returning ErrSpecNotAvailable (which would silently demote to CPU at the
+	// Download layer).
+	spec, err := SpecFor(Target{OS: "windows", Arch: "amd64", Accelerator: "cuda13"}, "b8816")
+	if err != nil {
+		t.Fatalf("SpecFor: %v", err)
+	}
+	if !strings.Contains(spec.URL, "cuda-12.4") {
+		t.Errorf("expected windows cuda13 to forward-fall-back to cuda-12.4 artifact, got %s", spec.URL)
+	}
+	if strings.Contains(spec.URL, "win-cpu") {
+		t.Errorf("cuda13 must not degrade to CPU artifact, got %s", spec.URL)
+	}
+}
+
 func TestSpecFor_WindowsAmd64Cuda12Alias(t *testing.T) {
 	spec, err := SpecFor(Target{OS: "windows", Arch: "amd64", Accelerator: "cuda12"}, "b8816")
 	if err != nil {

--- a/packages/llamafarm-llama/src/llamafarm_llama/_binary.py
+++ b/packages/llamafarm-llama/src/llamafarm_llama/_binary.py
@@ -40,19 +40,30 @@ LLAMA_CPP_VERSION = _read_llama_cpp_version()
 LLAMA_CPP_REPO = "ggml-org/llama.cpp"
 
 
-def _get_llamafarm_release_version() -> str:
-    """Get LlamaFarm release version for custom-built llama.cpp binary downloads.
+def _get_llamafarm_release_version(expected_asset: Optional[str] = None) -> str:
+    """Get LlamaFarm release tag hosting `expected_asset`.
 
     Custom binaries (Linux ARM64, Linux CUDA) are published as part of the
     main LlamaFarm monorepo release (e.g., v0.0.28), NOT the llamafarm-llama
-    package version. These versions are decoupled.
+    package version. These versions are decoupled — and any individual
+    release may carry only a subset of the platform-specific binaries (an
+    ARM64 release without CUDA, or vice-versa). Picking "the latest release"
+    blindly therefore yields 404s when the requested artifact is missing.
 
-    Priority:
-    1. LLAMAFARM_RELEASE_VERSION env var (explicit override)
-    2. GitHub API query for latest release with the ARM64 binary
-    3. Hardcoded fallback
+    Behavior:
+    1. LLAMAFARM_RELEASE_VERSION env var → explicit override, returned as-is
+       (the caller is taking responsibility for the choice; not validated).
+    2. GitHub API → walk recent releases newest-first, return the first tag
+       whose assets include `expected_asset`. Skips drafts/prereleases.
+    3. Hardcoded fallback (last known good release that ships the standard
+       custom binaries).
+
+    `expected_asset` is the fully-formatted artifact filename (e.g.
+    `llama-b8816-bin-linux-cuda13-x86_64.zip`). When None, accept any
+    release that carries any custom asset — preserves the original
+    behavior for callers that don't have a specific artifact in mind.
     """
-    # 1. Env var override
+    # 1. Env var override (caller is explicitly choosing a tag).
     env_version = os.environ.get("LLAMAFARM_RELEASE_VERSION")
     if env_version:
         if not env_version.startswith("v"):
@@ -60,28 +71,44 @@ def _get_llamafarm_release_version() -> str:
         logger.info(f"Using LlamaFarm release version from env: {env_version}")
         return env_version
 
-    # 2. Query GitHub API for latest release with ARM64 binary
+    # 2. Walk recent releases looking for one that actually carries the asset.
     try:
         import json
 
         req = Request(
-            "https://api.github.com/repos/llama-farm/llamafarm/releases/latest",
-            headers={"User-Agent": "llamafarm-llama", "Accept": "application/vnd.github.v3+json"},
+            "https://api.github.com/repos/llama-farm/llamafarm/releases?per_page=20",
+            headers={
+                "User-Agent": "llamafarm-llama",
+                "Accept": "application/vnd.github.v3+json",
+            },
         )
         with urlopen(req, timeout=10) as response:
-            data = json.loads(response.read())
-            tag = data.get("tag_name")
-            assets = data.get("assets", [])
-            asset_names = [a.get("name", "") for a in assets]
-            if tag and any(("arm64" in n) or ("cuda" in n) for n in asset_names):
-                logger.info(f"Using latest LlamaFarm release: {tag}")
-                return tag
-            elif tag:
-                logger.debug(f"Latest release {tag} has no custom llama.cpp asset, skipping")
+            releases = json.loads(response.read()) or []
+            for rel in releases:
+                if rel.get("draft") or rel.get("prerelease"):
+                    continue
+                tag = rel.get("tag_name")
+                if not tag:
+                    continue
+                asset_names = [a.get("name", "") for a in rel.get("assets", [])]
+                if expected_asset is not None:
+                    if expected_asset in asset_names:
+                        logger.info(
+                            f"Using LlamaFarm release {tag} (carries {expected_asset})"
+                        )
+                        return tag
+                else:
+                    if any(("arm64" in n) or ("cuda" in n) for n in asset_names):
+                        logger.info(f"Using latest LlamaFarm release: {tag}")
+                        return tag
+            logger.debug(
+                "No recent LlamaFarm release carries asset "
+                f"{expected_asset!r}; using fallback"
+            )
     except Exception as e:
-        logger.debug(f"Could not query GitHub for latest release: {e}")
+        logger.debug(f"Could not query GitHub for releases: {e}")
 
-    # 3. Hardcoded fallback (last known good release with ARM64 binary)
+    # 3. Hardcoded fallback (last known good release with custom binaries).
     fallback = "v0.0.28"
     logger.info(f"Using fallback LlamaFarm release version: {fallback}")
     return fallback
@@ -764,10 +791,15 @@ def download_binary(
     manifest = BINARY_MANIFEST[platform_key]
     artifact_template = manifest["artifact"]
     if "{llamafarm_version}" in artifact_template:
-        # Custom build hosted on LlamaFarm releases (Linux ARM64, Linux CUDA, etc.)
-        llamafarm_version = _get_llamafarm_release_version()
+        # Custom build hosted on LlamaFarm releases (Linux ARM64, Linux CUDA, etc.).
+        # Compute the expected asset filename first so _get_llamafarm_release_version
+        # can pick a release that actually carries it — different releases may ship
+        # different subsets of custom binaries (arm64-only, cuda-only, etc.).
+        # Filename portion of the templates never contains {llamafarm_version},
+        # so it's safe to format with just `version`.
+        artifact = artifact_template.rsplit("/", 1)[-1].format(version=version)
+        llamafarm_version = _get_llamafarm_release_version(expected_asset=artifact)
         url = artifact_template.format(version=version, llamafarm_version=llamafarm_version)
-        artifact = url.split("/")[-1]
     else:
         artifact = artifact_template.format(version=version)
         url = f"https://github.com/{LLAMA_CPP_REPO}/releases/download/{version}/{artifact}"

--- a/packages/llamafarm-llama/src/llamafarm_llama/_binary.py
+++ b/packages/llamafarm-llama/src/llamafarm_llama/_binary.py
@@ -368,8 +368,11 @@ def _get_cuda_version() -> Optional[str]:
             if major >= 12:
                 return "cuda12"
             return None
-    except Exception:
-        pass
+    except Exception as e:
+        # nvidia-smi missing, broken, or in an unrecognized format; fall through
+        # to the driver-version mapping. Log at debug so the failure is visible
+        # without spamming installs that intentionally have no CUDA.
+        logger.debug(f"CUDA detection strategy 1 (nvidia-smi text parse) failed: {e}")
 
     # Strategy 2: driver version mapping (CUDA 13 needs >= 580, CUDA 12 needs >= 525)
     try:
@@ -384,8 +387,8 @@ def _get_cuda_version() -> Optional[str]:
             return "cuda13"
         if driver >= 525:
             return "cuda12"
-    except Exception:
-        pass
+    except Exception as e:
+        logger.debug(f"CUDA detection strategy 2 (driver-version mapping) failed: {e}")
 
     return None
 

--- a/packages/llamafarm-llama/src/llamafarm_llama/_binary.py
+++ b/packages/llamafarm-llama/src/llamafarm_llama/_binary.py
@@ -41,11 +41,11 @@ LLAMA_CPP_REPO = "ggml-org/llama.cpp"
 
 
 def _get_llamafarm_release_version() -> str:
-    """Get LlamaFarm release version for ARM64 binary downloads.
+    """Get LlamaFarm release version for custom-built llama.cpp binary downloads.
 
-    The ARM64 llama.cpp binary is published as part of the main LlamaFarm
-    monorepo release (e.g., v0.0.28), NOT the llamafarm-llama package version.
-    These versions are decoupled.
+    Custom binaries (Linux ARM64, Linux CUDA) are published as part of the
+    main LlamaFarm monorepo release (e.g., v0.0.28), NOT the llamafarm-llama
+    package version. These versions are decoupled.
 
     Priority:
     1. LLAMAFARM_RELEASE_VERSION env var (explicit override)
@@ -73,11 +73,11 @@ def _get_llamafarm_release_version() -> str:
             tag = data.get("tag_name")
             assets = data.get("assets", [])
             asset_names = [a.get("name", "") for a in assets]
-            if tag and any("arm64" in name for name in asset_names):
+            if tag and any(("arm64" in n) or ("cuda" in n) for n in asset_names):
                 logger.info(f"Using latest LlamaFarm release: {tag}")
                 return tag
             elif tag:
-                logger.debug(f"Latest release {tag} has no ARM64 asset, skipping")
+                logger.debug(f"Latest release {tag} has no custom llama.cpp asset, skipping")
     except Exception as e:
         logger.debug(f"Could not query GitHub for latest release: {e}")
 
@@ -105,6 +105,19 @@ BINARY_MANIFEST: dict[tuple[str, str, str], dict] = {
     # Linux ARM64 (LlamaFarm provided - not available from upstream)
     ("linux", "arm64", "cpu"): {
         "artifact": "https://github.com/llama-farm/llamafarm/releases/download/{llamafarm_version}/llama-{version}-bin-linux-arm64.zip",
+        "lib": "libllama.so",
+        "sha256": None,
+    },
+    # Linux x86_64 CUDA (LlamaFarm provided - upstream stopped shipping these
+    # for Linux as of b7694; CUDA is split by major version because llama.cpp
+    # binaries are linked against a specific CUDA major).
+    ("linux", "x86_64", "cuda12"): {
+        "artifact": "https://github.com/llama-farm/llamafarm/releases/download/{llamafarm_version}/llama-{version}-bin-linux-cuda12-x86_64.zip",
+        "lib": "libllama.so",
+        "sha256": None,
+    },
+    ("linux", "x86_64", "cuda13"): {
+        "artifact": "https://github.com/llama-farm/llamafarm/releases/download/{llamafarm_version}/llama-{version}-bin-linux-cuda13-x86_64.zip",
         "lib": "libllama.so",
         "sha256": None,
     },
@@ -255,9 +268,9 @@ def _detect_backend(system: str, machine: str) -> str:
 
     # Check for CUDA (only CUDA 12+ is supported; CUDA 11 falls back to CPU)
     if _has_cuda():
-        cuda_version = _get_cuda_version()
-        if cuda_version >= 12:
-            return "cuda12"
+        cuda_backend = _get_cuda_version()
+        if cuda_backend is not None:
+            return cuda_backend
         # CUDA 11 not supported by upstream llama.cpp b7694+, fall through to CPU
 
     # Check for Vulkan
@@ -290,10 +303,42 @@ def _has_cuda() -> bool:
     return False
 
 
-def _get_cuda_version() -> int:
-    """Get major CUDA version."""
+def _get_cuda_version() -> Optional[str]:
+    """Detect the CUDA major version supported by the host driver.
+
+    Returns the BINARY_MANIFEST backend key — "cuda13" or "cuda12" — picking
+    the highest version the installed driver can run, or None when CUDA is
+    not available or only an unsupported (< 12) version is available.
+
+    Detection strategy:
+      1. Parse the "CUDA Version: X.Y" line from `nvidia-smi`'s text output
+         (this is the maximum CUDA runtime the driver supports).
+      2. Fall back to mapping the driver version when (1) is unavailable
+         (some minimal driver installs lack the text output).
+    """
+    import re
     import subprocess
 
+    # Strategy 1: parse "CUDA Version: X.Y" from nvidia-smi
+    try:
+        output = subprocess.check_output(
+            ["nvidia-smi"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=5,
+        )
+        m = re.search(r"CUDA Version:\s*(\d+)", output)
+        if m:
+            major = int(m.group(1))
+            if major >= 13:
+                return "cuda13"
+            if major >= 12:
+                return "cuda12"
+            return None
+    except Exception:
+        pass
+
+    # Strategy 2: driver version mapping (CUDA 13 needs >= 580, CUDA 12 needs >= 525)
     try:
         output = subprocess.check_output(
             ["nvidia-smi", "--query-gpu=driver_version", "--format=csv,noheader"],
@@ -301,13 +346,15 @@ def _get_cuda_version() -> int:
             text=True,
             timeout=5,
         )
-        # Map driver version to CUDA version (approximate)
-        driver = float(output.strip().split(".")[0])
+        driver = float(output.strip().splitlines()[0].split(".")[0])
+        if driver >= 580:
+            return "cuda13"
         if driver >= 525:
-            return 12
-        return 11
+            return "cuda12"
     except Exception:
-        return 11
+        pass
+
+    return None
 
 
 def _has_vulkan() -> bool:
@@ -695,13 +742,14 @@ def download_binary(
             raise RuntimeError(f"No pre-built binary available for {platform_key}")
 
     manifest = BINARY_MANIFEST[platform_key]
-    if platform_key == ("linux", "arm64", "cpu"):
-        # Use full URL from manifest for our custom builds (hosted on LlamaFarm releases)
+    artifact_template = manifest["artifact"]
+    if "{llamafarm_version}" in artifact_template:
+        # Custom build hosted on LlamaFarm releases (Linux ARM64, Linux CUDA, etc.)
         llamafarm_version = _get_llamafarm_release_version()
-        url = manifest["artifact"].format(version=version, llamafarm_version=llamafarm_version)
+        url = artifact_template.format(version=version, llamafarm_version=llamafarm_version)
         artifact = url.split("/")[-1]
     else:
-        artifact = manifest["artifact"].format(version=version)
+        artifact = artifact_template.format(version=version)
         url = f"https://github.com/{LLAMA_CPP_REPO}/releases/download/{version}/{artifact}"
 
     logger.info(f"Downloading llama.cpp {version} for {platform_key}...")

--- a/packages/llamafarm-llama/src/llamafarm_llama/_binary.py
+++ b/packages/llamafarm-llama/src/llamafarm_llama/_binary.py
@@ -112,12 +112,18 @@ BINARY_MANIFEST: dict[tuple[str, str, str], dict] = {
     # for Linux as of b7694; CUDA is split by major version because llama.cpp
     # binaries are linked against a specific CUDA major).
     ("linux", "x86_64", "cuda12"): {
-        "artifact": "https://github.com/llama-farm/llamafarm/releases/download/{llamafarm_version}/llama-{version}-bin-linux-cuda12-x86_64.zip",
+        "artifact": (
+            "https://github.com/llama-farm/llamafarm/releases/download/"
+            "{llamafarm_version}/llama-{version}-bin-linux-cuda12-x86_64.zip"
+        ),
         "lib": "libllama.so",
         "sha256": None,
     },
     ("linux", "x86_64", "cuda13"): {
-        "artifact": "https://github.com/llama-farm/llamafarm/releases/download/{llamafarm_version}/llama-{version}-bin-linux-cuda13-x86_64.zip",
+        "artifact": (
+            "https://github.com/llama-farm/llamafarm/releases/download/"
+            "{llamafarm_version}/llama-{version}-bin-linux-cuda13-x86_64.zip"
+        ),
         "lib": "libllama.so",
         "sha256": None,
     },

--- a/packages/llamafarm-llama/src/llamafarm_llama/_binary.py
+++ b/packages/llamafarm-llama/src/llamafarm_llama/_binary.py
@@ -732,14 +732,28 @@ def download_binary(
                 f"No pre-built binary for {platform_key}; building from source instead."
             )
             return _build_from_source(dest_dir, version, platform_key[2])
-        # Try falling back to CPU
-        system, machine, _ = platform_key
-        cpu_key = (system, machine, "cpu")
-        if cpu_key in BINARY_MANIFEST:
-            logger.warning(f"No binary for {platform_key}, falling back to CPU")
-            platform_key = cpu_key
-        else:
-            raise RuntimeError(f"No pre-built binary available for {platform_key}")
+        system, machine, backend = platform_key
+        # CUDA major-version compatibility: a CUDA 13 driver can load a binary
+        # built against CUDA 12 (this is how Windows works today — we ship a
+        # single cuda12 artifact). Fall back to cuda12 before degrading to CPU
+        # so a CUDA-13 host doesn't silently lose GPU acceleration on platforms
+        # that only publish a cuda12 artifact.
+        if backend == "cuda13":
+            cuda12_key = (system, machine, "cuda12")
+            if cuda12_key in BINARY_MANIFEST:
+                logger.info(
+                    f"No cuda13 binary for {system}/{machine}; using cuda12 "
+                    "(forward-compatible with CUDA 13 drivers)"
+                )
+                platform_key = cuda12_key
+        # Try falling back to CPU if we still don't have a match.
+        if platform_key not in BINARY_MANIFEST:
+            cpu_key = (system, machine, "cpu")
+            if cpu_key in BINARY_MANIFEST:
+                logger.warning(f"No binary for {platform_key}, falling back to CPU")
+                platform_key = cpu_key
+            else:
+                raise RuntimeError(f"No pre-built binary available for {platform_key}")
 
     manifest = BINARY_MANIFEST[platform_key]
     artifact_template = manifest["artifact"]

--- a/packages/llamafarm-llama/src/llamafarm_llama/_binary.py
+++ b/packages/llamafarm-llama/src/llamafarm_llama/_binary.py
@@ -101,10 +101,12 @@ def _get_llamafarm_release_version(expected_asset: Optional[str] = None) -> str:
                     if any(("arm64" in n) or ("cuda" in n) for n in asset_names):
                         logger.info(f"Using latest LlamaFarm release: {tag}")
                         return tag
-            logger.debug(
-                "No recent LlamaFarm release carries asset "
-                f"{expected_asset!r}; using fallback"
-            )
+            if expected_asset is not None:
+                logger.debug(
+                    f"No recent LlamaFarm release carries asset {expected_asset!r}; using fallback"
+                )
+            else:
+                logger.debug("No recent LlamaFarm release with custom assets found; using fallback")
     except Exception as e:
         logger.debug(f"Could not query GitHub for releases: {e}")
 
@@ -382,7 +384,16 @@ def _get_cuda_version() -> Optional[str]:
             text=True,
             timeout=5,
         )
-        driver = float(output.strip().splitlines()[0].split(".")[0])
+        lines = output.strip().splitlines()
+        driver = None
+        for line in lines:
+            try:
+                driver = float(line.strip().split(".")[0])
+                break
+            except ValueError:
+                continue
+        if driver is None:
+            raise ValueError(f"no parseable driver version in nvidia-smi output: {output!r}")
         if driver >= 580:
             return "cuda13"
         if driver >= 525:

--- a/packages/llamafarm-llama/tests/test_binary.py
+++ b/packages/llamafarm-llama/tests/test_binary.py
@@ -2,6 +2,7 @@
 
 import os
 import platform
+import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
@@ -151,6 +152,102 @@ class TestBinaryManifest:
         from llamafarm_llama._binary import BINARY_MANIFEST
 
         assert ("win32", "amd64", "cpu") in BINARY_MANIFEST
+
+    def test_manifest_has_linux_cuda12(self):
+        """Manifest should have Linux x86_64 CUDA 12 build (LlamaFarm provided)."""
+        from llamafarm_llama._binary import BINARY_MANIFEST
+
+        entry = BINARY_MANIFEST[("linux", "x86_64", "cuda12")]
+        assert "{llamafarm_version}" in entry["artifact"]
+        assert "cuda12-x86_64.zip" in entry["artifact"]
+        assert entry["lib"] == "libllama.so"
+
+    def test_manifest_has_linux_cuda13(self):
+        """Manifest should have Linux x86_64 CUDA 13 build (LlamaFarm provided)."""
+        from llamafarm_llama._binary import BINARY_MANIFEST
+
+        entry = BINARY_MANIFEST[("linux", "x86_64", "cuda13")]
+        assert "{llamafarm_version}" in entry["artifact"]
+        assert "cuda13-x86_64.zip" in entry["artifact"]
+        assert entry["lib"] == "libllama.so"
+
+
+class TestCudaVersionDetection:
+    """Test _get_cuda_version() backend selection."""
+
+    def _smi_output(self, cuda_version: str) -> str:
+        """Build a minimal nvidia-smi output containing the CUDA Version field."""
+        return (
+            "Mon May  5 12:00:00 2026\n"
+            "+-----------------------------------------------------------------------------+\n"
+            f"| NVIDIA-SMI 580.00   Driver Version: 580.00   CUDA Version: {cuda_version}     |\n"
+            "+-----------------------------------------------------------------------------+\n"
+        )
+
+    def test_returns_cuda13_when_driver_supports_13(self, monkeypatch):
+        from llamafarm_llama import _binary
+
+        def fake_check_output(cmd, *args, **kwargs):
+            assert cmd[0] == "nvidia-smi"
+            # First call (no --query) returns the text dump.
+            if len(cmd) == 1:
+                return self._smi_output("13.0")
+            raise AssertionError(f"unexpected command {cmd}")
+
+        monkeypatch.setattr(subprocess, "check_output", fake_check_output)
+        assert _binary._get_cuda_version() == "cuda13"
+
+    def test_returns_cuda12_when_driver_supports_12(self, monkeypatch):
+        from llamafarm_llama import _binary
+
+        def fake_check_output(cmd, *args, **kwargs):
+            if len(cmd) == 1:
+                return self._smi_output("12.4")
+            raise AssertionError(f"unexpected command {cmd}")
+
+        monkeypatch.setattr(subprocess, "check_output", fake_check_output)
+        assert _binary._get_cuda_version() == "cuda12"
+
+    def test_returns_none_when_cuda_too_old(self, monkeypatch):
+        """CUDA 11 and below are unsupported and should fall back to CPU."""
+        from llamafarm_llama import _binary
+
+        def fake_check_output(cmd, *args, **kwargs):
+            if len(cmd) == 1:
+                return self._smi_output("11.8")
+            raise AssertionError(f"unexpected command {cmd}")
+
+        monkeypatch.setattr(subprocess, "check_output", fake_check_output)
+        assert _binary._get_cuda_version() is None
+
+    def test_returns_none_when_nvidia_smi_missing(self, monkeypatch):
+        """No CUDA → None, never raises."""
+        from llamafarm_llama import _binary
+
+        def fake_check_output(cmd, *args, **kwargs):
+            raise FileNotFoundError("nvidia-smi not found")
+
+        monkeypatch.setattr(subprocess, "check_output", fake_check_output)
+        assert _binary._get_cuda_version() is None
+
+    def test_falls_back_to_driver_version_mapping(self, monkeypatch):
+        """When the text dump lacks 'CUDA Version', use driver-version fallback."""
+        from llamafarm_llama import _binary
+
+        calls = {"n": 0}
+
+        def fake_check_output(cmd, *args, **kwargs):
+            calls["n"] += 1
+            if len(cmd) == 1:
+                # No "CUDA Version:" line → falls through to strategy 2.
+                return "minimal nvidia-smi output without cuda field\n"
+            # Strategy 2: --query-gpu=driver_version
+            assert "--query-gpu=driver_version" in cmd
+            return "535.183.01\n"
+
+        monkeypatch.setattr(subprocess, "check_output", fake_check_output)
+        assert _binary._get_cuda_version() == "cuda12"
+        assert calls["n"] == 2
 
     def test_manifest_entries_have_artifact(self):
         """All manifest entries should have artifact key."""

--- a/packages/llamafarm-llama/tests/test_binary.py
+++ b/packages/llamafarm-llama/tests/test_binary.py
@@ -172,6 +172,139 @@ class TestBinaryManifest:
         assert entry["lib"] == "libllama.so"
 
 
+class TestLlamafarmReleaseVersionSelection:
+    """`_get_llamafarm_release_version()` must skip releases that lack the
+    requested asset, so an ARM64 download doesn't 404 because the latest
+    release only ships CUDA binaries (or vice-versa)."""
+
+    def _release(self, tag, asset_names, *, draft=False, prerelease=False):
+        return {
+            "tag_name": tag,
+            "draft": draft,
+            "prerelease": prerelease,
+            "assets": [{"name": n} for n in asset_names],
+        }
+
+    def _patch_releases(self, monkeypatch, releases):
+        """Patch urlopen so the function sees `releases` as the API response."""
+        import json
+
+        from llamafarm_llama import _binary
+
+        # _get_llamafarm_release_version uses `with urlopen(...) as r: r.read()`,
+        # so the fake needs a context-manager shape.
+        class _Resp:
+            def __init__(self, data):
+                self._data = data
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+            def read(self):
+                return self._data
+
+        def fake_urlopen(req, timeout=None):  # noqa: ARG001
+            return _Resp(json.dumps(releases).encode())
+
+        monkeypatch.setattr(_binary, "urlopen", fake_urlopen)
+        monkeypatch.delenv("LLAMAFARM_RELEASE_VERSION", raising=False)
+
+    def test_skips_releases_missing_expected_asset(self, monkeypatch):
+        """The newest release ships arm64 only; cuda13 must skip it."""
+        from llamafarm_llama import _binary
+
+        releases = [
+            self._release("v0.0.40", ["llama-b8816-bin-linux-arm64.zip"]),
+            self._release(
+                "v0.0.39",
+                [
+                    "llama-b8816-bin-linux-arm64.zip",
+                    "llama-b8816-bin-linux-cuda13-x86_64.zip",
+                ],
+            ),
+            self._release("v0.0.38", ["unrelated.tar.gz"]),
+        ]
+        self._patch_releases(monkeypatch, releases)
+
+        chosen = _binary._get_llamafarm_release_version(
+            expected_asset="llama-b8816-bin-linux-cuda13-x86_64.zip"
+        )
+        assert chosen == "v0.0.39", (
+            f"expected to skip v0.0.40 (no cuda13 asset), got {chosen}"
+        )
+
+    def test_returns_newest_release_when_asset_present(self, monkeypatch):
+        from llamafarm_llama import _binary
+
+        releases = [
+            self._release(
+                "v0.0.40",
+                [
+                    "llama-b8816-bin-linux-arm64.zip",
+                    "llama-b8816-bin-linux-cuda12-x86_64.zip",
+                ],
+            ),
+            self._release("v0.0.39", ["llama-b8816-bin-linux-cuda12-x86_64.zip"]),
+        ]
+        self._patch_releases(monkeypatch, releases)
+
+        chosen = _binary._get_llamafarm_release_version(
+            expected_asset="llama-b8816-bin-linux-cuda12-x86_64.zip"
+        )
+        assert chosen == "v0.0.40"
+
+    def test_skips_drafts_and_prereleases(self, monkeypatch):
+        from llamafarm_llama import _binary
+
+        releases = [
+            self._release(
+                "v0.0.41-rc1",
+                ["llama-b8816-bin-linux-arm64.zip"],
+                prerelease=True,
+            ),
+            self._release(
+                "v0.0.41-draft",
+                ["llama-b8816-bin-linux-arm64.zip"],
+                draft=True,
+            ),
+            self._release("v0.0.40", ["llama-b8816-bin-linux-arm64.zip"]),
+        ]
+        self._patch_releases(monkeypatch, releases)
+
+        chosen = _binary._get_llamafarm_release_version(
+            expected_asset="llama-b8816-bin-linux-arm64.zip"
+        )
+        assert chosen == "v0.0.40"
+
+    def test_falls_back_when_no_release_carries_asset(self, monkeypatch):
+        from llamafarm_llama import _binary
+
+        releases = [
+            self._release("v0.0.40", ["llama-b8816-bin-linux-arm64.zip"]),
+            self._release("v0.0.39", ["llama-b8816-bin-linux-arm64.zip"]),
+        ]
+        self._patch_releases(monkeypatch, releases)
+
+        chosen = _binary._get_llamafarm_release_version(
+            expected_asset="llama-b8816-bin-linux-cuda13-x86_64.zip"
+        )
+        # Hardcoded fallback returned because no release carried the asset.
+        assert chosen == "v0.0.28"
+
+    def test_env_override_bypasses_validation(self, monkeypatch):
+        from llamafarm_llama import _binary
+
+        monkeypatch.setenv("LLAMAFARM_RELEASE_VERSION", "v9.9.9")
+        # No urlopen patching: env override must short-circuit the API call.
+        chosen = _binary._get_llamafarm_release_version(
+            expected_asset="anything.zip"
+        )
+        assert chosen == "v9.9.9"
+
+
 class TestCudaVersionDetection:
     """Test _get_cuda_version() backend selection."""
 

--- a/packages/llamafarm-llama/tests/test_binary.py
+++ b/packages/llamafarm-llama/tests/test_binary.py
@@ -230,6 +230,35 @@ class TestCudaVersionDetection:
         monkeypatch.setattr(subprocess, "check_output", fake_check_output)
         assert _binary._get_cuda_version() is None
 
+    def test_cuda13_falls_back_to_cuda12_when_no_cuda13_artifact(self, tmp_path, monkeypatch):
+        """Hosts that detect cuda13 but have no cuda13 manifest entry (e.g.
+        Windows, where we ship only a cuda12 artifact) should resolve the
+        cuda12 manifest entry instead of silently degrading to CPU."""
+        from llamafarm_llama import _binary
+
+        monkeypatch.setattr(_binary, "get_platform_key", lambda: ("win32", "amd64", "cuda13"))
+
+        captured: dict[str, str] = {}
+
+        def fake_urlopen(req, timeout=None):  # noqa: ARG001
+            url = req.get_full_url() if hasattr(req, "get_full_url") else str(req)
+            captured["url"] = url
+            raise RuntimeError("stop after URL capture")
+
+        monkeypatch.setattr("llamafarm_llama._binary.urlopen", fake_urlopen)
+
+        with pytest.raises(RuntimeError, match="stop after URL capture|Failed to download"):
+            _binary.download_binary(tmp_path)
+
+        assert "url" in captured, "download_binary did not even attempt a download"
+        # Must hit the cuda12 artifact, NOT a CPU fallback.
+        assert "cuda-12.4" in captured["url"], (
+            f"expected cuda13 to forward-fall-back to cuda12 artifact, got {captured['url']}"
+        )
+        assert "win-cpu" not in captured["url"], (
+            f"cuda13 must not silently degrade to CPU on Windows, got {captured['url']}"
+        )
+
     def test_falls_back_to_driver_version_mapping(self, monkeypatch):
         """When the text dump lacks 'CUDA Version', use driver-version fallback."""
         from llamafarm_llama import _binary


### PR DESCRIPTION
## Summary

Phase 1 of #833. Upstream ggml-org/llama.cpp stopped shipping Linux CUDA prebuilt binaries, silently demoting Linux users with NVIDIA GPUs to CPU (model loads ~5min instead of seconds). This adds LlamaFarm-hosted Linux x86_64 CUDA 12 and CUDA 13 artifacts, mirroring the existing Linux ARM64 pattern.

- **`build-llama.yml`**: new `build-llama-cpp-cuda` matrix job builds `cuda12` and `cuda13` artifacts in `nvidia/cuda:*-devel-ubuntu22.04` containers with `-DGGML_CUDA=ON`, attached to releases alongside the arm64 binary. Builds link against the libcuda stub (symlinked to `libcuda.so.1`) since GH runners have no NVIDIA driver — link-only, the executables aren't shipped.
- **`_get_cuda_version()`**: now returns `"cuda12" | "cuda13" | None`. Parses `CUDA Version: X.Y` from `nvidia-smi`'s text dump; falls back to driver-version mapping (>=580 cuda13, >=525 cuda12). Unit tests cover both versions, the unsupported (CUDA <12) case, missing `nvidia-smi`, and the fallback path.
- **`BINARY_MANIFEST`**: new entries for `("linux","x86_64","cuda12")` and `("linux","x86_64","cuda13")` pointing at the LlamaFarm release URL. `download_binary()` now routes any manifest entry whose template contains `{llamafarm_version}` through the LlamaFarm-hosted path (was hard-coded to the arm64 cpu key) and resolves the LlamaFarm release tag by exact asset name so an arm64-only release can't be picked for a CUDA download.
- **`cli/internal/llamabinary/llamabinary.go`**: `linux/amd64/cuda{,12,13}` resolve to the new LlamaFarm-hosted ZIPs (was silently falling back to Vulkan). Bare `cuda` defaults to `cuda12` for broader driver compatibility. `cuda13` forward-falls-back to `cuda12` on platforms that don't ship a `cuda13` artifact (Windows today). `cuda12`/`cuda13` added to `ValidAccelerators`.

## Out of scope (intentional)

- No bundling of CUDA binaries into release artifacts (200MB+; CUDA stays download-on-first-run).
- No ARM64 + CUDA support.
- No minor-version CUDA granularity (majors only).

## Test plan

- [x] `pytest tests/test_binary.py` — 31/31 pass locally on the rebased branch
- [x] `go test ./internal/llamabinary/...` — passes; new tests cover Linux cuda12/cuda13/bare-cuda routing, the rocm→Vulkan fallback, the Windows cuda12 alias, and the cuda13 → cuda12 forward-fallback
- [x] CI pipeline: 61/61 checks green on the head commit; 0 open CodeQL alerts
- [x] `gh workflow run build-llama.yml` against this branch — all three jobs green: arm64, cuda12, cuda13 (run [25507950919](https://github.com/llama-farm/llamafarm/actions/runs/25507950919))
- [x] Rebased onto main after #829 merged; `download_binary()`'s `{llamafarm_version}` routing matches the new resolution chain. End-to-end "pulls the new artifact on a real CUDA host" can only happen once these binaries ship in a tagged LlamaFarm release (the workflow only attaches to releases on tag refs).