### PR TITLE
feat(rag): add OCR parameter passthrough and metadata enrichment

### DIFF
--- a/rag/components/parsers/universal/config.yaml
+++ b/rag/components/parsers/universal/config.yaml
@@ -90,6 +90,9 @@ parsers:
       chunk_strategy: semantic  # semantic, sections, paragraphs, sentences, characters
       use_ocr: true
       ocr_endpoint: "http://127.0.0.1:14345/v1/vision/ocr"
+      ocr_model: null
+      ocr_languages: null
+      return_boxes: false
       extract_metadata: true
       min_chunk_size: 50
       max_chunk_size: 8000

--- a/rag/components/parsers/universal/universal_parser.py
+++ b/rag/components/parsers/universal/universal_parser.py
@@ -62,9 +62,7 @@ class UniversalParser(BaseParser):
     - Graceful degradation when dependencies unavailable
     """
 
-    def __init__(
-        self, name: str | None = None, config: dict[str, Any] | None = None
-    ):
+    def __init__(self, name: str | None = None, config: dict[str, Any] | None = None):
         """Initialize the UniversalParser.
 
         Args:
@@ -92,6 +90,9 @@ class UniversalParser(BaseParser):
         self.ocr_endpoint = self.config.get(
             "ocr_endpoint", "http://127.0.0.1:14345/v1/vision/ocr"
         )
+        self.ocr_model = self.config.get("ocr_model")
+        self.ocr_languages = self.config.get("ocr_languages")
+        self.return_boxes = self.config.get("return_boxes", False)
         self.extract_metadata = self.config.get("extract_metadata", True)
         self.min_chunk_size = self.config.get("min_chunk_size", 50)
         self.max_chunk_size = self.config.get("max_chunk_size", 8000)
@@ -205,10 +206,17 @@ class UniversalParser(BaseParser):
             and self.use_ocr
             and self._needs_ocr(file_path, text)
         ):
-            ocr_text = self._run_remote_ocr(str(file_path))
-            if ocr_text and len(ocr_text) > len(text or ""):
-                text = ocr_text
+            ocr_result = self._run_remote_ocr(str(file_path))
+            if ocr_result and len(ocr_result["text"]) > len(text or ""):
+                text = ocr_result["text"]
                 doc_metadata["ocr_applied"] = True
+                doc_metadata["source_type"] = "image"
+                if ocr_result.get("ocr_model"):
+                    doc_metadata["ocr_model"] = ocr_result["ocr_model"]
+                if ocr_result.get("ocr_languages"):
+                    doc_metadata["ocr_languages"] = ocr_result["ocr_languages"]
+                if ocr_result.get("ocr_confidence"):
+                    doc_metadata["ocr_confidence"] = ocr_result["ocr_confidence"]
                 self.logger.info("OCR applied", file_path=str(file_path))
 
         if not text or len(text.strip()) < self.min_chunk_size:
@@ -297,9 +305,7 @@ class UniversalParser(BaseParser):
                 with open(file_path, encoding=encoding, errors="ignore") as f:
                     return f.read(), metadata
             except Exception as e:
-                self.logger.error(
-                    f"Failed to read file: {e}", file_path=str(file_path)
-                )
+                self.logger.error(f"Failed to read file: {e}", file_path=str(file_path))
                 return "", metadata
 
         try:
@@ -444,10 +450,7 @@ class UniversalParser(BaseParser):
                 continue
 
             # Check if adding this paragraph exceeds chunk size
-            if (
-                len(current_chunk) + len(para) + 2 > self.chunk_size
-                and current_chunk
-            ):
+            if len(current_chunk) + len(para) + 2 > self.chunk_size and current_chunk:
                 if len(current_chunk) >= self.min_chunk_size:
                     chunks.append(current_chunk)
                 current_chunk = para
@@ -615,14 +618,14 @@ class UniversalParser(BaseParser):
         text_len = len((text or "").strip())
         return text_len < 50
 
-    def _run_remote_ocr(self, file_path: str) -> str | None:
+    def _run_remote_ocr(self, file_path: str) -> dict | None:
         """Run OCR via Universal Runtime endpoint.
 
         Args:
             file_path: Path to the file
 
         Returns:
-            OCR text or None if failed
+            Dict with OCR results or None if failed
         """
         try:
             import base64
@@ -633,18 +636,34 @@ class UniversalParser(BaseParser):
             with open(file_path, "rb") as f:
                 file_data = base64.b64encode(f.read()).decode("utf-8")
 
+            # Build request payload
+            payload = {
+                "image": file_data,
+                "filename": Path(file_path).name,
+            }
+
+            # Conditionally add optional parameters
+            if self.ocr_model:
+                payload["model"] = self.ocr_model
+            if self.ocr_languages:
+                payload["languages"] = self.ocr_languages
+            if self.return_boxes:
+                payload["return_boxes"] = self.return_boxes
+
             response = requests.post(
                 self.ocr_endpoint,
-                json={
-                    "image": file_data,
-                    "filename": Path(file_path).name,
-                },
+                json=payload,
                 timeout=60,
             )
 
             if response.ok:
                 result = response.json()
-                return result.get("text", "")
+                return {
+                    "text": result.get("text", ""),
+                    "ocr_model": result.get("model"),
+                    "ocr_languages": result.get("languages"),
+                    "ocr_confidence": result.get("confidence"),
+                }
 
         except Exception as e:
             self.logger.warning(f"OCR request failed: {e}")

--- a/rag/components/parsers/universal/universal_parser.py
+++ b/rag/components/parsers/universal/universal_parser.py
@@ -628,41 +628,33 @@ class UniversalParser(BaseParser):
             Dict with OCR results or None if failed
         """
         try:
-            import base64
-
             import requests
 
-            # Read file and encode as base64
-            with open(file_path, "rb") as f:
-                file_data = base64.b64encode(f.read()).decode("utf-8")
+            with open(file_path, "rb") as fh:
+                files = {"file": (Path(file_path).name, fh)}
+                data = {}
+                if self.ocr_model:
+                    data["model"] = self.ocr_model
+                if self.ocr_languages:
+                    data["languages"] = ",".join(self.ocr_languages)
+                if self.return_boxes:
+                    data["return_boxes"] = "true"
 
-            # Build request payload
-            payload = {
-                "image": file_data,
-                "filename": Path(file_path).name,
-            }
-
-            # Conditionally add optional parameters
-            if self.ocr_model:
-                payload["model"] = self.ocr_model
-            if self.ocr_languages:
-                payload["languages"] = self.ocr_languages
-            if self.return_boxes:
-                payload["return_boxes"] = self.return_boxes
-
-            response = requests.post(
-                self.ocr_endpoint,
-                json=payload,
-                timeout=60,
-            )
+                response = requests.post(
+                    self.ocr_endpoint,
+                    files=files,
+                    data=data,
+                    timeout=60,
+                )
 
             if response.ok:
-                result = response.json()
+                payload = response.json()
+                item = (payload.get("data") or [{}])[0]
                 return {
-                    "text": result.get("text", ""),
-                    "ocr_model": result.get("model"),
-                    "ocr_languages": result.get("languages"),
-                    "ocr_confidence": result.get("confidence"),
+                    "text": item.get("text", ""),
+                    "ocr_model": payload.get("model"),
+                    "ocr_languages": self.ocr_languages,
+                    "ocr_confidence": item.get("confidence"),
                 }
 
         except Exception as e:

--- a/rag/components/parsers/universal/universal_parser.py
+++ b/rag/components/parsers/universal/universal_parser.py
@@ -23,8 +23,7 @@ from core.logging import RAGStructLogger
 logger = RAGStructLogger("rag.components.parsers.universal")
 
 # Chunking strategy type
-ChunkStrategy = Literal["semantic", "sections",
-                        "paragraphs", "sentences", "characters"]
+ChunkStrategy = Literal["semantic", "sections", "paragraphs", "sentences", "characters"]
 
 # Try to import optional dependencies
 try:
@@ -161,8 +160,7 @@ class UniversalParser(BaseParser):
                 "text/markdown",
             ],
             capabilities=["text_extraction", "chunking"],
-            dependencies={"required": ["markitdown"],
-                          "optional": ["semchunk"]},
+            dependencies={"required": ["markitdown"], "optional": ["semchunk"]},
             default_config={"chunk_size": 1024, "chunk_strategy": "semantic"},
         )
 
@@ -307,14 +305,12 @@ class UniversalParser(BaseParser):
                 with open(file_path, encoding=encoding, errors="ignore") as f:
                     return f.read(), metadata
             except Exception as e:
-                self.logger.error(
-                    f"Failed to read file: {e}", file_path=str(file_path))
+                self.logger.error(f"Failed to read file: {e}", file_path=str(file_path))
                 return "", metadata
 
         try:
             result = self._markitdown.convert(str(file_path))
-            text = result.text_content if hasattr(
-                result, "text_content") else ""
+            text = result.text_content if hasattr(result, "text_content") else ""
 
             # Extract any metadata from MarkItDown result
             if (
@@ -386,8 +382,7 @@ class UniversalParser(BaseParser):
             # Average ~4 chars per token for English
             token_chunk_size = max(self.chunk_size // 4, 100)
 
-            chunker = semchunk.chunkerify(
-                self._encoder, chunk_size=token_chunk_size)
+            chunker = semchunk.chunkerify(self._encoder, chunk_size=token_chunk_size)
             chunks = chunker(text)
 
             # Filter out empty chunks and ensure minimum size
@@ -615,8 +610,7 @@ class UniversalParser(BaseParser):
             True if OCR should be attempted
         """
         # Always try OCR for image files
-        image_extensions = {".png", ".jpg", ".jpeg",
-                            ".gif", ".bmp", ".tiff", ".webp"}
+        image_extensions = {".png", ".jpg", ".jpeg", ".gif", ".bmp", ".tiff", ".webp"}
         if file_path.suffix.lower() in image_extensions:
             return True
 

--- a/rag/components/parsers/universal/universal_parser.py
+++ b/rag/components/parsers/universal/universal_parser.py
@@ -23,7 +23,8 @@ from core.logging import RAGStructLogger
 logger = RAGStructLogger("rag.components.parsers.universal")
 
 # Chunking strategy type
-ChunkStrategy = Literal["semantic", "sections", "paragraphs", "sentences", "characters"]
+ChunkStrategy = Literal["semantic", "sections",
+                        "paragraphs", "sentences", "characters"]
 
 # Try to import optional dependencies
 try:
@@ -160,7 +161,8 @@ class UniversalParser(BaseParser):
                 "text/markdown",
             ],
             capabilities=["text_extraction", "chunking"],
-            dependencies={"required": ["markitdown"], "optional": ["semchunk"]},
+            dependencies={"required": ["markitdown"],
+                          "optional": ["semchunk"]},
             default_config={"chunk_size": 1024, "chunk_strategy": "semantic"},
         )
 
@@ -215,7 +217,7 @@ class UniversalParser(BaseParser):
                     doc_metadata["ocr_model"] = ocr_result["ocr_model"]
                 if ocr_result.get("ocr_languages"):
                     doc_metadata["ocr_languages"] = ocr_result["ocr_languages"]
-                if ocr_result.get("ocr_confidence"):
+                if ocr_result.get("ocr_confidence") is not None:
                     doc_metadata["ocr_confidence"] = ocr_result["ocr_confidence"]
                 self.logger.info("OCR applied", file_path=str(file_path))
 
@@ -305,12 +307,14 @@ class UniversalParser(BaseParser):
                 with open(file_path, encoding=encoding, errors="ignore") as f:
                     return f.read(), metadata
             except Exception as e:
-                self.logger.error(f"Failed to read file: {e}", file_path=str(file_path))
+                self.logger.error(
+                    f"Failed to read file: {e}", file_path=str(file_path))
                 return "", metadata
 
         try:
             result = self._markitdown.convert(str(file_path))
-            text = result.text_content if hasattr(result, "text_content") else ""
+            text = result.text_content if hasattr(
+                result, "text_content") else ""
 
             # Extract any metadata from MarkItDown result
             if (
@@ -382,7 +386,8 @@ class UniversalParser(BaseParser):
             # Average ~4 chars per token for English
             token_chunk_size = max(self.chunk_size // 4, 100)
 
-            chunker = semchunk.chunkerify(self._encoder, chunk_size=token_chunk_size)
+            chunker = semchunk.chunkerify(
+                self._encoder, chunk_size=token_chunk_size)
             chunks = chunker(text)
 
             # Filter out empty chunks and ensure minimum size
@@ -610,7 +615,8 @@ class UniversalParser(BaseParser):
             True if OCR should be attempted
         """
         # Always try OCR for image files
-        image_extensions = {".png", ".jpg", ".jpeg", ".gif", ".bmp", ".tiff", ".webp"}
+        image_extensions = {".png", ".jpg", ".jpeg",
+                            ".gif", ".bmp", ".tiff", ".webp"}
         if file_path.suffix.lower() in image_extensions:
             return True
 

--- a/rag/schema.yaml
+++ b/rag/schema.yaml
@@ -776,6 +776,22 @@ definitions:
           type: string
           default: "http://127.0.0.1:14345/v1/vision/ocr"
           description: LlamaFarm API OCR endpoint URL
+        ocr_model:
+          type: string
+          description: OCR model to use at the endpoint (e.g. "mistral-ocr-latest")
+        ocr_languages:
+          type: array
+          items:
+            type: string
+          description: >
+            List of language codes to hint to the OCR engine
+            (e.g. ["en", "fr"]). Leave unset to use endpoint defaults.
+        return_boxes:
+          type: boolean
+          default: false
+          description: >
+            Whether to request bounding box data alongside extracted text.
+            Stored in chunk metadata when available.
         extract_metadata:
           type: boolean
           default: true

--- a/rag/tests/components/parsers/test_universal_parser_ocr.py
+++ b/rag/tests/components/parsers/test_universal_parser_ocr.py
@@ -89,7 +89,10 @@ class TestUniversalParserOCREndpoint:
         # Setup mock response
         mock_response = MagicMock()
         mock_response.ok = True
-        mock_response.json.return_value = {"text": "Extracted text from OCR"}
+        mock_response.json.return_value = {
+            "data": [{"text": "Extracted text from OCR", "confidence": 0.95}],
+            "model": "test-model",
+        }
         mock_post.return_value = mock_response
 
         # Create a temp file to test with
@@ -108,17 +111,13 @@ class TestUniversalParserOCREndpoint:
             # Verify the endpoint URL
             assert call_args[0][0] == "http://127.0.0.1:14345/v1/vision/ocr"
 
-            # Verify the request contains base64 image
-            request_json = call_args[1]["json"]
-            assert "image" in request_json
-            assert "filename" in request_json
-
-            # Verify result
+            assert "files" in call_args[1]
+            assert "json" not in call_args[1]
             assert result == {
                 "text": "Extracted text from OCR",
-                "ocr_model": None,
+                "ocr_model": "test-model",
                 "ocr_languages": None,
-                "ocr_confidence": None,
+                "ocr_confidence": 0.95,
             }
 
         finally:
@@ -197,6 +196,47 @@ class TestUniversalParserOCREndpoint:
         finally:
             Path(temp_path).unlink(missing_ok=True)
 
+    @patch("requests.post")
+    def test_sends_multipart_with_ocr_params(self, mock_post):
+        """Test: OCR request is sent as multipart with model/languages/return_boxes."""
+        from components.parsers.universal import UniversalParser
+
+        mock_response = MagicMock()
+        mock_response.ok = True
+        mock_response.json.return_value = {
+            "data": [{"text": "OCR result", "confidence": 0.9}],
+            "model": "mistral-ocr-latest",
+        }
+        mock_post.return_value = mock_response
+
+        with tempfile.NamedTemporaryFile(mode="wb", suffix=".png", delete=False) as f:
+            f.write(b"fake image data")
+            temp_path = f.name
+
+        try:
+            parser = UniversalParser(
+                config={
+                    "use_ocr": True,
+                    "ocr_model": "mistral-ocr-latest",
+                    "ocr_languages": ["en", "fr"],
+                    "return_boxes": True,
+                }
+            )
+            result = parser._run_remote_ocr(temp_path)
+
+            call_args = mock_post.call_args
+            assert "files" in call_args[1]
+            assert "json" not in call_args[1]
+            sent_data = call_args[1]["data"]
+            assert sent_data["model"] == "mistral-ocr-latest"
+            assert sent_data["languages"] == "en,fr"
+            assert sent_data["return_boxes"] == "true"
+            assert result["text"] == "OCR result"
+            assert result["ocr_confidence"] == 0.9
+
+        finally:
+            Path(temp_path).unlink(missing_ok=True)
+
 
 class TestUniversalParserOCRIntegration:
     """Test OCR integration with parse flow."""
@@ -210,7 +250,13 @@ class TestUniversalParserOCRIntegration:
         mock_response = MagicMock()
         mock_response.ok = True
         mock_response.json.return_value = {
-            "text": "This text was extracted via OCR from the image. " * 20
+            "data": [
+                {
+                    "text": "This text was extracted via OCR from the image. " * 20,
+                    "confidence": 0.9,
+                }
+            ],
+            "model": None,
         }
         mock_post.return_value = mock_response
 
@@ -242,7 +288,10 @@ class TestUniversalParserOCRIntegration:
         mock_response = MagicMock()
         mock_response.ok = True
         ocr_text = "This is OCR extracted text. " * 50  # Long enough to create chunks
-        mock_response.json.return_value = {"text": ocr_text}
+        mock_response.json.return_value = {
+            "data": [{"text": ocr_text, "confidence": 0.9}],
+            "model": None,
+        }
         mock_post.return_value = mock_response
 
         # Create a fake image file
@@ -344,7 +393,10 @@ class TestUniversalParserOCREndpointConfig:
 
         mock_response = MagicMock()
         mock_response.ok = True
-        mock_response.json.return_value = {"text": "OCR result"}
+        mock_response.json.return_value = {
+            "data": [{"text": "OCR result", "confidence": 0.9}],
+            "model": None,
+        }
         mock_post.return_value = mock_response
 
         custom_endpoint = "http://my-ocr-server:9000/ocr"

--- a/rag/tests/components/parsers/test_universal_parser_ocr.py
+++ b/rag/tests/components/parsers/test_universal_parser_ocr.py
@@ -114,7 +114,12 @@ class TestUniversalParserOCREndpoint:
             assert "filename" in request_json
 
             # Verify result
-            assert result == "Extracted text from OCR"
+            assert result == {
+                "text": "Extracted text from OCR",
+                "ocr_model": None,
+                "ocr_languages": None,
+                "ocr_confidence": None,
+            }
 
         finally:
             Path(temp_path).unlink(missing_ok=True)

--- a/rag/tests/components/parsers/test_universal_parser_ocr.py
+++ b/rag/tests/components/parsers/test_universal_parser_ocr.py
@@ -89,9 +89,7 @@ class TestUniversalParserOCREndpoint:
         # Setup mock response
         mock_response = MagicMock()
         mock_response.ok = True
-        mock_response.json.return_value = {
-            "text": "Extracted text from OCR"
-        }
+        mock_response.json.return_value = {"text": "Extracted text from OCR"}
         mock_post.return_value = mock_response
 
         # Create a temp file to test with
@@ -295,7 +293,10 @@ class TestUniversalParserOCRIntegration:
 
         # Create a text file with more content
         with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
-            content = "This is a text file with significantly more content than OCR would extract. " * 5
+            content = (
+                "This is a text file with significantly more content than OCR would extract. "
+                * 5
+            )
             f.write(content)
             temp_path = f.name
 


### PR DESCRIPTION
Closes #790 (partial — implements tasks 1 and 3)

## What this PR does

The OCR ingestion pipeline previously only sent `image` and `filename` 
to the OCR endpoint, and only stored `ocr_applied: true` as metadata.

This PR adds:

**Task 1 — OCR parameter passthrough**
- `_run_remote_ocr()` now conditionally passes `model`, `languages`, 
  and `return_boxes` to the OCR endpoint when configured
- Return type changed from `str | None` to `dict | None` to carry 
  both text and metadata back to the caller

**Task 3 — Rich OCR metadata on documents**
- Chunks now include `source_type`, `ocr_model`, `ocr_languages`, 
  and `ocr_confidence` in metadata when available

**Task 2 — Config schema**
- Added `ocr_model`, `ocr_languages`, and `return_boxes` to 
  `universalParserConfig` in `rag/schema.yaml` so they can be 
  set in strategy definitions

## Files changed
- `rag/schema.yaml`
- `rag/components/parsers/universal/universal_parser.py`

## What's not included
Task 4 (dataset-level cascading config) is out of scope for this PR 
and can be tracked separately.