### PR TITLE
feat(ci): add Linux ARM64 CUDA build profiles

### DIFF
--- a/.github/workflows/build-llama.yml
+++ b/.github/workflows/build-llama.yml
@@ -209,3 +209,107 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: llama.cpp/${{ steps.artifact.outputs.name }}
+
+  build-llama-cpp-cuda-arm64:
+    name: Build llama.cpp (arm64-${{ matrix.cuda.backend }})
+    runs-on: ubuntu-24.04-arm
+    container: ${{ matrix.cuda.image }}
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        cuda:
+          - backend: cuda12
+            image: nvidia/cuda:12.6.3-devel-ubuntu22.04
+          - backend: cuda13
+            image: nvidia/cuda:13.1.2-devel-ubuntu24.04
+    steps:
+      - name: Install dependencies
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            build-essential cmake git ca-certificates curl zip
+          # GitHub runners have no NVIDIA driver, so libcuda.so.1 (the runtime
+          # driver lib) is absent. NVIDIA's CUDA devel image ships a stub at
+          # /usr/local/cuda/lib64/stubs/libcuda.so for build-time linking, but
+          # the file is unversioned while libggml-cuda.so declares a SONAME of
+          # libcuda.so.1 — so ld -rpath-link can't satisfy the NEEDED entry by
+          # filename. Symlink the versioned name to the stub so the executables
+          # can link cleanly.
+          ln -sf /usr/local/cuda/lib64/stubs/libcuda.so \
+                 /usr/local/cuda/lib64/stubs/libcuda.so.1
+
+      - name: Checkout LlamaFarm (for version file)
+        uses: actions/checkout@v6
+        with:
+          path: llamafarm
+          sparse-checkout: |
+            llama-cpp-version.txt
+
+      - name: Determine llama.cpp version
+        id: version
+        run: |
+          if [ -n "${{ inputs.llama_version }}" ]; then
+            echo "version=${{ inputs.llama_version }}" >> $GITHUB_OUTPUT
+            echo "Using input version: ${{ inputs.llama_version }}"
+          else
+            VERSION=$(cat llamafarm/llama-cpp-version.txt | tr -d '\n')
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
+            echo "Using version from llama-cpp-version.txt: $VERSION"
+          fi
+
+      - name: Checkout llama.cpp
+        uses: actions/checkout@v6
+        with:
+          repository: ggml-org/llama.cpp
+          ref: ${{ steps.version.outputs.version }}
+          path: llama.cpp
+
+      - name: Configure CMake
+        run: |
+          cd llama.cpp
+          STUB_LDFLAGS="-Wl,-rpath-link,/usr/local/cuda/lib64/stubs -L/usr/local/cuda/lib64/stubs"
+          cmake -S . -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_SHARED_LIBS=ON \
+            -DLLAMA_BUILD_TESTS=OFF \
+            -DLLAMA_BUILD_EXAMPLES=OFF \
+            -DLLAMA_CURL=OFF \
+            -DGGML_NATIVE=OFF \
+            -DGGML_CUDA=ON \
+            -DCMAKE_EXE_LINKER_FLAGS="$STUB_LDFLAGS" \
+            -DCMAKE_SHARED_LINKER_FLAGS="$STUB_LDFLAGS"
+
+      - name: Build
+        run: |
+          cd llama.cpp
+          cmake --build build --config Release -j $(nproc)
+
+      - name: Prepare Artifact
+        id: artifact
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          ARTIFACT_NAME="llama-${VERSION}-bin-linux-${{ matrix.cuda.backend }}-arm64.zip"
+          echo "name=$ARTIFACT_NAME" >> $GITHUB_OUTPUT
+
+          cd llama.cpp
+          mkdir -p dist/bin
+          cp build/bin/libllama.so dist/bin/
+          # Copy dependencies (libggml.so, libggml-cuda.so, etc.) if they exist
+          find build/bin -name "*.so*" -not -name "libllama.so" -exec cp {} dist/bin/ \;
+
+          cd dist
+          zip -r ../$ARTIFACT_NAME .
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.artifact.outputs.name }}
+          path: llama.cpp/${{ steps.artifact.outputs.name }}
+
+      - name: Release
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: llama.cpp/${{ steps.artifact.outputs.name }}

--- a/cli/internal/llamabinary/llamabinary.go
+++ b/cli/internal/llamabinary/llamabinary.go
@@ -225,6 +225,22 @@ func SpecFor(t Target, version string) (Spec, error) {
 			LibPath: libName,
 			LibName: libName,
 		}, nil
+	case t.OS == "linux" && t.Arch == "arm64" && (t.Accelerator == "cuda" || t.Accelerator == "cuda12" || t.Accelerator == "cuda13"):
+		// LlamaFarm hosts Linux ARM64 CUDA builds via build-llama.yml.
+		// Bare "cuda" defaults to cuda12 for broader driver compatibility.
+		major := "cuda12"
+		if t.Accelerator == "cuda13" {
+			major = "cuda13"
+		}
+		lfVersion := llamafarmReleaseVersion()
+		return Spec{
+			URL: fmt.Sprintf(
+				"https://github.com/llama-farm/llamafarm/releases/download/%s/llama-%s-bin-linux-%s-arm64.zip",
+				lfVersion, version, major,
+			),
+			LibPath: libName,
+			LibName: libName,
+		}, nil
 	case t.OS == "windows" && t.Arch == "amd64" && t.Accelerator == "cpu":
 		return Spec{
 			URL:     urlBase(fmt.Sprintf("llama-%s-bin-win-cpu-x64.zip", version)),

--- a/cli/internal/llamabinary/llamabinary_test.go
+++ b/cli/internal/llamabinary/llamabinary_test.go
@@ -131,6 +131,45 @@ func TestSpecFor_LinuxAmd64Cuda13UsesLlamaFarmHost(t *testing.T) {
 	}
 }
 
+func TestSpecFor_LinuxArm64Cuda12UsesLlamaFarmHost(t *testing.T) {
+	spec, err := SpecFor(Target{OS: "linux", Arch: "arm64", Accelerator: "cuda12"}, "b8816")
+	if err != nil {
+		t.Fatalf("SpecFor: %v", err)
+	}
+	if !strings.Contains(spec.URL, "llama-farm/llamafarm") {
+		t.Errorf("expected llama-farm host, got %s", spec.URL)
+	}
+	if !strings.Contains(spec.URL, "bin-linux-cuda12-arm64.zip") {
+		t.Errorf("unexpected artifact in URL: %s", spec.URL)
+	}
+	if spec.LibName != "libllama.so" {
+		t.Errorf("expected libllama.so, got %s", spec.LibName)
+	}
+}
+
+func TestSpecFor_LinuxArm64Cuda13UsesLlamaFarmHost(t *testing.T) {
+	spec, err := SpecFor(Target{OS: "linux", Arch: "arm64", Accelerator: "cuda13"}, "b8816")
+	if err != nil {
+		t.Fatalf("SpecFor: %v", err)
+	}
+	if !strings.Contains(spec.URL, "llama-farm/llamafarm") {
+		t.Errorf("expected llama-farm host, got %s", spec.URL)
+	}
+	if !strings.Contains(spec.URL, "bin-linux-cuda13-arm64.zip") {
+		t.Errorf("unexpected artifact in URL: %s", spec.URL)
+	}
+}
+
+func TestSpecFor_LinuxArm64BareCudaDefaultsToCuda12(t *testing.T) {
+	spec, err := SpecFor(Target{OS: "linux", Arch: "arm64", Accelerator: "cuda"}, "b8816")
+	if err != nil {
+		t.Fatalf("SpecFor: %v", err)
+	}
+	if !strings.Contains(spec.URL, "bin-linux-cuda12-arm64.zip") {
+		t.Errorf("expected bare cuda to default to cuda12 artifact, got %s", spec.URL)
+	}
+}
+
 func TestSpecFor_LinuxAmd64BareCudaDefaultsToCuda12(t *testing.T) {
 	// Bare "cuda" must NOT silently fall back to Vulkan now that LlamaFarm
 	// publishes Linux x86_64 CUDA binaries. It defaults to cuda12 because that

--- a/packages/llamafarm-llama/src/llamafarm_llama/_binary.py
+++ b/packages/llamafarm-llama/src/llamafarm_llama/_binary.py
@@ -137,6 +137,23 @@ BINARY_MANIFEST: dict[tuple[str, str, str], dict] = {
         "lib": "libllama.so",
         "sha256": None,
     },
+    # Linux ARM64 CUDA (LlamaFarm provided)
+    ("linux", "arm64", "cuda12"): {
+        "artifact": (
+            "https://github.com/llama-farm/llamafarm/releases/download/"
+            "{llamafarm_version}/llama-{version}-bin-linux-cuda12-arm64.zip"
+        ),
+        "lib": "libllama.so",
+        "sha256": None,
+    },
+    ("linux", "arm64", "cuda13"): {
+        "artifact": (
+            "https://github.com/llama-farm/llamafarm/releases/download/"
+            "{llamafarm_version}/llama-{version}-bin-linux-cuda13-arm64.zip"
+        ),
+        "lib": "libllama.so",
+        "sha256": None,
+    },
     # Linux x86_64 CUDA (LlamaFarm provided - upstream stopped shipping these
     # for Linux as of b7694; CUDA is split by major version because llama.cpp
     # binaries are linked against a specific CUDA major).

--- a/packages/llamafarm-llama/tests/test_binary.py
+++ b/packages/llamafarm-llama/tests/test_binary.py
@@ -171,6 +171,24 @@ class TestBinaryManifest:
         assert "cuda13-x86_64.zip" in entry["artifact"]
         assert entry["lib"] == "libllama.so"
 
+    def test_manifest_has_linux_arm64_cuda12(self):
+        """Manifest should have Linux ARM64 CUDA 12 build (LlamaFarm provided)."""
+        from llamafarm_llama._binary import BINARY_MANIFEST
+
+        entry = BINARY_MANIFEST[("linux", "arm64", "cuda12")]
+        assert "{llamafarm_version}" in entry["artifact"]
+        assert "cuda12-arm64.zip" in entry["artifact"]
+        assert entry["lib"] == "libllama.so"
+
+    def test_manifest_has_linux_arm64_cuda13(self):
+        """Manifest should have Linux ARM64 CUDA 13 build (LlamaFarm provided)."""
+        from llamafarm_llama._binary import BINARY_MANIFEST
+
+        entry = BINARY_MANIFEST[("linux", "arm64", "cuda13")]
+        assert "{llamafarm_version}" in entry["artifact"]
+        assert "cuda13-arm64.zip" in entry["artifact"]
+        assert entry["lib"] == "libllama.so"
+
 
 class TestLlamafarmReleaseVersionSelection:
     """`_get_llamafarm_release_version()` must skip releases that lack the


### PR DESCRIPTION
## Summary

- Adds a `build-llama-cpp-cuda-arm64` CI job to `build-llama.yml` that builds llama.cpp for Linux ARM64 with CUDA 12 and CUDA 13, mirroring the existing x86_64 CUDA matrix
- Adds `(linux, arm64, cuda12)` and `(linux, arm64, cuda13)` entries to the Python `BINARY_MANIFEST` so the Python downloader resolves the new artifacts
- Adds a `linux/arm64/cuda*` case to the Go `SpecFor` function so the CLI resolves the correct download URLs
- Adds test coverage for the new platform keys in both Go and Python

The new CI job runs on `ubuntu-24.04-arm` with `nvidia/cuda` container images (multi-arch, pulls native ARM64 variants). If container support on ARM runners doesn't work, fallback options are bare-metal CUDA toolkit install or self-hosted GCP ARM64 VMs.

Artifact naming: `llama-{version}-bin-linux-cuda{12,13}-arm64.zip`

## Test plan

- [x] Go tests pass (`TestSpecFor_LinuxArm64Cuda12UsesLlamaFarmHost`, `TestSpecFor_LinuxArm64Cuda13UsesLlamaFarmHost`, `TestSpecFor_LinuxArm64BareCudaDefaultsToCuda12`)
- [ ] Python manifest tests pass (`test_manifest_has_linux_arm64_cuda12`, `test_manifest_has_linux_arm64_cuda13`)
- [ ] Trigger `build-llama.yml` via `workflow_dispatch` to smoke-test the ARM64 CUDA container builds
- [ ] If container jobs fail on ARM runners, fall back to bare-metal CUDA toolkit install