### PR TITLE
feat(server): add LiteLLM as AI gateway provider

### DIFF
--- a/config/schema.yaml
+++ b/config/schema.yaml
@@ -119,7 +119,7 @@ properties:
               description: Human-readable description of this model configuration
             provider:
               type: string
-              enum: [openai, ollama, lemonade, universal]
+              enum: [openai, ollama, lemonade, universal, litellm]
               description: Runtime provider for this model
             model:
               type: string

--- a/packages/llamafarm-sdk/src/llamafarm/_generated_types.py
+++ b/packages/llamafarm-sdk/src/llamafarm/_generated_types.py
@@ -1192,7 +1192,7 @@ class PromptTokensDetails(BaseModel):
 
 
 # Enum: Provider
-Provider = Literal['openai', 'ollama', 'lemonade', 'universal']
+Provider = Literal['openai', 'ollama', 'lemonade', 'universal', 'litellm']
 
 class QueryResponse(BaseModel):
     """RAG query response model."""

--- a/server/agents/base/clients/litellm.py
+++ b/server/agents/base/clients/litellm.py
@@ -1,0 +1,105 @@
+"""LiteLLM client - unified gateway for 100+ LLM providers."""
+
+from collections.abc import AsyncGenerator
+
+from openai.types.chat import ChatCompletionToolParam
+
+from agents.base.history import LFChatCompletionMessageParam
+from agents.base.types import ToolDefinition
+from core.logging import FastAPIStructLogger
+
+from .client import (
+    LFAgentClient,
+    LFChatCompletion,
+    LFChatCompletionChunk,
+)
+
+logger = FastAPIStructLogger(__name__)
+
+
+class LFAgentClientLiteLLM(LFAgentClient):
+    """LiteLLM client for 100+ LLM providers via unified SDK.
+
+    Uses litellm.acompletion() which returns OpenAI-format responses,
+    so tool calling, streaming, and response parsing work identically
+    to the OpenAI client.
+    """
+
+    async def chat(
+        self,
+        *,
+        messages: list[LFChatCompletionMessageParam],
+        tools: list[ToolDefinition] | None = None,
+        extra_body: dict | None = None,
+    ) -> LFChatCompletion:
+        import litellm
+
+        openai_tools = (
+            [self._tool_to_openai_format(t) for t in tools] if tools else None
+        )
+
+        api_params = (self._model_config.model_api_parameters or {}).copy()
+        extra_body_copy = dict(extra_body or {})
+        if "max_tokens" in extra_body_copy and "max_tokens" not in api_params:
+            api_params["max_tokens"] = extra_body_copy.pop("max_tokens")
+
+        kwargs = {
+            "model": self._model_config.model,
+            "messages": messages,
+            "drop_params": True,
+            **api_params,
+        }
+        if self._model_config.api_key:
+            kwargs["api_key"] = self._model_config.api_key
+        if self._model_config.base_url:
+            kwargs["api_base"] = self._model_config.base_url
+        if openai_tools:
+            kwargs["tools"] = openai_tools
+
+        return await litellm.acompletion(**kwargs)
+
+    async def stream_chat(
+        self,
+        *,
+        messages: list[LFChatCompletionMessageParam],
+        tools: list[ToolDefinition] | None = None,
+        extra_body: dict | None = None,
+    ) -> AsyncGenerator[LFChatCompletionChunk]:
+        import litellm
+
+        openai_tools = (
+            [self._tool_to_openai_format(t) for t in tools] if tools else None
+        )
+
+        api_params = (self._model_config.model_api_parameters or {}).copy()
+        extra_body_copy = dict(extra_body or {})
+        if "max_tokens" in extra_body_copy and "max_tokens" not in api_params:
+            api_params["max_tokens"] = extra_body_copy.pop("max_tokens")
+
+        kwargs = {
+            "model": self._model_config.model,
+            "messages": messages,
+            "stream": True,
+            "drop_params": True,
+            **api_params,
+        }
+        if self._model_config.api_key:
+            kwargs["api_key"] = self._model_config.api_key
+        if self._model_config.base_url:
+            kwargs["api_base"] = self._model_config.base_url
+        if openai_tools:
+            kwargs["tools"] = openai_tools
+
+        response = await litellm.acompletion(**kwargs)
+        async for chunk in response:
+            yield chunk
+
+    def _tool_to_openai_format(self, tool: ToolDefinition) -> ChatCompletionToolParam:
+        return ChatCompletionToolParam(
+            type="function",
+            function={
+                "name": tool.name,
+                "description": tool.description,
+                "parameters": tool.parameters,
+            },
+        )

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -61,6 +61,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = ["pytest>=8.0.0", "pytest-mock>=3.12.0"]
 test = ["pytest>=8.0.0", "pytest-mock>=3.12.0"]
+litellm = ["litellm>=1.80.0,<1.87.0"]
 
 [dependency-groups]
 dev = [

--- a/server/services/runtime_service/providers/litellm_provider.py
+++ b/server/services/runtime_service/providers/litellm_provider.py
@@ -1,0 +1,23 @@
+"""LiteLLM runtime provider - unified gateway for 100+ LLM providers."""
+
+from agents.base.clients.client import LFAgentClient
+from agents.base.clients.litellm import LFAgentClientLiteLLM
+
+from .base import RuntimeProvider
+from .health import HealthCheckResult
+
+
+class LiteLLMProvider(RuntimeProvider):
+    """LiteLLM provider - routes to 100+ LLM providers via litellm SDK."""
+
+    def get_client(self) -> LFAgentClient:
+        return LFAgentClientLiteLLM(model_config=self._model_config)
+
+    def check_health(self) -> HealthCheckResult:
+        return HealthCheckResult(
+            name="litellm",
+            status="reachable",
+            message="LiteLLM SDK routes to provider at call time",
+            latency_ms=0,
+            details={"model": self._model_config.model},
+        )

--- a/server/services/runtime_service/runtime_service.py
+++ b/server/services/runtime_service/runtime_service.py
@@ -3,6 +3,7 @@ from config.datamodel import Model, Provider
 from .providers.base import RuntimeProvider
 from .providers.lemonade_provider import LemonadeProvider
 from .providers.ollama_provider import OllamaProvider
+from .providers.litellm_provider import LiteLLMProvider
 from .providers.openai_provider import OpenAIProvider
 from .providers.universal_provider import UniversalProvider
 
@@ -35,6 +36,8 @@ class RuntimeService:
                 return LemonadeProvider(model_config=model_config)
             case Provider.universal:
                 return UniversalProvider(model_config=model_config)
+            case Provider.litellm:
+                return LiteLLMProvider(model_config=model_config)
 
 
 runtime_service = RuntimeService()


### PR DESCRIPTION
## Summary

Adds LiteLLM as a new runtime provider alongside OpenAI, Ollama, Lemonade, and Universal, giving users access to 100+ LLM providers (Anthropic, Bedrock, Vertex AI, Groq, DeepSeek, Azure OpenAI, etc.) through a single `provider: litellm` config.

## Motivation

LlamaFarm currently supports 4 runtime providers. Users wanting to use providers like Anthropic, Bedrock, or Groq need to route through an OpenAI-compatible proxy. LiteLLM SDK handles routing natively - users set `provider: litellm` and any [litellm model string](https://docs.litellm.ai/docs/providers) works. `drop_params=True` handles cross-provider kwarg incompatibilities automatically.

## Changes

- `server/agents/base/clients/litellm.py` - new `LFAgentClientLiteLLM(LFAgentClient)` using `litellm.acompletion()` with streaming and tool calling
- `server/services/runtime_service/providers/litellm_provider.py` - new `LiteLLMProvider(RuntimeProvider)`
- `server/services/runtime_service/runtime_service.py` - registered `Provider.litellm` case
- `config/schema.yaml` - added `litellm` to provider enum
- `packages/llamafarm-sdk/src/llamafarm/_generated_types.py` - updated `Provider` type

## Example usage

```yaml
# llamafarm.yaml
models:
  claude:
    provider: litellm
    model: anthropic/claude-sonnet-4-6
    # api_key read from ANTHROPIC_API_KEY env var by litellm
```

```python
from llamafarm import LlamaFarm

lf = LlamaFarm()
response = await lf.chat("claude", "What is 2+2?")
```
