### PR TITLE
fix(rag): filter empty chunks before embedding to prevent ingestion f…

### DIFF
--- a/rag/core/ingest_handler.py
+++ b/rag/core/ingest_handler.py
@@ -135,7 +135,8 @@ class IngestHandler:
                 merged.update(wildcard_override)
             if override_cfg:
                 merged.update(override_cfg)
-            self._validate_chunk_settings(merged, getattr(parser, "type", None))
+            self._validate_chunk_settings(
+                merged, getattr(parser, "type", None))
             parser.config = merged
 
         return parsers
@@ -207,7 +208,8 @@ class IngestHandler:
 
         # Dynamically import the embedder based on type from config
         # Convert type like "OllamaEmbedder" to module path
-        embedder_name_lower = embedder_type.replace("Embedder", "_embedder").lower()
+        embedder_name_lower = embedder_type.replace(
+            "Embedder", "_embedder").lower()
         module_path = f"components.embedders.{embedder_name_lower}"
 
         try:
@@ -222,7 +224,8 @@ class IngestHandler:
             logger.error(
                 f"Failed to load embedder {embedder_type} from {module_path}: {e}"
             )
-            raise ValueError(f"Cannot initialize embedder {embedder_type}: {e}") from e
+            raise ValueError(
+                f"Cannot initialize embedder {embedder_type}: {e}") from e
 
     def _initialize_vector_store(self, project_dir: Path, database: Database):
         """
@@ -323,7 +326,8 @@ class IngestHandler:
         try:
             # Process the blob with the blob processor
             try:
-                documents = self.blob_processor.process_blob(file_data, metadata)
+                documents = self.blob_processor.process_blob(
+                    file_data, metadata)
             except UnsupportedFileTypeError as e:
                 # No appropriate parser configured for this file type
                 error_msg = str(e)
@@ -380,13 +384,35 @@ class IngestHandler:
                 }
 
             if not documents:
-                event_logger.fail_event(f"No documents extracted from {filename}")
+                event_logger.fail_event(
+                    f"No documents extracted from {filename}")
                 return {
                     "status": "error",
                     "message": f"No documents extracted from {filename}",
                     "filename": filename,
                     "document_count": 0,
                 }
+
+            original_chunk_count = len(documents)
+            documents = [doc for doc in documents if doc.content.strip()]
+            filtered_count = original_chunk_count - len(documents)
+
+            if filtered_count == original_chunk_count:
+                error_msg = f"All {original_chunk_count} chunks were empty or whitespace-only for {filename}"
+                logger.error(error_msg)
+                event_logger.fail_event(error_msg)
+                return {
+                    "status": "error",
+                    "reason": "all_chunks_empty",
+                    "message": error_msg,
+                    "filename": filename,
+                    "document_count": 0,
+                }
+
+            if filtered_count > 0:
+                logger.warning(
+                    f"Filtered out {filtered_count}/{original_chunk_count} empty or whitespace-only chunks from {filename}"
+                )
 
             # Log file parsed
             # Extract parser names
@@ -475,7 +501,8 @@ class IngestHandler:
                                 logger.info(
                                     f"\n🧠 Embedding with {self.embedder.__class__.__name__}:"
                                 )
-                                logger.info(f"   └─ Dimensions: {len(doc.embeddings)}")
+                                logger.info(
+                                    f"   └─ Dimensions: {len(doc.embeddings)}")
                             embedded_documents.append(doc)
                         else:
                             # Invalid embedding (zero vector or wrong dimension)
@@ -591,7 +618,8 @@ class IngestHandler:
                         )
                 elif result is False:
                     # Database error occurred
-                    logger.error("Database error occurred during document storage")
+                    logger.error(
+                        "Database error occurred during document storage")
                     raise Exception(
                         "Failed to add documents to vector store - database error"
                     )
@@ -606,7 +634,8 @@ class IngestHandler:
 
             except Exception as e:
                 # If batch add fails, try individual adds for better error handling
-                logger.warning(f"Batch add failed: {e}, trying individual adds")
+                logger.warning(
+                    f"Batch add failed: {e}, trying individual adds")
 
                 for doc in embedded_documents:
                     try:
@@ -621,17 +650,20 @@ class IngestHandler:
                         elif isinstance(result, list) and len(result) == 0:
                             # Empty list means duplicate
                             skipped_count += 1
-                            logger.info(f"Document {doc.id} is duplicate - skipped")
+                            logger.info(
+                                f"Document {doc.id} is duplicate - skipped")
                             logger.info(
                                 f"[DUPLICATE] Document {doc.id} already in database - skipped"
                             )
                         elif result is False:
                             # Database error
-                            logger.error(f"Database error storing document {doc.id}")
+                            logger.error(
+                                f"Database error storing document {doc.id}")
                             logger.error(
                                 f"[ERROR] Database error storing document {doc.id}"
                             )
-                            raise Exception(f"Database error storing document {doc.id}")
+                            raise Exception(
+                                f"Database error storing document {doc.id}")
                         else:
                             # Unexpected return
                             logger.error(
@@ -641,7 +673,8 @@ class IngestHandler:
                                 f"Unexpected return storing document {doc.id}: {type(result)}"
                             )
                     except Exception as doc_e:
-                        logger.error(f"Failed to store document {doc.id}: {doc_e}")
+                        logger.error(
+                            f"Failed to store document {doc.id}: {doc_e}")
                         logger.error(
                             f"[ERROR] Failed to store document {doc.id}: {doc_e}"
                         )
@@ -669,7 +702,8 @@ class IngestHandler:
             if stored_count > 0:
                 logger.info(f"   ✅ Stored: {stored_count} new chunks")
             if skipped_count > 0:
-                logger.info(f"   ⏭️  Skipped: {skipped_count} duplicate chunks")
+                logger.info(
+                    f"   ⏭️  Skipped: {skipped_count} duplicate chunks")
 
             # Summary
             summary_lines = [
@@ -856,7 +890,8 @@ class IngestHandler:
                 logger.error(f"Error processing file {file_path}: {e}")
                 results["failed"] += 1
                 results["file_results"].append(
-                    {"status": "error", "filename": file_path.name, "message": str(e)}
+                    {"status": "error", "filename": file_path.name,
+                        "message": str(e)}
                 )
 
         return results

--- a/rag/core/ingest_handler.py
+++ b/rag/core/ingest_handler.py
@@ -438,6 +438,7 @@ class IngestHandler:
                 "chunks_created",
                 {
                     "chunk_count": len(documents),
+                    "filtered_chunk_count": filtered_count,
                     "avg_chunk_size": int(avg_chunk_size),
                     "file_hash": file_hash[:16],
                 },

--- a/rag/core/ingest_handler.py
+++ b/rag/core/ingest_handler.py
@@ -135,8 +135,7 @@ class IngestHandler:
                 merged.update(wildcard_override)
             if override_cfg:
                 merged.update(override_cfg)
-            self._validate_chunk_settings(
-                merged, getattr(parser, "type", None))
+            self._validate_chunk_settings(merged, getattr(parser, "type", None))
             parser.config = merged
 
         return parsers
@@ -208,8 +207,7 @@ class IngestHandler:
 
         # Dynamically import the embedder based on type from config
         # Convert type like "OllamaEmbedder" to module path
-        embedder_name_lower = embedder_type.replace(
-            "Embedder", "_embedder").lower()
+        embedder_name_lower = embedder_type.replace("Embedder", "_embedder").lower()
         module_path = f"components.embedders.{embedder_name_lower}"
 
         try:
@@ -224,8 +222,7 @@ class IngestHandler:
             logger.error(
                 f"Failed to load embedder {embedder_type} from {module_path}: {e}"
             )
-            raise ValueError(
-                f"Cannot initialize embedder {embedder_type}: {e}") from e
+            raise ValueError(f"Cannot initialize embedder {embedder_type}: {e}") from e
 
     def _initialize_vector_store(self, project_dir: Path, database: Database):
         """
@@ -326,8 +323,7 @@ class IngestHandler:
         try:
             # Process the blob with the blob processor
             try:
-                documents = self.blob_processor.process_blob(
-                    file_data, metadata)
+                documents = self.blob_processor.process_blob(file_data, metadata)
             except UnsupportedFileTypeError as e:
                 # No appropriate parser configured for this file type
                 error_msg = str(e)
@@ -384,8 +380,7 @@ class IngestHandler:
                 }
 
             if not documents:
-                event_logger.fail_event(
-                    f"No documents extracted from {filename}")
+                event_logger.fail_event(f"No documents extracted from {filename}")
                 return {
                     "status": "error",
                     "message": f"No documents extracted from {filename}",
@@ -501,8 +496,7 @@ class IngestHandler:
                                 logger.info(
                                     f"\n🧠 Embedding with {self.embedder.__class__.__name__}:"
                                 )
-                                logger.info(
-                                    f"   └─ Dimensions: {len(doc.embeddings)}")
+                                logger.info(f"   └─ Dimensions: {len(doc.embeddings)}")
                             embedded_documents.append(doc)
                         else:
                             # Invalid embedding (zero vector or wrong dimension)
@@ -618,8 +612,7 @@ class IngestHandler:
                         )
                 elif result is False:
                     # Database error occurred
-                    logger.error(
-                        "Database error occurred during document storage")
+                    logger.error("Database error occurred during document storage")
                     raise Exception(
                         "Failed to add documents to vector store - database error"
                     )
@@ -634,8 +627,7 @@ class IngestHandler:
 
             except Exception as e:
                 # If batch add fails, try individual adds for better error handling
-                logger.warning(
-                    f"Batch add failed: {e}, trying individual adds")
+                logger.warning(f"Batch add failed: {e}, trying individual adds")
 
                 for doc in embedded_documents:
                     try:
@@ -650,20 +642,17 @@ class IngestHandler:
                         elif isinstance(result, list) and len(result) == 0:
                             # Empty list means duplicate
                             skipped_count += 1
-                            logger.info(
-                                f"Document {doc.id} is duplicate - skipped")
+                            logger.info(f"Document {doc.id} is duplicate - skipped")
                             logger.info(
                                 f"[DUPLICATE] Document {doc.id} already in database - skipped"
                             )
                         elif result is False:
                             # Database error
-                            logger.error(
-                                f"Database error storing document {doc.id}")
+                            logger.error(f"Database error storing document {doc.id}")
                             logger.error(
                                 f"[ERROR] Database error storing document {doc.id}"
                             )
-                            raise Exception(
-                                f"Database error storing document {doc.id}")
+                            raise Exception(f"Database error storing document {doc.id}")
                         else:
                             # Unexpected return
                             logger.error(
@@ -673,8 +662,7 @@ class IngestHandler:
                                 f"Unexpected return storing document {doc.id}: {type(result)}"
                             )
                     except Exception as doc_e:
-                        logger.error(
-                            f"Failed to store document {doc.id}: {doc_e}")
+                        logger.error(f"Failed to store document {doc.id}: {doc_e}")
                         logger.error(
                             f"[ERROR] Failed to store document {doc.id}: {doc_e}"
                         )
@@ -702,8 +690,7 @@ class IngestHandler:
             if stored_count > 0:
                 logger.info(f"   ✅ Stored: {stored_count} new chunks")
             if skipped_count > 0:
-                logger.info(
-                    f"   ⏭️  Skipped: {skipped_count} duplicate chunks")
+                logger.info(f"   ⏭️  Skipped: {skipped_count} duplicate chunks")
 
             # Summary
             summary_lines = [
@@ -890,8 +877,7 @@ class IngestHandler:
                 logger.error(f"Error processing file {file_path}: {e}")
                 results["failed"] += 1
                 results["file_results"].append(
-                    {"status": "error", "filename": file_path.name,
-                        "message": str(e)}
+                    {"status": "error", "filename": file_path.name, "message": str(e)}
                 )
 
         return results

--- a/rag/tests/test_ingest_empty_chunks.py
+++ b/rag/tests/test_ingest_empty_chunks.py
@@ -5,41 +5,33 @@ Verifies fix for issue #686 - PDF ingestion fails with
 """
 from unittest.mock import MagicMock, patch
 
-import pytest
-
+from core.base import Document
 from core.ingest_handler import IngestHandler
 
 
 def _make_doc(content):
-    doc = MagicMock()
-    doc.content = content
-    doc.metadata = {"parser": "test"}
-    return doc
+    return Document(content=content, metadata={"parser": "test"})
 
 
 def _make_handler():
-    with patch("core.ingest_handler.load_config"), \
-         patch("core.ingest_handler.SchemaHandler"), \
-         patch("core.ingest_handler.BlobProcessor"), \
-         patch("core.ingest_handler.EventLogger"):
-        handler = IngestHandler.__new__(IngestHandler)
-        handler.namespace = "test"
-        handler.project = "test"
-        handler.database = "test"
-        handler.dataset_name = None
-        handler.data_processing_strategy = "test"
-        handler.blob_processor = MagicMock()
-        handler.embedder = MagicMock()
-        handler.vector_store = MagicMock()
-        handler.config = MagicMock()
-        return handler
+    handler = IngestHandler.__new__(IngestHandler)
+    handler.namespace = "test"
+    handler.project = "test"
+    handler.database = "test"
+    handler.dataset_name = None
+    handler.data_processing_strategy = "test"
+    handler.blob_processor = MagicMock()
+    handler.embedder = MagicMock()
+    handler.vector_store = MagicMock()
+    handler.config = MagicMock()
+    return handler
 
 
 class TestEmptyChunkFiltering:
     """Tests that ingest_file filters empty chunks before embedding."""
 
     def test_empty_chunks_are_filtered(self):
-        """Embedder should only receive non-empty chunks."""
+        """Empty string chunks should never reach the embedder."""
         handler = _make_handler()
         handler.blob_processor.process_blob.return_value = [
             _make_doc("valid chunk"),
@@ -53,9 +45,10 @@ class TestEmptyChunkFiltering:
 
         with patch("core.ingest_handler.EventLogger"), \
              patch("core.ingest_handler.is_valid_embedding", return_value=(True, None)):
-            result = handler.ingest_file(b"fake pdf", {"filename": "test.pdf"})
+            handler.ingest_file(b"fake pdf", {"filename": "test.pdf"})
 
-        assert handler.embedder.embed.call_count == 2
+        embedded_args = [call.args[0] for call in handler.embedder.embed.call_args_list]
+        assert len(embedded_args) == 2
 
     def test_whitespace_only_chunks_are_filtered(self):
         """Whitespace-only chunks should never reach the embedder."""
@@ -72,9 +65,10 @@ class TestEmptyChunkFiltering:
 
         with patch("core.ingest_handler.EventLogger"), \
              patch("core.ingest_handler.is_valid_embedding", return_value=(True, None)):
-            result = handler.ingest_file(b"fake pdf", {"filename": "test.pdf"})
+            handler.ingest_file(b"fake pdf", {"filename": "test.pdf"})
 
-        assert handler.embedder.embed.call_count == 1
+        embedded_args = [call.args[0] for call in handler.embedder.embed.call_args_list]
+        assert len(embedded_args) == 1
 
     def test_all_valid_chunks_pass_through(self):
         """Valid chunks should all reach the embedder."""
@@ -91,12 +85,13 @@ class TestEmptyChunkFiltering:
 
         with patch("core.ingest_handler.EventLogger"), \
              patch("core.ingest_handler.is_valid_embedding", return_value=(True, None)):
-            result = handler.ingest_file(b"fake pdf", {"filename": "test.pdf"})
+            handler.ingest_file(b"fake pdf", {"filename": "test.pdf"})
 
-        assert handler.embedder.embed.call_count == 3
+        embedded_args = [call.args[0] for call in handler.embedder.embed.call_args_list]
+        assert len(embedded_args) == 3
 
     def test_all_empty_chunks_returns_error(self):
-        """If all chunks are empty, ingest_file should return an error."""
+        """If all chunks are empty, ingest_file should return error and never call embedder."""
         handler = _make_handler()
         handler.blob_processor.process_blob.return_value = [
             _make_doc(""),
@@ -111,8 +106,8 @@ class TestEmptyChunkFiltering:
         assert result["reason"] == "all_chunks_empty"
         handler.embedder.embed.assert_not_called()
 
-    def test_filtered_count_logged_correctly(self):
-        """When some chunks are filtered, result should reflect only valid chunks."""
+    def test_mixed_valid_and_empty_chunks(self):
+        """Embedder should only receive the valid chunks from a mixed input."""
         handler = _make_handler()
         handler.blob_processor.process_blob.return_value = [
             _make_doc("valid"),
@@ -127,6 +122,7 @@ class TestEmptyChunkFiltering:
 
         with patch("core.ingest_handler.EventLogger"), \
              patch("core.ingest_handler.is_valid_embedding", return_value=(True, None)):
-            result = handler.ingest_file(b"fake pdf", {"filename": "test.pdf"})
+            handler.ingest_file(b"fake pdf", {"filename": "test.pdf"})
 
-        assert handler.embedder.embed.call_count == 2
+        embedded_args = [call.args[0] for call in handler.embedder.embed.call_args_list]
+        assert len(embedded_args) == 2

--- a/rag/tests/test_ingest_empty_chunks.py
+++ b/rag/tests/test_ingest_empty_chunks.py
@@ -3,75 +3,130 @@ Tests for empty chunk filtering in the ingest pipeline.
 Verifies fix for issue #686 - PDF ingestion fails with
 "Cannot embed empty text" error.
 """
-
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from core.ingest_handler import IngestHandler
+
+
+def _make_doc(content):
+    doc = MagicMock()
+    doc.content = content
+    doc.metadata = {"parser": "test"}
+    return doc
+
+
+def _make_handler():
+    with patch("core.ingest_handler.load_config"), \
+         patch("core.ingest_handler.SchemaHandler"), \
+         patch("core.ingest_handler.BlobProcessor"), \
+         patch("core.ingest_handler.EventLogger"):
+        handler = IngestHandler.__new__(IngestHandler)
+        handler.namespace = "test"
+        handler.project = "test"
+        handler.database = "test"
+        handler.dataset_name = None
+        handler.data_processing_strategy = "test"
+        handler.blob_processor = MagicMock()
+        handler.embedder = MagicMock()
+        handler.vector_store = MagicMock()
+        handler.config = MagicMock()
+        return handler
+
 
 class TestEmptyChunkFiltering:
-    """Tests for empty/whitespace chunk filtering before embedding."""
-
-    def _make_doc(self, content):
-        doc = MagicMock()
-        doc.content = content
-        doc.metadata = {}
-        return doc
+    """Tests that ingest_file filters empty chunks before embedding."""
 
     def test_empty_chunks_are_filtered(self):
-        """Empty string chunks should be removed before embedding."""
-        documents = [
-            self._make_doc("valid chunk"),
-            self._make_doc(""),
-            self._make_doc("another valid chunk"),
+        """Embedder should only receive non-empty chunks."""
+        handler = _make_handler()
+        handler.blob_processor.process_blob.return_value = [
+            _make_doc("valid chunk"),
+            _make_doc(""),
+            _make_doc("another valid chunk"),
         ]
-        filtered = [
-            doc for doc in documents if doc.content and doc.content.strip()]
-        assert len(filtered) == 2
+        handler.embedder.get_embedding_dimension.return_value = 3
+        handler.embedder.validate_config.return_value = True
+        handler.embedder.embed.return_value = [[0.1, 0.2, 0.3]]
+        handler.vector_store.add_documents.return_value = ["id1"]
+
+        with patch("core.ingest_handler.EventLogger"), \
+             patch("core.ingest_handler.is_valid_embedding", return_value=(True, None)):
+            result = handler.ingest_file(b"fake pdf", {"filename": "test.pdf"})
+
+        assert handler.embedder.embed.call_count == 2
 
     def test_whitespace_only_chunks_are_filtered(self):
-        """Whitespace-only chunks should be removed before embedding."""
-        documents = [
-            self._make_doc("valid chunk"),
-            self._make_doc("   "),
-            self._make_doc("\n\t"),
+        """Whitespace-only chunks should never reach the embedder."""
+        handler = _make_handler()
+        handler.blob_processor.process_blob.return_value = [
+            _make_doc("valid chunk"),
+            _make_doc("   "),
+            _make_doc("\n\t"),
         ]
-        filtered = [
-            doc for doc in documents if doc.content and doc.content.strip()]
-        assert len(filtered) == 1
+        handler.embedder.get_embedding_dimension.return_value = 3
+        handler.embedder.validate_config.return_value = True
+        handler.embedder.embed.return_value = [[0.1, 0.2, 0.3]]
+        handler.vector_store.add_documents.return_value = ["id1"]
+
+        with patch("core.ingest_handler.EventLogger"), \
+             patch("core.ingest_handler.is_valid_embedding", return_value=(True, None)):
+            result = handler.ingest_file(b"fake pdf", {"filename": "test.pdf"})
+
+        assert handler.embedder.embed.call_count == 1
 
     def test_all_valid_chunks_pass_through(self):
-        """Valid chunks should not be filtered."""
-        documents = [
-            self._make_doc("chunk one"),
-            self._make_doc("chunk two"),
-            self._make_doc("chunk three"),
+        """Valid chunks should all reach the embedder."""
+        handler = _make_handler()
+        handler.blob_processor.process_blob.return_value = [
+            _make_doc("chunk one"),
+            _make_doc("chunk two"),
+            _make_doc("chunk three"),
         ]
-        filtered = [
-            doc for doc in documents if doc.content and doc.content.strip()]
-        assert len(filtered) == 3
+        handler.embedder.get_embedding_dimension.return_value = 3
+        handler.embedder.validate_config.return_value = True
+        handler.embedder.embed.return_value = [[0.1, 0.2, 0.3]]
+        handler.vector_store.add_documents.return_value = ["id1"]
 
-    def test_all_empty_chunks_returns_zero(self):
-        """If all chunks are empty, result should be empty list."""
-        documents = [
-            self._make_doc(""),
-            self._make_doc("   "),
-            self._make_doc("\n"),
-        ]
-        filtered = [
-            doc for doc in documents if doc.content and doc.content.strip()]
-        assert len(filtered) == 0
+        with patch("core.ingest_handler.EventLogger"), \
+             patch("core.ingest_handler.is_valid_embedding", return_value=(True, None)):
+            result = handler.ingest_file(b"fake pdf", {"filename": "test.pdf"})
 
-    def test_filtered_count_is_correct(self):
-        """Filtered count should accurately reflect removed chunks."""
-        documents = [
-            self._make_doc("valid"),
-            self._make_doc(""),
-            self._make_doc("  "),
-            self._make_doc("also valid"),
+        assert handler.embedder.embed.call_count == 3
+
+    def test_all_empty_chunks_returns_error(self):
+        """If all chunks are empty, ingest_file should return an error."""
+        handler = _make_handler()
+        handler.blob_processor.process_blob.return_value = [
+            _make_doc(""),
+            _make_doc("   "),
+            _make_doc("\n"),
         ]
-        original_count = len(documents)
-        filtered = [
-            doc for doc in documents if doc.content and doc.content.strip()]
-        filtered_count = original_count - len(filtered)
-        assert filtered_count == 2
+
+        with patch("core.ingest_handler.EventLogger"):
+            result = handler.ingest_file(b"fake pdf", {"filename": "test.pdf"})
+
+        assert result["status"] == "error"
+        assert result["reason"] == "all_chunks_empty"
+        handler.embedder.embed.assert_not_called()
+
+    def test_filtered_count_logged_correctly(self):
+        """When some chunks are filtered, result should reflect only valid chunks."""
+        handler = _make_handler()
+        handler.blob_processor.process_blob.return_value = [
+            _make_doc("valid"),
+            _make_doc(""),
+            _make_doc("  "),
+            _make_doc("also valid"),
+        ]
+        handler.embedder.get_embedding_dimension.return_value = 3
+        handler.embedder.validate_config.return_value = True
+        handler.embedder.embed.return_value = [[0.1, 0.2, 0.3]]
+        handler.vector_store.add_documents.return_value = ["id1"]
+
+        with patch("core.ingest_handler.EventLogger"), \
+             patch("core.ingest_handler.is_valid_embedding", return_value=(True, None)):
+            result = handler.ingest_file(b"fake pdf", {"filename": "test.pdf"})
+
+        assert handler.embedder.embed.call_count == 2

--- a/rag/tests/test_ingest_empty_chunks.py
+++ b/rag/tests/test_ingest_empty_chunks.py
@@ -1,0 +1,77 @@
+"""
+Tests for empty chunk filtering in the ingest pipeline.
+Verifies fix for issue #686 - PDF ingestion fails with
+"Cannot embed empty text" error.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestEmptyChunkFiltering:
+    """Tests for empty/whitespace chunk filtering before embedding."""
+
+    def _make_doc(self, content):
+        doc = MagicMock()
+        doc.content = content
+        doc.metadata = {}
+        return doc
+
+    def test_empty_chunks_are_filtered(self):
+        """Empty string chunks should be removed before embedding."""
+        documents = [
+            self._make_doc("valid chunk"),
+            self._make_doc(""),
+            self._make_doc("another valid chunk"),
+        ]
+        filtered = [
+            doc for doc in documents if doc.content and doc.content.strip()]
+        assert len(filtered) == 2
+
+    def test_whitespace_only_chunks_are_filtered(self):
+        """Whitespace-only chunks should be removed before embedding."""
+        documents = [
+            self._make_doc("valid chunk"),
+            self._make_doc("   "),
+            self._make_doc("\n\t"),
+        ]
+        filtered = [
+            doc for doc in documents if doc.content and doc.content.strip()]
+        assert len(filtered) == 1
+
+    def test_all_valid_chunks_pass_through(self):
+        """Valid chunks should not be filtered."""
+        documents = [
+            self._make_doc("chunk one"),
+            self._make_doc("chunk two"),
+            self._make_doc("chunk three"),
+        ]
+        filtered = [
+            doc for doc in documents if doc.content and doc.content.strip()]
+        assert len(filtered) == 3
+
+    def test_all_empty_chunks_returns_zero(self):
+        """If all chunks are empty, result should be empty list."""
+        documents = [
+            self._make_doc(""),
+            self._make_doc("   "),
+            self._make_doc("\n"),
+        ]
+        filtered = [
+            doc for doc in documents if doc.content and doc.content.strip()]
+        assert len(filtered) == 0
+
+    def test_filtered_count_is_correct(self):
+        """Filtered count should accurately reflect removed chunks."""
+        documents = [
+            self._make_doc("valid"),
+            self._make_doc(""),
+            self._make_doc("  "),
+            self._make_doc("also valid"),
+        ]
+        original_count = len(documents)
+        filtered = [
+            doc for doc in documents if doc.content and doc.content.strip()]
+        filtered_count = original_count - len(filtered)
+        assert filtered_count == 2


### PR DESCRIPTION
Fixes #686

## Problem

PDF ingestion can fail with:

`Cannot embed empty text`

This happens when the parser generates empty or whitespace-only chunks from blank pages or image-only pages.

## Fix

Added filtering after parsing and before embedding to remove empty/whitespace-only chunks.

Behavior:
- skips invalid chunks before embedding
- prevents embedding failures caused by empty chunks
- safely handles all-empty inputs

## Changes

- `rag/core/ingest_handler.py`
  - added empty chunk filtering before embedding

- `rag/tests/test_ingest_empty_chunks.py`
  - added tests covering:
    - empty chunks
    - whitespace-only chunks
    - mixed valid/invalid chunks
    - all-empty input handling
    - filtered chunk counting

## Test Results

```text
5 passed in 0.12s